### PR TITLE
Fix compile error

### DIFF
--- a/applets/clock/calendar-client.c
+++ b/applets/clock/calendar-client.c
@@ -27,6 +27,8 @@
 
 #include "calendar-client.h"
 
+#include <mateconf/mateconf-client.h>
+
 #include <libintl.h>
 #include <string.h>
 #define HANDLE_LIBICAL_MEMORY


### PR DESCRIPTION
applets/clock/calendar-client.c references MateConfClient without
including mateconf-client.h which caused a compile error on my
setup.
