### PR TITLE
incorrect-fsf-address and others

### DIFF
--- a/mate-panel/mate-panel-add.in
+++ b/mate-panel/mate-panel-add.in
@@ -18,7 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
 import optparse

--- a/mate-panel/mate-panel-applet-frame.h
+++ b/mate-panel/mate-panel-applet-frame.h
@@ -15,9 +15,8 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA.
- *
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
  * Authors:
  *	Mark McLoughlin <mark@skynet.ie>
  */

--- a/mate-panel/mate-panel-applet-info.h
+++ b/mate-panel/mate-panel-applet-info.h
@@ -16,8 +16,8 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
  */
 
 #ifndef __MATE_PANEL_APPLET_INFO_H__


### PR DESCRIPTION
before

[rave@mother ~]$ rpmlint /var/lib/mock/fedora-16-x86_64/mate-panel-1.4.0-5.fc16.x86_64.rpm 
mate-panel.x86_64: W: spelling-error %description -l en_US workspace -> work space, work-space, works pace
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-default-setup.entries
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/tasklist.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-object.schemas
mate-panel.x86_64: E: incorrect-fsf-address /usr/libexec/mate-panel/mate-panel-add
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-compatibility.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/workspace-switcher.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/clock.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-general.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/pager.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/window-list.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-toplevel.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/fish.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-global.schemas
mate-panel.x86_64: W: no-manual-page-for-binary mate-desktop-item-edit
mate-panel.x86_64: E: invalid-desktopfile /usr/share/applications/mate-panel.desktop value "MATE;GTK;System;Core;" for key "Categories" in group "Desktop Entry" contains an unregistered value "MATE"; values extending the format should start with "X-"
1 packages and 0 specfiles checked; 2 errors, 14 warnings.

after

rpmlint /home/rave/rpmbuild/RPMS/x86_64/mate-panel-1.4.0-5.fc16.x86_64.rpm
mate-panel.x86_64: W: spelling-error %description -l en_US workspace -> work space, work-space, works pace
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-default-setup.entries
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/tasklist.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-object.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-compatibility.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/workspace-switcher.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/clock.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-general.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/pager.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/window-list.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-toplevel.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/fish.schemas
mate-panel.x86_64: W: non-conffile-in-etc /etc/mateconf/schemas/panel-global.schemas
mate-panel.x86_64: W: no-manual-page-for-binary mate-desktop-item-edit
mate-panel.x86_64: E: invalid-desktopfile /usr/share/applications/mate-panel.desktop value "MATE;GTK;System;Core;" for key "Categories" in group "Desktop Entry" contains an unregistered value "MATE"; values extending the format should start with "X-"
1 packages and 0 specfiles checked; 1 errors, 14 warnings.

Note: this fix only the incorrect licence information for using rpmlint.
There are much more files in the code with uncorrect adress
