### PR TITLE
Fix for issue #73: when the difference between timezones in the clock applet is less than 1 hour, an offset is not shown

### DIFF
--- a/applets/clock/clock-location-tile.c
+++ b/applets/clock/clock-location-tile.c
@@ -488,7 +488,7 @@ format_time (struct tm   *now,
         hours = offset / 3600;
         minutes = labs (offset % 3600) / 60;
 
-	if (hours != 0 && minutes != 0) {
+	if (minutes != 0) {
 		tmp = g_strdup_printf ("%s <small>%s %+ld:%ld</small>", buf, tzname, hours, minutes);
 	}
 	else if (hours != 0) {


### PR DESCRIPTION
Fix for issue #73.

Instead of checking for the minutes and hours not equalling zero, check only the minutes aren't 0.

This means locations where the time is the same are correctly shown without the annotations, and locations where the time difference is less than 1 hour but more than 0 minutes the difference is shown.
