### PR TITLE
gtk3: panel always have alpha support

### DIFF
--- a/applets/clock/calendar-window.c
+++ b/applets/clock/calendar-window.c
@@ -161,14 +161,22 @@ create_hig_frame (CalendarWindow *calwin,
 	char      *text;
         GtkWidget *expander;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+        vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+#else
         vbox = gtk_vbox_new (FALSE, 6);
+#endif
 
         bold_title = g_strdup_printf ("<b>%s</b>", title);
 	expander = gtk_expander_new (bold_title);
         g_free (bold_title);
 	gtk_expander_set_use_markup (GTK_EXPANDER (expander), TRUE);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+#else
 	hbox = gtk_hbox_new (FALSE, 0);
+#endif
 	gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
         gtk_box_pack_start (GTK_BOX (hbox), expander, FALSE, FALSE, 0);
 	gtk_widget_show_all (vbox);
@@ -241,7 +249,11 @@ calendar_window_fill (CalendarWindow *calwin)
         gtk_container_add (GTK_CONTAINER (calwin), frame);
         gtk_widget_show (frame);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+        vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+#else
         vbox = gtk_vbox_new (FALSE, 6);
+#endif
         gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);
         gtk_container_add (GTK_CONTAINER (frame), vbox);
         gtk_widget_show (vbox);

--- a/applets/clock/clock-location-tile.c
+++ b/applets/clock/clock-location-tile.c
@@ -275,8 +275,13 @@ clock_location_tile_fill (ClockLocationTile *this)
         alignment = gtk_alignment_new (0, 0, 1, 0);
         gtk_alignment_set_padding (GTK_ALIGNMENT (alignment), 3, 3, 3, 0);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+        tile = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+        head_section = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+#else
         tile = gtk_hbox_new (FALSE, 6);
         head_section = gtk_vbox_new (FALSE, 0);
+#endif
 
         priv->city_label = gtk_label_new (NULL);
         gtk_misc_set_alignment (GTK_MISC (priv->city_label), 0, 0);
@@ -293,7 +298,11 @@ clock_location_tile_fill (ClockLocationTile *this)
         align = gtk_alignment_new (0, 0, 0, 0);
         gtk_container_add (GTK_CONTAINER (align), priv->weather_icon);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+        box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+#else
         box = gtk_hbox_new (FALSE, 0);
+#endif
         gtk_box_pack_start (GTK_BOX (head_section), box, FALSE, FALSE, 0);
         gtk_box_pack_start (GTK_BOX (box), align, FALSE, FALSE, 0);
         gtk_box_pack_start (GTK_BOX (box), priv->time_label, FALSE, FALSE, 0);

--- a/applets/clock/clock-location.c
+++ b/applets/clock/clock-location.c
@@ -710,6 +710,7 @@ rad2dms (gfloat lat, gfloat lon)
 
 static GList *locations = NULL;
 
+#ifdef HAVE_NETWORK_MANAGER
 static void
 update_weather_infos (void)
 {
@@ -724,7 +725,6 @@ update_weather_infos (void)
 	}
 }
 
-#ifdef HAVE_NETWORK_MANAGER
 static void
 state_notify (DBusPendingCall *pending, gpointer data)
 {

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -182,10 +182,6 @@ struct _ClockData {
 	GSettings *settings;
 };
 
-/* Used to count the number of clock instances. It's there to know when we
- * should free resources that are shared. */
-static int clock_numbers = 0;
-
 static void  update_clock (ClockData * cd);
 static void  update_tooltip (ClockData * cd);
 static void  update_panel_weather (ClockData *cd);
@@ -939,7 +935,11 @@ create_clock_window (ClockData *cd)
         locations_box = calendar_window_get_locations_box (CALENDAR_WINDOW (cd->calendar_popup));
         gtk_widget_show (locations_box);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	cd->clock_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+#else
 	cd->clock_vbox = gtk_vbox_new (FALSE, 6);
+#endif
 	gtk_container_add (GTK_CONTAINER (locations_box), cd->clock_vbox);
 
 	cd->clock_group = gtk_size_group_new (GTK_SIZE_GROUP_HORIZONTAL);
@@ -1088,7 +1088,11 @@ create_cities_section (ClockData *cd)
 		g_list_free (cd->location_tiles);
         cd->location_tiles = NULL;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+        cd->cities_section = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+#else
         cd->cities_section = gtk_vbox_new (FALSE, 6);
+#endif
         gtk_container_set_border_width (GTK_CONTAINER (cd->cities_section), 0);
 
 	cities = cd->locations;
@@ -2482,8 +2486,8 @@ save_cities_store (ClockData *cd)
         ClockLocation *loc;
         GList *node = cd->locations;
         gint len = g_list_length(cd->locations);
-        gchar **array[len + 1];
-        gchar **array_reverse[len + 1];
+        gchar *array[len + 1];
+        gchar *array_reverse[len + 1];
         gint i = 0;
 
         while (node) {
@@ -2905,7 +2909,6 @@ temperature_combo_changed (GtkComboBox *combo, ClockData *cd)
 {
 	int value;
 	int old_value;
-	const gchar *str;
 
 	value = gtk_combo_box_get_active (combo) + 2;
 	old_value = cd->temperature_unit;
@@ -2921,7 +2924,6 @@ speed_combo_changed (GtkComboBox *combo, ClockData *cd)
 {
 	int value;
 	int old_value;
-	const gchar *str;
 
 	value = gtk_combo_box_get_active (combo) + 2;
 	old_value = cd->speed_unit;

--- a/applets/clock/system-timezone.c
+++ b/applets/clock/system-timezone.c
@@ -861,7 +861,6 @@ system_timezone_is_zone_file_valid (const char  *zone_file,
 {
         GError     *our_error;
         GIOChannel *channel;
-        GIOStatus   status;
         char        buffer[strlen (TZ_MAGIC)];
         gsize       read;
 
@@ -888,7 +887,7 @@ system_timezone_is_zone_file_valid (const char  *zone_file,
         our_error = NULL;
         channel = g_io_channel_new_file (zone_file, "r", &our_error);
         if (!our_error)
-                status = g_io_channel_read_chars (channel,
+                g_io_channel_read_chars (channel,
                                                   buffer, strlen (TZ_MAGIC),
                                                   &read, &our_error);
         if (channel)

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -142,7 +142,7 @@ static const GtkActionEntry menu_actions [] = {
 };
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, cairo_pattern_t *pattern, AppletData* data)
+static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkRGBA* color, cairo_pattern_t *pattern, AppletData* data)
 #else
 static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, GdkPixmap* pixmap, AppletData* data)
 #endif

--- a/applets/notification_area/na-tray-child.c
+++ b/applets/notification_area/na-tray-child.c
@@ -201,7 +201,9 @@ na_tray_child_expose_event (GtkWidget      *widget,
 #endif
 {
   NaTrayChild *child = NA_TRAY_CHILD (widget);
+#if !GTK_CHECK_VERSION(3, 0, 0)
   GdkWindow *window = gtk_widget_get_window (widget);
+#endif
 
   if (na_tray_child_has_alpha (child))
     {

--- a/applets/notification_area/na-tray.c
+++ b/applets/notification_area/na-tray.c
@@ -633,11 +633,17 @@ na_tray_constructor (GType type,
 
   if (!initialized)
     {
+#if !GTK_CHECK_VERSION(3, 10, 0)
       GdkDisplay *display;
+#endif
       int n_screens;
 
+#if GTK_CHECK_VERSION(3, 10, 0)
+      n_screens = 1;
+#else
       display = gdk_display_get_default ();
       n_screens = gdk_display_get_n_screens (display);
+#endif
       trays_screens = g_new0 (TraysScreen, n_screens);
       initialized = TRUE;
     }

--- a/applets/notification_area/testtray.c
+++ b/applets/notification_area/testtray.c
@@ -150,14 +150,22 @@ create_tray_on_screen (GdkScreen *screen,
   data->window = window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   g_object_weak_ref (G_OBJECT (window), (GWeakNotify) maybe_quit, NULL);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+  vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+#else
   vbox = gtk_vbox_new (FALSE, 6);
+#endif
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   button = gtk_button_new_with_mnemonic ("_Add another tray");
   g_signal_connect (button, "clicked", G_CALLBACK (add_tray_cb), data);
   gtk_box_pack_start (GTK_BOX (vbox), button, FALSE, FALSE, 0);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+  hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
+#else
   hbox = gtk_hbox_new (FALSE, 12);
+#endif
   gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
   label = gtk_label_new_with_mnemonic ("_Orientation:");
   gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
@@ -213,7 +221,11 @@ main (int argc, char *argv[])
   gtk_window_set_default_icon_name (NOTIFICATION_AREA_ICON);
 
   display = gdk_display_get_default ();
+#if GTK_CHECK_VERSION(3, 0, 0)
+  n_screens = 1;
+#else
   n_screens =  gdk_display_get_n_screens (display);
+#endif
   for (i = 0; i < n_screens; ++i) {
     screen = gdk_display_get_screen (display, i);
 

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -123,14 +123,14 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 
 #ifdef WNCK_CHECK_VERSION
 #if WNCK_CHECK_VERSION (3, 4, 6)
-	wnck_tasklist_set_orientation (tasklist->tasklist, new_orient);
+	wnck_tasklist_set_orientation (WNCK_TASKLIST(tasklist->tasklist), new_orient);
 #endif
 #endif
 	tasklist_update(tasklist);
 }
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, cairo_pattern_t* pattern, TasklistData* tasklist)
+static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkRGBA* color, cairo_pattern_t* pattern, TasklistData* tasklist)
 #else
 static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, GdkPixmap* pixmap, TasklistData* tasklist)
 #endif
@@ -447,7 +447,7 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 
 #ifdef WNCK_CHECK_VERSION
 #if WNCK_CHECK_VERSION (3, 4, 6)
-	wnck_tasklist_set_orientation (tasklist->tasklist, tasklist->orientation);
+	wnck_tasklist_set_orientation (WNCK_TASKLIST(tasklist->tasklist), tasklist->orientation);
 #endif
 #endif
 
@@ -629,7 +629,6 @@ static void display_all_workspaces_toggled(GtkToggleButton* button, TasklistData
 
 static void setup_sensitivity(TasklistData* tasklist, GtkBuilder* builder, const char* wid1, const char* wid2, const char* wid3, const char* key)
 {
-	MatePanelApplet* applet = MATE_PANEL_APPLET(tasklist->applet);
 	GtkWidget* w;
 
 	if (g_settings_is_writable(tasklist->settings, key))

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -196,14 +196,16 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 }
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, cairo_pattern_t *pattern, PagerData* pager)
+static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkRGBA* color, cairo_pattern_t *pattern, PagerData* pager)
 #else
 static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, GdkPixmap* pixmap, PagerData* pager)
 #endif
 {
         /* taken from the TrashApplet */
         GtkRcStyle *rc_style;
+#if !GTK_CHECK_VERSION (3, 0, 0)
         GtkStyle *style;
+#endif
 
         /* reset style */
         gtk_widget_set_style (GTK_WIDGET (pager->pager), NULL);

--- a/libmate-panel-applet/mate-panel-applet.h
+++ b/libmate-panel-applet/mate-panel-applet.h
@@ -84,7 +84,7 @@ struct _MatePanelAppletClass {
 	void (*change_size) (MatePanelApplet* applet, guint size);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-	void (*change_background) (MatePanelApplet *applet, MatePanelAppletBackgroundType type, GdkColor* color, cairo_pattern_t *pattern);
+	void (*change_background) (MatePanelApplet *applet, MatePanelAppletBackgroundType type, GdkRGBA* color, cairo_pattern_t *pattern);
 #else
 	void (*change_background) (MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, GdkPixmap* pixmap);
 #endif

--- a/libmate-panel-applet/test-dbus-applet.c
+++ b/libmate-panel-applet/test-dbus-applet.c
@@ -112,7 +112,11 @@ test_applet_handle_size_change (TestApplet *applet,
 static void
 test_applet_handle_background_change (TestApplet                *applet,
 				      MatePanelAppletBackgroundType  type,
+#if GTK_CHECK_VERSION(3, 0, 0)
+				      GdkRGBA                   *color,
+#else
 				      GdkColor                  *color,
+#endif
 #if GTK_CHECK_VERSION (3, 0, 0)
 				      cairo_pattern_t           *pattern,
 #else
@@ -131,14 +135,20 @@ test_applet_handle_background_change (TestApplet                *applet,
 		gdk_window_set_back_pixmap (window, NULL, FALSE);
 #endif
 		break;
-	case PANEL_COLOR_BACKGROUND:
-		g_message ("Setting background to #%2x%2x%2x",
-			   color->red, color->green, color->blue);
+	case PANEL_COLOR_BACKGROUND: {
 #if GTK_CHECK_VERSION (3, 0, 0)
-		gdk_window_set_background_pattern (window, NULL);
+		gchar *color_str = gdk_rgba_to_string(color);
 #else
-		gdk_window_set_back_pixmap (window, NULL, FALSE);
+		gchar *color_str = gdk_color_to_string(color);
 #endif
+		g_message ("Setting background to %s", color_str);
+		g_free (color_str);
+#if GTK_CHECK_VERSION (3, 0, 0)
+		gdk_window_set_background_rgba (window, color);
+#else
+		gdk_window_set_background (window, color);
+#endif
+		}
 		break;
 	case PANEL_PIXMAP_BACKGROUND:
 #if GTK_CHECK_VERSION (3, 0, 0)

--- a/mate-panel/applet.c
+++ b/mate-panel/applet.c
@@ -612,13 +612,21 @@ mate_panel_applet_position_menu (GtkMenu   *menu,
 	screen = gtk_widget_get_screen (applet);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-	gtk_widget_get_preferred_size (GTK_WIDGET (menu), &requisition, NULL);
+	gtk_widget_get_preferred_size (GTK_WIDGET (menu), NULL, &requisition);
 #else
 	gtk_widget_size_request (GTK_WIDGET (menu), &requisition);
 #endif
 
 	gdk_window_get_origin (gtk_widget_get_window (applet), &menu_x, &menu_y);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	GdkDisplay *display = gdk_screen_get_display (screen);
+	GdkDeviceManager *device_manager = gdk_display_get_device_manager (display);
+	GdkDevice *pointer = gdk_device_manager_get_client_pointer (device_manager);
+	GdkWindow *window = gtk_widget_get_window (GTK_WIDGET (menu));
+	gdk_window_get_device_position(window, pointer, &pointer_x, &pointer_y, NULL);
+#else
 	gtk_widget_get_pointer (applet, &pointer_x, &pointer_y);
+#endif
 
 	gtk_widget_get_allocation (applet, &allocation);
 

--- a/mate-panel/libpanel-util/panel-icon-chooser.c
+++ b/mate-panel/libpanel-util/panel-icon-chooser.c
@@ -396,9 +396,17 @@ _panel_icon_chooser_clicked (GtkButton *button)
 	filechooser = gtk_file_chooser_dialog_new (_("Choose an icon"),
 						   parent,
 						   GTK_FILE_CHOOSER_ACTION_OPEN,
+#if GTK_CHECK_VERSION (3, 10, 0)
+						   _("_Cancel"),
+#else
 						   GTK_STOCK_CANCEL,
+#endif
 						   GTK_RESPONSE_CANCEL,
+#if GTK_CHECK_VERSION (3, 10, 0)
+						   _("_Open"),
+#else
 						   GTK_STOCK_OPEN,
+#endif
 						   GTK_RESPONSE_ACCEPT,
 						   NULL);
 	panel_gtk_file_chooser_add_image_preview (GTK_FILE_CHOOSER (filechooser));

--- a/mate-panel/libpanel-util/panel-launch.c
+++ b/mate-panel/libpanel-util/panel-launch.c
@@ -109,7 +109,11 @@ panel_app_info_launch_uris (GAppInfo   *appinfo,
 	g_return_val_if_fail (GDK_IS_SCREEN (screen), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	context = gdk_display_get_app_launch_context(gdk_screen_get_display(screen));
+#else
 	context = gdk_app_launch_context_new ();
+#endif
 	gdk_app_launch_context_set_screen (context, screen);
 	gdk_app_launch_context_set_timestamp (context, timestamp);
 
@@ -267,7 +271,7 @@ panel_launch_desktop_file_with_fallback (const char  *desktop_file,
 				G_SPAWN_SEARCH_PATH,
 				set_environment,
 				&display,
-				NULL,
+				&pid,
 				&local_error);
 				g_free (display);
 #else

--- a/mate-panel/mate-panel-applet-frame.c
+++ b/mate-panel/mate-panel-applet-frame.c
@@ -121,8 +121,11 @@ mate_panel_applet_frame_draw (GtkWidget *widget,
 			       NULL);
 	background = &frame->priv->panel->background;
 
-	if (bg_pattern && (background->type == PANEL_BACK_IMAGE ||
-	    (background->type == PANEL_BACK_COLOR && background->has_alpha))) {
+	if (bg_pattern && (background->type == PANEL_BACK_IMAGE
+#if !GTK_CHECK_VERSION (3, 0, 0)
+		|| (background->type == PANEL_BACK_COLOR && background->has_alpha)
+#endif
+		)) {
 		cairo_matrix_t ptm;
 
 		cairo_matrix_init_translate (&ptm,
@@ -218,7 +221,11 @@ mate_panel_applet_frame_update_background_size (MatePanelAppletFrame *frame,
 	background = &frame->priv->panel->background;
 
 	if (background->type == PANEL_BACK_NONE ||
-	   (background->type == PANEL_BACK_COLOR && !background->has_alpha))
+	   (background->type == PANEL_BACK_COLOR 
+#if !GTK_CHECK_VERSION (3, 0, 0)
+		&& !background->has_alpha
+#endif
+		))
 		return;
 
 	mate_panel_applet_frame_change_background (frame, background->type);
@@ -949,7 +956,7 @@ mate_panel_applet_frame_activating_free (MatePanelAppletFrameActivating *frame_a
 GdkScreen *
 panel_applet_frame_activating_get_screen (MatePanelAppletFrameActivating *frame_act)
 {
-	return gtk_widget_get_screen (frame_act->panel);
+	return gtk_widget_get_screen (GTK_WIDGET(frame_act->panel));
 }
 
 PanelOrientation
@@ -1034,7 +1041,11 @@ mate_panel_applet_frame_loading_failed (const char  *iid,
 
 	if (locked_down) {
 		gtk_dialog_add_buttons (GTK_DIALOG (dialog),
+#if GTK_CHECK_VERSION (3, 10, 0)
+					_("_OK"), LOADING_FAILED_RESPONSE_DONT_DELETE,
+#else
 					GTK_STOCK_OK, LOADING_FAILED_RESPONSE_DONT_DELETE,
+#endif
 					NULL);
 	} else {
 		gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog),
@@ -1042,7 +1053,11 @@ mate_panel_applet_frame_loading_failed (const char  *iid,
 					  "from your configuration?"));
 		gtk_dialog_add_buttons (GTK_DIALOG (dialog),
 					PANEL_STOCK_DONT_DELETE, LOADING_FAILED_RESPONSE_DONT_DELETE,
+#if GTK_CHECK_VERSION(3, 10, 0)
+					_("_Delete"), LOADING_FAILED_RESPONSE_DELETE,
+#else
 					GTK_STOCK_DELETE, LOADING_FAILED_RESPONSE_DELETE,
+#endif
 					NULL);
 	}
 

--- a/mate-panel/menu.c
+++ b/mate-panel/menu.c
@@ -1096,7 +1096,11 @@ drag_end_menu_cb (GtkWidget *widget, GdkDragContext     *context)
 	    }
 	}
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+      g_object_unref (cursor);
+#else
       gdk_cursor_unref (cursor);
+#endif
     }
 }
 

--- a/mate-panel/panel-addto.c
+++ b/mate-panel/panel-addto.c
@@ -1290,14 +1290,22 @@ panel_addto_dialog_new (PanelWidget *panel_widget)
 	gtk_container_add (GTK_CONTAINER (dialog_vbox), vbox);
 #endif
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	inner_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+#else
 	inner_vbox = gtk_vbox_new (FALSE, 6);
+#endif
 #if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_box_pack_start (GTK_BOX (dialog_vbox), inner_vbox, TRUE, TRUE, 0);
 #else
 	gtk_box_pack_start (GTK_BOX (vbox), inner_vbox, TRUE, TRUE, 0);
 #endif
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	find_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+#else
 	find_hbox = gtk_hbox_new (FALSE, 6);
+#endif
 	gtk_box_pack_start (GTK_BOX (inner_vbox), find_hbox, FALSE, FALSE, 0);
 
 	dialog->label = gtk_label_new_with_mnemonic ("");

--- a/mate-panel/panel-background-monitor.c
+++ b/mate-panel/panel-background-monitor.c
@@ -202,7 +202,11 @@ panel_background_monitor_get_for_screen (GdkScreen *screen)
 	if (!global_background_monitors) {
 		int n_screens;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+		n_screens = 1;
+#else
 		n_screens = gdk_display_get_n_screens (gdk_display_get_default ());
+#endif
 
 		global_background_monitors = g_new0 (PanelBackgroundMonitor *, n_screens);
 	}

--- a/mate-panel/panel-background.h
+++ b/mate-panel/panel-background.h
@@ -82,8 +82,9 @@ struct _PanelBackground {
 	guint                   stretch_image : 1;
 	guint                   rotate_image : 1;
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	guint                   has_alpha : 1;
-
+#endif
 	guint                   loaded : 1;
 	guint                   transformed : 1;
 	guint                   composited : 1;

--- a/mate-panel/panel-ditem-editor.c
+++ b/mate-panel/panel-ditem-editor.c
@@ -660,7 +660,11 @@ panel_ditem_editor_make_ui (PanelDItemEditor *dialog)
 	/* Command */
 	priv->command_label = label_new_with_mnemonic ("");
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	priv->command_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
+#else
 	priv->command_hbox = gtk_hbox_new (FALSE, 12);
+#endif
 	gtk_widget_show (priv->command_hbox);
 
 	priv->command_entry = gtk_entry_new ();

--- a/mate-panel/panel-force-quit.c
+++ b/mate-panel/panel-force-quit.c
@@ -63,7 +63,11 @@ display_popup_window (GdkScreen *screen)
 	gtk_container_add (GTK_CONTAINER (retval), frame);
 	gtk_widget_show (frame);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+#else
 	vbox = gtk_vbox_new (FALSE, 0);
+#endif
 	gtk_container_set_border_width (GTK_CONTAINER (vbox), 8);
 	gtk_container_add (GTK_CONTAINER (frame), vbox);
 	gtk_widget_show (vbox);
@@ -221,7 +225,11 @@ kill_window_question (gpointer window)
 						  "in it might get lost."));
 
 	gtk_dialog_add_buttons (GTK_DIALOG (dialog),
+#if GTK_CHECK_VERSION (3, 10, 0)
+				_("_Cancel"),
+#else
 				GTK_STOCK_CANCEL,
+#endif
 				GTK_RESPONSE_CANCEL,
 				PANEL_STOCK_FORCE_QUIT,
 				GTK_RESPONSE_ACCEPT,
@@ -306,7 +314,11 @@ panel_force_quit (GdkScreen *screen,
 	cross = gdk_cursor_new (GDK_CROSS);
 	status = gdk_pointer_grab (root, FALSE, GDK_BUTTON_PRESS_MASK,
 				   NULL, cross, time);
+#if GTK_CHECK_VERSION(3, 0, 0)
+	g_object_unref (cross);
+#else
 	gdk_cursor_unref (cross);
+#endif
 	if (status != GDK_GRAB_SUCCESS) {
 		g_warning ("Pointer grab failed\n");
 		remove_popup (popup);

--- a/mate-panel/panel-frame.c
+++ b/mate-panel/panel-frame.c
@@ -153,7 +153,9 @@ panel_frame_draw (GtkWidget      *widget,
 #endif
 		  PanelFrameEdge  edges)
 {
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	GdkWindow     *window;
+#endif
 	GtkStyle      *style;
 	GtkStateType   state;
 #if GTK_CHECK_VERSION (3, 0, 0)
@@ -168,7 +170,9 @@ panel_frame_draw (GtkWidget      *widget,
 	if (edges == PANEL_EDGE_NONE)
 		return;
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	window = gtk_widget_get_window (widget);
+#endif
 	style = gtk_widget_get_style (widget);
 	state = gtk_widget_get_state (widget);
 #if GTK_CHECK_VERSION (3, 0, 0)

--- a/mate-panel/panel-layout.c
+++ b/mate-panel/panel-layout.c
@@ -125,7 +125,7 @@ panel_layout_append_group_helper (GKeyFile                  *keyfile,
                                   const char                *type_for_error_message)
 {
     gboolean    retval = FALSE;
-    char       *id;
+    const char       *id;
     char       *unique_id = NULL;
     char       *path = NULL;
     GSettings  *settings = NULL;

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -271,7 +271,11 @@ static void panel_menu_bar_size_allocate(GtkWidget* widget, GtkAllocation* alloc
 
 	background = &PANEL_MENU_BAR(widget)->priv->panel->background;
 
-	if (background->type == PANEL_BACK_NONE || (background->type == PANEL_BACK_COLOR && !background->has_alpha))
+	if (background->type == PANEL_BACK_NONE 
+#if !GTK_CHECK_VERSION (3, 0, 0)
+		|| (background->type == PANEL_BACK_COLOR && !background->has_alpha)
+#endif
+		)
 	{
 		return;
 	}
@@ -329,24 +333,20 @@ static gboolean panel_menu_bar_on_expose(GtkWidget* widget, GdkEventExpose* even
 
 	if (gtk_widget_has_focus(GTK_WIDGET(menubar)))
 	{
-		gtk_paint_focus(gtk_widget_get_style(widget),
-#if GTK_CHECK_VERSION (3, 0, 0)
-						cr,
+#if GTK_CHECK_VERSION(3, 0, 0)
+		gtk_render_focus(gtk_widget_get_style_context(widget),
+				 cr, 0, 0,
+				 gtk_widget_get_allocated_width (widget),
+				 gtk_widget_get_allocated_height (widget));
 #else
+		gtk_paint_focus(gtk_widget_get_style(widget),
 						gtk_widget_get_window(widget),
-#endif
 						gtk_widget_get_state(GTK_WIDGET(menubar)),
-#if !GTK_CHECK_VERSION (3, 0, 0)
 						NULL,
-#endif
 						widget,
 						"menubar-applet",
 						0,
 						0,
-#if GTK_CHECK_VERSION (3, 0, 0)
-						gtk_widget_get_allocated_width (widget),
-						gtk_widget_get_allocated_height (widget));
-#else
 						-1,
 						-1);
 #endif

--- a/mate-panel/panel-multiscreen.c
+++ b/mate-panel/panel-multiscreen.c
@@ -454,7 +454,11 @@ panel_multiscreen_init (void)
 		return;
 
 	display = gdk_display_get_default ();
+#if GTK_CHECK_VERSION (3, 10, 0)
+	screens = 1;
+#else
 	screens = gdk_display_get_n_screens (display);
+#endif
 
 	panel_multiscreen_init_randr (display);
 
@@ -505,7 +509,11 @@ panel_multiscreen_reinit (void)
 	display = gdk_display_get_default ();
 	/* Don't use the screens variable since in the future, we might
 	 * want to call this function when a screen appears/disappears. */
+#if GTK_CHECK_VERSION (3, 10, 0)
+	new_screens = 1;
+#else
 	new_screens = gdk_display_get_n_screens (display);
+#endif
 
 	for (i = 0; i < new_screens; i++) {
 		GdkScreen *screen;

--- a/mate-panel/panel-recent.c
+++ b/mate-panel/panel-recent.c
@@ -151,7 +151,11 @@ recent_documents_clear_cb (GtkMenuItem      *menuitem,
 						    "\342\200\242 All items from the recent documents list in all applications."));
 
 	gtk_dialog_add_buttons (GTK_DIALOG (clear_recent_dialog),
+#if GTK_CHECK_VERSION (3, 10, 0)
+				_("_Cancel"), GTK_RESPONSE_CANCEL,
+#else
 				GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+#endif
 				PANEL_STOCK_CLEAR, GTK_RESPONSE_ACCEPT,
 				NULL);
 

--- a/mate-panel/panel-run-dialog.c
+++ b/mate-panel/panel-run-dialog.c
@@ -360,17 +360,6 @@ dummy_child_watch (GPid         pid,
 	 */
 }
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-/*
- * Set the DISPLAY variable, to be use by g_spawn_async.
- */
-static void
-set_environment (gpointer display)
-{
-	g_setenv ("DISPLAY", display, TRUE);
-}
-#endif
-
 static gboolean
 panel_run_dialog_launch_command (PanelRunDialog *dialog,
 				 const char     *command,
@@ -382,9 +371,6 @@ panel_run_dialog_launch_command (PanelRunDialog *dialog,
 	char      **argv;
 	int         argc;
 	GPid        pid;
-#if GTK_CHECK_VERSION (3, 0, 0)
-	char       *display;
-#endif
 
 	if (!command_is_executable (locale_command, &argc, &argv))
 		return FALSE;
@@ -395,18 +381,14 @@ panel_run_dialog_launch_command (PanelRunDialog *dialog,
 		mate_desktop_prepend_terminal_to_vector (&argc, &argv);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-	display = gdk_screen_make_display_name (screen);
-
 	result = g_spawn_async (NULL, /* working directory */
 				argv,
 				NULL, /* envp */
 				G_SPAWN_SEARCH_PATH,
-				set_environment,
-				&display,
 				NULL,
+				NULL,
+				&pid,
 				&error);
-
-	g_free (display);
 #else
 	result = gdk_spawn_on_screen (screen,
 				      NULL, /* working directory */

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -50,7 +50,9 @@ panel_separator_paint (GtkWidget    *widget,
 #endif
 {
 	PanelSeparator *separator;
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	GdkWindow      *window;
+#endif
 	GtkStyle       *style;
 #if GTK_CHECK_VERSION (3, 0, 0)
 	int             width;
@@ -61,7 +63,9 @@ panel_separator_paint (GtkWidget    *widget,
 
 	separator = PANEL_SEPARATOR (widget);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	window = gtk_widget_get_window (widget);
+#endif
 	style = gtk_widget_get_style (widget);
 #if GTK_CHECK_VERSION (3, 0, 0)
 	width = gtk_widget_get_allocated_width (widget);
@@ -200,8 +204,11 @@ panel_separator_size_allocate (GtkWidget     *widget,
 
 	background = &PANEL_SEPARATOR (widget)->priv->panel->background;
 
-	if (background->type == PANEL_BACK_NONE ||
-	   (background->type == PANEL_BACK_COLOR && !background->has_alpha))
+	if (background->type == PANEL_BACK_NONE
+#if !GTK_CHECK_VERSION (3, 0, 0)
+		|| (background->type == PANEL_BACK_COLOR && !background->has_alpha)
+#endif
+		)
 		return;
 
 	panel_separator_change_background (PANEL_SEPARATOR (widget));

--- a/mate-panel/panel-util.c
+++ b/mate-panel/panel-util.c
@@ -116,7 +116,11 @@ panel_push_window_busy (GtkWidget *window)
 		if (win != NULL) {
 			GdkCursor *cursor = gdk_cursor_new (GDK_WATCH);
 			gdk_window_set_cursor (win, cursor);
+#if GTK_CHECK_VERSION(3, 0, 0)
+			g_object_unref (cursor);
+#else
 			gdk_cursor_unref (cursor);
+#endif
 			gdk_flush ();
 		}
 	}
@@ -294,7 +298,11 @@ panel_find_icon (GtkIconTheme  *icon_theme,
 
 	if (info) {
 		retval = g_strdup (gtk_icon_info_get_filename (info));
+#if GTK_CHECK_VERSION(3, 0, 0)
+		g_object_unref (info);
+#else
 		gtk_icon_info_free (info);
+#endif
 	} else
 		retval = NULL;
 

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -1358,8 +1358,13 @@ panel_deletion_dialog (PanelToplevel *toplevel)
 	gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog),
 	                                          "%s", text2);	
 	gtk_dialog_add_buttons (GTK_DIALOG (dialog),
+#if GTK_CHECK_VERSION (3, 10, 0)
+				_("_Cancel"), GTK_RESPONSE_CANCEL,
+				_("_Delete"), GTK_RESPONSE_OK,
+#else
 				GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
 				GTK_STOCK_DELETE, GTK_RESPONSE_OK,
+#endif
 				NULL);
 
 	gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);

--- a/mate-panel/xstuff.c
+++ b/mate-panel/xstuff.c
@@ -728,7 +728,11 @@ xstuff_grab_key_on_all_screens (int      keycode,
 	int         i;
 
 	display   = gdk_display_get_default ();
+#if GTK_CHECK_VERSION(3, 0, 0)
+	n_screens = 1;
+#else
 	n_screens = gdk_display_get_n_screens (display);
+#endif
 
 	for (i = 0; i < n_screens; i++) {
 		GdkWindow *root;


### PR DESCRIPTION
panel real transparency.
rewrite deprecated symbols.
remove unused variables.
fix uninitialized variables

this commit depends on https://github.com/mate-desktop/mate-desktop/pull/102
