### PR TITLE
Fix for displaying the Network icon in the places menu

### DIFF
--- a/mate-panel/panel-menu-items.c
+++ b/mate-panel/panel-menu-items.c
@@ -1083,7 +1083,7 @@ panel_place_menu_item_create_menu (PanelPlaceMenuItem *place_item)
 	add_menu_separator (places_menu);
 
 	panel_menu_items_append_from_desktop (places_menu,
-					      "network-scheme.desktop",
+					      "mate-network-scheme.desktop",
 					      NULL,
                                               TRUE);
 	panel_place_menu_item_append_remote_gio (place_item, places_menu);


### PR DESCRIPTION
Since the mate version of the network icon .desktop file is called mate-network-scheme.desktop instead of network-scheme.desktop (to avoid GNOME conflicts), the panel should use this file instead of the GNOME one to properly display the Network icon on the places menu.
