### PR TITLE
remove mate-panelrc

### DIFF
--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -223,9 +223,6 @@ BUILT_SOURCES = \
 	panel-marshal.c \
 	panel-marshal.h
 
-rcdir = $(datadir)
-rc_DATA = mate-panelrc
-
 uidir = $(datadir)/mate-panel/ui
 ui_DATA = \
 	panel-properties-dialog.ui \

--- a/mate-panel/mate-panelrc
+++ b/mate-panel/mate-panelrc
@@ -1,4 +1,0 @@
-#
-# This file is intentionally left empty. You may add gtk theme
-# definitions here and they will only apply to the MATE Panel.
-#


### PR DESCRIPTION
this is a deprecation file which was also deprecated by gnome in 2011.
https://git.gnome.org/browse/gnome-panel/commit/?id=09fa68b0b4d9ae185ad0ac703cbaafe9eb052124
I did test this example file and copied it to ~.matepanel.rc and add a content. It doesn't work. After rename it to  .gtkrc-2.0 it works.
So i quess the method to change GTK settings only for the panel is obsolete, imo.

Bye the way, this is the only file which is in /usr/share/ on my system
