### PR TITLE
Fixed the WNCK_CHECK_VERSION calls to only be used when GTK is version 3.0

### DIFF
--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -121,8 +121,10 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 
 	tasklist->orientation = new_orient;
 
+#if GTK_CHECK_VERSION (3, 0, 0)
 #if WNCK_CHECK_VERSION (3, 4, 6)
 	wnck_tasklist_set_orientation (tasklist->tasklist, new_orient);
+#endif
 #endif
 	tasklist_update(tasklist);
 }
@@ -425,16 +427,19 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 			break;
 	}
 
+#if GTK_CHECK_VERSION (3, 0, 0)
 #if WNCK_CHECK_VERSION (2, 91, 6)
 	tasklist->tasklist = wnck_tasklist_new();
+#endif
 #else
 	tasklist->tasklist = wnck_tasklist_new(NULL);
 #endif
 
+#if GTK_CHECK_VERSION (3, 0, 0)
 #if WNCK_CHECK_VERSION (3, 4, 6)
 	wnck_tasklist_set_orientation (tasklist->tasklist, tasklist->orientation);
 #endif
-
+#endif
 	wnck_tasklist_set_icon_loader(WNCK_TASKLIST(tasklist->tasklist), icon_loader_func, tasklist, NULL);
 
 	g_signal_connect(G_OBJECT(tasklist->tasklist), "destroy", G_CALLBACK(destroy_tasklist), tasklist);

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -529,8 +529,10 @@ gboolean workspace_switcher_applet_fill(MatePanelApplet* applet)
 			break;
 	}
 
+#if GTK_CHECK_VERSION (3, 0, 0)
 #if WNCK_CHECK_VERSION (2, 91, 6)
 	pager->pager = wnck_pager_new();
+#endif
 #else
 	pager->pager = wnck_pager_new(NULL);
 #endif


### PR DESCRIPTION
mate-panel fails to build unless GTK is version 3 due to the WNCK_CHECK_VERSION macro. This macro requires libwnck3 which is only used in the build if GTK 3 is also used. This patched version checks if GTK is version 3 using the GTK_CHECK_VERSION macro and then proceeds to check the WNCK_CHECK_VERSION macro.
