### PR TITLE
add transparency background function for workspace-switcher

### DIFF
--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -194,17 +194,34 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 
 static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, GdkPixmap* pixmap, PagerData* pager)
 {
+        /* taken from the TrashApplet */
+        GtkRcStyle *rc_style;
+        GtkStyle *style;
+
+        /* reset style */
+        gtk_widget_set_style (GTK_WIDGET (pager->pager), NULL);
+        rc_style = gtk_rc_style_new ();
+        gtk_widget_modify_style (GTK_WIDGET (pager->pager), rc_style);
+        g_object_unref (rc_style);
+
 	switch (type)
 	{
-		case PANEL_NO_BACKGROUND:
-			matewnck_pager_set_shadow_type(MATEWNCK_PAGER(pager->pager), GTK_SHADOW_IN);
-			break;
-		case PANEL_COLOR_BACKGROUND:
-			matewnck_pager_set_shadow_type(MATEWNCK_PAGER(pager->pager), GTK_SHADOW_NONE);
-			break;
-		case PANEL_PIXMAP_BACKGROUND:
-			matewnck_pager_set_shadow_type(MATEWNCK_PAGER(pager->pager), GTK_SHADOW_NONE);
-			break;
+                case PANEL_COLOR_BACKGROUND:
+                        gtk_widget_modify_bg (GTK_WIDGET (pager->pager), GTK_STATE_NORMAL, color);
+                        break;
+
+                case PANEL_PIXMAP_BACKGROUND:
+                        style = gtk_style_copy (gtk_widget_get_style (GTK_WIDGET (pager->pager)));
+                        if (style->bg_pixmap[GTK_STATE_NORMAL])
+                                g_object_unref (style->bg_pixmap[GTK_STATE_NORMAL]);
+                        style->bg_pixmap[GTK_STATE_NORMAL] = g_object_ref(pixmap);
+                        gtk_widget_set_style (GTK_WIDGET (pager->pager), style);
+                        g_object_unref (style);
+                        break;
+
+                case PANEL_NO_BACKGROUND:
+                default:
+                        break;
 	}
 }
 


### PR DESCRIPTION
this function set the the background of the applet to transparency if an user choose a transparency panel.
some examples:
![Bildschirmfoto](https://f.cloud.github.com/assets/961604/214044/da1c1adc-83e6-11e2-80c2-219d4ac97cf8.png)
![workspace-switcher](https://f.cloud.github.com/assets/961604/214070/78c3233a-83ea-11e2-98c8-c640ec357efc.png)
Hope you see the little different :)
Edit:
a screenshot with a real big panel, here you see the transparency in the space between the workspaces.
https://dl.dropbox.com/u/49862637/Mate-desktop/Bugs/work-space-switcher2.png
