### PR TITLE
Fix for clock in mate-panel skipping seconds

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -317,7 +317,7 @@ clock_set_timeout (ClockData *cd,
  		struct timeval tv;
 
 		gettimeofday (&tv, NULL);
- 		timeouttime = (G_USEC_PER_SEC - tv.tv_usec)/1000+1;
+ 		timeouttime = (G_USEC_PER_SEC - tv.tv_usec)/1000+20;
 
 		/* timeout of one minute if we don't care about the seconds */
  		if (cd->format != CLOCK_FORMAT_UNIX &&


### PR DESCRIPTION
When the clock in the mate-panel is set to show seconds, they often skip. This fixes that and makes the seconds display smooth.  I got the fix from here: https://bugzilla.gnome.org/show_bug.cgi?id=585668
It's already fixed in Gnome 3, but not yet in Mate.
