### PR TITLE
do not apply the 'ubuntu hack' on ubuntu >= 12.04

### DIFF
--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -4441,13 +4441,15 @@ panel_toplevel_init (PanelToplevel *toplevel)
 {
 	int i;
 
-	/* This is a hack for the default resize grip on Ubuntu.
+	/* This is a hack for the default resize grip on Ubuntu < 12.04.
 	 * Once again, thank you Ubuntu.
 	 *
 	 * We need to add a --enable-ubuntu for this.
 	 */
-	#ifdef UBUNTU
-		gtk_window_set_has_resize_grip(&toplevel->window_instance, FALSE);
+	#if defined(UBUNTU) && !GTK_CHECK_VERSION(2, 24, 10)
+		// the symbol is dropped in the gtk version used by Ubuntu 12.04
+		if (gtk_check_version(2, 24, 10))
+			gtk_window_set_has_resize_grip(&toplevel->window_instance, FALSE);
 	#endif
 	toplevel->priv = PANEL_TOPLEVEL_GET_PRIVATE (toplevel);
 


### PR DESCRIPTION
This checks whether the gtk version is older than the one in Ubuntu 12.04 and only applies the ubuntu fix if this is the case.
If we want to build this package on 12.04, we have to disable the ubuntu hack altogether, but this way a package with --enable-ubuntu build on oneiric will run on precise.
