### PR TITLE
Fix for RGBA transparency.

### DIFF
--- a/mate-panel/mate-panel-applet-frame.c
+++ b/mate-panel/mate-panel-applet-frame.c
@@ -624,6 +624,7 @@ mate_panel_applet_frame_change_background (MatePanelAppletFrame    *frame,
 
 	g_return_if_fail (PANEL_IS_WIDGET (parent));
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	if (frame->priv->has_handle) {
 		PanelBackground *background;
 
@@ -631,6 +632,7 @@ mate_panel_applet_frame_change_background (MatePanelAppletFrame    *frame,
 		panel_background_change_background_on_widget (background,
 							      GTK_WIDGET (frame));
 	}
+#endif
 
 	MATE_PANEL_APPLET_FRAME_GET_CLASS (frame)->change_background (frame, type);
 }

--- a/mate-panel/panel-background.h
+++ b/mate-panel/panel-background.h
@@ -55,6 +55,7 @@ struct _PanelBackground {
 	GtkOrientation          orientation;
 	GdkRectangle            region;
 #if GTK_CHECK_VERSION (3, 0, 0)
+	GtkWidget              *background_widget;
 	cairo_pattern_t        *transformed_pattern;
 	cairo_pattern_t        *composited_pattern;
 #else
@@ -134,6 +135,10 @@ void  panel_background_set_default_style (PanelBackground     *background,
 #else
 					  GdkColor            *color,
 					  GdkPixmap           *pixmap);
+#endif
+#if GTK_CHECK_VERSION (3, 0, 0)
+void  panel_background_set_background_widget	(PanelBackground     *background,
+					         GtkWidget           *widget);
 #endif
 void  panel_background_realized          (PanelBackground     *background,
 					  GdkWindow           *window);

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -467,7 +467,12 @@ void panel_menu_bar_popup_menu(PanelMenuBar* menubar, guint32 activate_time)
 
 void panel_menu_bar_change_background(PanelMenuBar* menubar)
 {
+#if GTK_CHECK_VERSION (3, 0, 0)
+	GdkRGBA transparent = {0, 0, 0, 0};
+	gtk_widget_override_background_color(GTK_WIDGET(menubar),gtk_widget_get_state_flags(GTK_WIDGET(menubar)),&transparent);
+#else
 	panel_background_change_background_on_widget(&menubar->priv->panel->background, GTK_WIDGET(menubar));
+#endif
 }
 
 static void set_item_text_gravity(GtkWidget* item)

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -50,23 +50,23 @@ panel_separator_paint (GtkWidget    *widget,
 #endif
 {
 	PanelSeparator *separator;
-	GdkWindow      *window;
 	GtkStyle       *style;
 #if GTK_CHECK_VERSION (3, 0, 0)
 	int             width;
 	int             height;
 #else
+	GdkWindow      *window;
 	GtkAllocation   allocation;
 #endif
 
 	separator = PANEL_SEPARATOR (widget);
 
-	window = gtk_widget_get_window (widget);
 	style = gtk_widget_get_style (widget);
 #if GTK_CHECK_VERSION (3, 0, 0)
 	width = gtk_widget_get_allocated_width (widget);
 	height = gtk_widget_get_allocated_height (widget);
 #else
+	window = gtk_widget_get_window (widget);
 	gtk_widget_get_allocation (widget, &allocation);
 #endif
 
@@ -321,6 +321,10 @@ panel_separator_create (PanelToplevel *toplevel,
 void
 panel_separator_change_background (PanelSeparator *separator)
 {
-	panel_background_change_background_on_widget (&separator->priv->panel->background,
-						      GTK_WIDGET (separator));
+#if GTK_CHECK_VERSION (3, 0, 0)
+	GdkRGBA transparent = {0, 0, 0, 0};
+	gtk_widget_override_background_color(GTK_WIDGET(separator),gtk_widget_get_state_flags(GTK_WIDGET(separator)),&transparent);
+#else
+	panel_background_change_background_on_widget(&separator->priv->panel->background, GTK_WIDGET(separator));
+#endif
 }

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1749,11 +1749,11 @@ panel_widget_realize (GtkWidget *widget)
 #if !GTK_CHECK_VERSION (3, 0, 0)
 	style = gtk_widget_get_style (widget);
 	state = gtk_widget_get_state (widget);
-#endif
 
 	/* For auto-hidden panels with a colored background, we need native
 	 * windows to avoid some uglyness on unhide */
 	gdk_window_ensure_native (window);
+#endif
 
 #if GTK_CHECK_VERSION (3, 0, 0)
 	panel_widget_set_background_default_style (widget);
@@ -1763,7 +1763,10 @@ panel_widget_realize (GtkWidget *widget)
 		&style->bg [state],
 		style->bg_pixmap [state]);
 #endif
-
+#if GTK_CHECK_VERSION (3, 0, 0)
+	panel_background_set_background_widget(&panel->background,
+						gtk_widget_get_toplevel(widget));
+#endif
 	panel_background_realized (&panel->background, window);
 }
 


### PR DESCRIPTION
Request for testing!!!
Fix for GTK3 color background.
Now GTK3 panel uses real transparency.
Also this partially fixes https://github.com/mate-desktop/mate-panel/issues/187 and partially fixes https://github.com/mate-desktop/mate-panel/issues/185
