### PR TITLE
clock-applet: set sane unit values

### DIFF
--- a/applets/clock/org.mate.panel.applet.clock.gschema.xml.in.in
+++ b/applets/clock/org.mate.panel.applet.clock.gschema.xml.in.in
@@ -75,12 +75,12 @@
       <_description>A list of locations to display in the calendar window.</_description>
     </key>
     <key name="temperature-unit" enum="org.mate.panel.applet.clock.TemperatureUnit">
-      <default>'Default'</default>
+      <default>'Centigrade'</default>
       <_summary>Temperature unit</_summary>
       <_description>The unit to use when showing temperatures.</_description>
     </key>
     <key name="speed-unit" enum="org.mate.panel.applet.clock.SpeedUnit">
-      <default>'Default'</default>
+      <default>'m/s'</default>
       <_summary>Speed unit</_summary>
       <_description>The unit to use when showing wind speed.</_description>
     </key>


### PR DESCRIPTION
The default values where removed and now the units of measure don't get set. This leads to no weather icon/data being shown. Fixes #95

Please also backport to the 1.6 branch.
