### PR TITLE
gtk3: remove transparent hack

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -2408,8 +2408,10 @@ fill_clock_applet (MatePanelApplet *applet)
 			  G_CALLBACK (panel_button_change_pixel_size),
 			  cd);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	mate_panel_applet_set_background_widget (MATE_PANEL_APPLET (cd->applet),
 					    GTK_WIDGET (cd->applet));
+#endif
 
         action_group = gtk_action_group_new ("ClockApplet Menu Actions");
         gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);

--- a/applets/fish/fish.c
+++ b/applets/fish/fish.c
@@ -1965,7 +1965,9 @@ static void fish_applet_instance_init(FishApplet* fish, FishAppletClass* klass)
 
 	mate_panel_applet_set_flags (MATE_PANEL_APPLET (fish), MATE_PANEL_APPLET_EXPAND_MINOR);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	mate_panel_applet_set_background_widget(MATE_PANEL_APPLET(fish), GTK_WIDGET(fish));
+#endif
 }
 
 static void fish_applet_class_init(FishAppletClass* klass)

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -252,7 +252,9 @@ static gboolean applet_factory(MatePanelApplet* applet, const gchar* iid, gpoint
 
 	mate_panel_applet_set_flags(applet, MATE_PANEL_APPLET_HAS_HANDLE | MATE_PANEL_APPLET_EXPAND_MINOR);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	mate_panel_applet_set_background_widget(applet, GTK_WIDGET(applet));
+#endif
 
 	force_no_focus_padding(GTK_WIDGET(applet));
 

--- a/applets/wncklet/showdesktop.c
+++ b/applets/wncklet/showdesktop.c
@@ -434,7 +434,9 @@ gboolean show_desktop_applet_fill(MatePanelApplet* applet)
 	   initial oriantation, and we get that during the _add call */
 	g_signal_connect(G_OBJECT (sdd->applet), "change_orient", G_CALLBACK (applet_change_orient), sdd);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	mate_panel_applet_set_background_widget(MATE_PANEL_APPLET (sdd->applet), GTK_WIDGET(sdd->applet));
+#endif
 
 	action_group = gtk_action_group_new("ShowDesktop Applet Actions");
 	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -471,7 +471,9 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 	g_signal_connect(G_OBJECT(tasklist->applet), "change_size", G_CALLBACK(applet_change_pixel_size), tasklist);
 	g_signal_connect(G_OBJECT(tasklist->applet), "change_background", G_CALLBACK(applet_change_background), tasklist);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	mate_panel_applet_set_background_widget(MATE_PANEL_APPLET(tasklist->applet), GTK_WIDGET(tasklist->applet));
+#endif
 
 	action_group = gtk_action_group_new("Tasklist Applet Actions");
 	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);

--- a/applets/wncklet/window-menu.c
+++ b/applets/wncklet/window-menu.c
@@ -284,7 +284,9 @@ gboolean window_menu_applet_fill(MatePanelApplet* applet)
 	window_menu->selector = wnck_selector_new();
 	gtk_container_add(GTK_CONTAINER(window_menu->applet), window_menu->selector);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	mate_panel_applet_set_background_widget(MATE_PANEL_APPLET(window_menu->applet), GTK_WIDGET(window_menu->selector));
+#endif
 
 	g_signal_connect(window_menu->applet, "key_press_event", G_CALLBACK(window_menu_key_press_event), window_menu);
 	g_signal_connect(window_menu->applet, "size-allocate", G_CALLBACK(window_menu_size_allocate), window_menu);

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -556,7 +556,9 @@ gboolean workspace_switcher_applet_fill(MatePanelApplet* applet)
 
 	gtk_widget_show(pager->applet);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	mate_panel_applet_set_background_widget(MATE_PANEL_APPLET(pager->applet), GTK_WIDGET(pager->applet));
+#endif
 
 	action_group = gtk_action_group_new("WorkspaceSwitcher Applet Actions");
 	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);

--- a/libmate-panel-applet/mate-panel-applet.h
+++ b/libmate-panel-applet/mate-panel-applet.h
@@ -102,7 +102,10 @@ MatePanelAppletBackgroundType mate_panel_applet_get_background (MatePanelApplet 
 #else
 MatePanelAppletBackgroundType mate_panel_applet_get_background(MatePanelApplet* applet, /* return values */ GdkColor* color, GdkPixmap** pixmap);
 #endif
+
+#if !GTK_CHECK_VERSION (3, 0, 0)
 void mate_panel_applet_set_background_widget(MatePanelApplet* applet, GtkWidget* widget);
+#endif
 
 gchar* mate_panel_applet_get_preferences_path(MatePanelApplet* applet);
 


### PR DESCRIPTION
background widget is hack to change background for some widget.
background should be :
- for MATE_PANEL_APPLET_OUT_PROCESS_FACTORY applets changed for applet window
- for MATE_PANEL_APPLET_IN_PROCESS_FACTORY applets have no own window and they are drawn on panel frame window
