### PR TITLE
Fix rgba all

### DIFF
--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -139,8 +139,10 @@ static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBac
 	switch (type)
 	{
 		case PANEL_NO_BACKGROUND:
+#if !GTK_CHECK_VERSION (3, 0 ,0)
 			wnck_tasklist_set_button_relief(WNCK_TASKLIST(tasklist->tasklist), GTK_RELIEF_NORMAL);
 			break;
+#endif
 		case PANEL_COLOR_BACKGROUND:
 		case PANEL_PIXMAP_BACKGROUND:
 			wnck_tasklist_set_button_relief(WNCK_TASKLIST(tasklist->tasklist), GTK_RELIEF_NONE);

--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -120,6 +120,9 @@ static void       mate_panel_applet_menu_cmd_move       (GtkAction         *acti
 static void       mate_panel_applet_menu_cmd_lock       (GtkAction         *action,
 						    MatePanelApplet       *applet);
 static void       mate_panel_applet_register_object     (MatePanelApplet       *applet);
+#if GTK_CHECK_VERSION (3, 0, 0)
+void	_mate_panel_applet_apply_css	(GtkWidget* widget, MatePanelAppletBackgroundType type);
+#endif
 
 static const gchar panel_menu_ui[] =
 	"<ui>\n"
@@ -1464,7 +1467,7 @@ mate_panel_applet_get_pixmap (MatePanelApplet     *applet,
 	width = gdk_window_get_width(window);
 	height = gdk_window_get_height(window);
 #if GTK_CHECK_VERSION(3, 0, 0)
-	surface = cairo_image_surface_create (CAIRO_FORMAT_RGB24, width, height);
+	surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, width, height);
 #endif
 
 #if GTK_CHECK_VERSION (3, 0, 0)
@@ -1490,10 +1493,6 @@ mate_panel_applet_get_pixmap (MatePanelApplet     *applet,
 #if GTK_CHECK_VERSION (3, 0, 0)
 	if (cairo_status (cr) == CAIRO_STATUS_SUCCESS) {
 		pattern = cairo_pattern_create_for_surface (surface);
-		cairo_matrix_init_translate (&matrix, 0, 0);
-		cairo_matrix_scale (&matrix, width, height);
-		cairo_pattern_set_matrix (pattern, &matrix);
-		cairo_pattern_set_extend (pattern, CAIRO_EXTEND_PAD);
 	}
 
 	cairo_destroy (cr);
@@ -1770,9 +1769,14 @@ mate_panel_applet_handle_background (MatePanelApplet *applet)
 
 	type = mate_panel_applet_get_background (applet, &color, &pattern);
 
+
 	if (applet->priv->background_widget)
+	{
 		mate_panel_applet_update_background_for_widget (applet->priv->background_widget,
 							   type, &color, pattern);
+		_mate_panel_applet_apply_css(applet->priv->background_widget,type);
+	}
+
 #else
 	GdkColor                   color;
 	GdkPixmap                 *pixmap;
@@ -1838,6 +1842,33 @@ mate_panel_applet_move_focus_out_of_applet (MatePanelApplet      *applet,
 	gtk_widget_child_focus (toplevel, dir);
 	applet->priv->moving_focus_out = FALSE;
 }
+
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void
+mate_panel_applet_change_background(MatePanelApplet *applet,
+				    MatePanelAppletBackgroundType type,
+				    GdkRGBA* color,
+				    cairo_pattern_t *pattern)
+{
+	GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(applet));
+	gtk_widget_set_app_paintable(GTK_WIDGET(applet),TRUE);
+	_mate_panel_applet_apply_css(GTK_WIDGET(applet->priv->plug),type);
+	switch (type) {
+	case PANEL_NO_BACKGROUND:
+		gdk_window_set_background_pattern(window,NULL);
+		break;
+	case PANEL_COLOR_BACKGROUND:
+		gdk_window_set_background_rgba(window,color);
+		break;
+	case PANEL_PIXMAP_BACKGROUND:
+		gdk_window_set_background_pattern(window,pattern);
+		break;
+	default:
+		g_assert_not_reached ();
+		break;
+	}
+}
+#endif
 
 static void
 mate_panel_applet_get_property (GObject    *object,
@@ -2009,6 +2040,40 @@ mate_panel_applet_setup (MatePanelApplet *applet)
 	}
 }
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+void _mate_panel_applet_apply_css(GtkWidget* widget, MatePanelAppletBackgroundType type)
+{
+	GtkStyleContext* context;
+	GtkCssProvider  *provider;
+
+	context = gtk_widget_get_style_context (widget);
+	gtk_widget_reset_style(widget);
+
+	switch (type) {
+	case PANEL_NO_BACKGROUND:
+		gtk_style_context_remove_class(context,"-mate-custom-panel-background");
+		break;
+	case PANEL_COLOR_BACKGROUND:
+	case PANEL_PIXMAP_BACKGROUND:
+		provider = gtk_css_provider_new ();
+		gtk_css_provider_load_from_data (provider,
+						".-mate-custom-panel-background{\n"
+						" background-color: rgba (0, 0, 0, 0);\n"
+						" background-image: none;\n"
+						"}",
+						-1, NULL);
+		gtk_style_context_add_class (context, "-mate-custom-panel-background");
+		gtk_style_context_add_provider (context,
+						GTK_STYLE_PROVIDER (provider),
+						GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+		break;
+	default:
+		g_assert_not_reached ();
+		break;
+	}
+}
+#endif
+
 static void
 mate_panel_applet_init (MatePanelApplet *applet)
 {
@@ -2043,6 +2108,12 @@ mate_panel_applet_init (MatePanelApplet *applet)
 	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(applet->priv->plug));
 	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
 	gtk_widget_set_visual(GTK_WIDGET(applet->priv->plug), visual);
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(applet->priv->plug));
+	gtk_style_context_remove_class (context,GTK_STYLE_CLASS_BACKGROUND);
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
+	gtk_widget_set_name(GTK_WIDGET(applet->priv->plug), "PanelPlug");
 #endif
 	g_signal_connect_swapped (G_OBJECT (applet->priv->plug), "embedded",
 				  G_CALLBACK (mate_panel_applet_setup),
@@ -2082,7 +2153,9 @@ mate_panel_applet_class_init (MatePanelAppletClass *klass)
 	gobject_class->set_property = mate_panel_applet_set_property;
 	gobject_class->constructed = mate_panel_applet_constructed;
 	klass->move_focus_out_of_applet = mate_panel_applet_move_focus_out_of_applet;
-
+#if GTK_CHECK_VERSION (3, 0, 0)
+	klass->change_background = mate_panel_applet_change_background;
+#endif
 	widget_class->button_press_event = mate_panel_applet_button_press;
 	widget_class->button_release_event = mate_panel_applet_button_release;
 #if GTK_CHECK_VERSION (3, 0, 0)
@@ -2218,10 +2291,11 @@ mate_panel_applet_class_init (MatePanelAppletClass *klass)
                               G_TYPE_NONE,
 			      3,
 			      PANEL_TYPE_MATE_PANEL_APPLET_BACKGROUND_TYPE,
-			      GDK_TYPE_COLOR,
 #if GTK_CHECK_VERSION (3, 0, 0)
+			      GDK_TYPE_RGBA,
 			      CAIRO_GOBJECT_TYPE_PATTERN);
 #else
+			      GDK_TYPE_COLOR,
 			      GDK_TYPE_PIXMAP);
 #endif
 
@@ -2533,6 +2607,8 @@ mate_panel_applet_set_background_widget (MatePanelApplet *applet,
 		type = mate_panel_applet_get_background (applet, &color, &pattern);
 		mate_panel_applet_update_background_for_widget (widget, type,
 							   &color, pattern);
+		_mate_panel_applet_apply_css(widget,type);
+
 		if (type == PANEL_PIXMAP_BACKGROUND)
 			cairo_pattern_destroy (pattern);
 #else

--- a/libmate-panel-applet/mate-panel-applet.h
+++ b/libmate-panel-applet/mate-panel-applet.h
@@ -84,7 +84,7 @@ struct _MatePanelAppletClass {
 	void (*change_size) (MatePanelApplet* applet, guint size);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-	void (*change_background) (MatePanelApplet *applet, MatePanelAppletBackgroundType type, GdkColor* color, cairo_pattern_t *pattern);
+	void (*change_background) (MatePanelApplet *applet, MatePanelAppletBackgroundType type, GdkRGBA* color, cairo_pattern_t *pattern);
 #else
 	void (*change_background) (MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, GdkPixmap* pixmap);
 #endif

--- a/mate-panel/mate-panel-applet-frame.c
+++ b/mate-panel/mate-panel-applet-frame.c
@@ -624,6 +624,7 @@ mate_panel_applet_frame_change_background (MatePanelAppletFrame    *frame,
 
 	g_return_if_fail (PANEL_IS_WIDGET (parent));
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	if (frame->priv->has_handle) {
 		PanelBackground *background;
 
@@ -631,6 +632,7 @@ mate_panel_applet_frame_change_background (MatePanelAppletFrame    *frame,
 		panel_background_change_background_on_widget (background,
 							      GTK_WIDGET (frame));
 	}
+#endif
 
 	MATE_PANEL_APPLET_FRAME_GET_CLASS (frame)->change_background (frame, type);
 }

--- a/mate-panel/panel-background-monitor.c
+++ b/mate-panel/panel-background-monitor.c
@@ -84,6 +84,13 @@ static PanelBackgroundMonitor **global_background_monitors = NULL;
 
 static guint signals [LAST_SIGNAL] = { 0 };
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+gboolean gdk_window_check_composited_wm(GdkWindow* window)
+{
+	return gdk_screen_is_composited(gdk_window_get_screen(window));
+}
+#endif
+
 static void
 panel_background_monitor_finalize (GObject *object)
 {

--- a/mate-panel/panel-background-monitor.h
+++ b/mate-panel/panel-background-monitor.h
@@ -49,6 +49,9 @@
 typedef struct _PanelBackgroundMonitorClass PanelBackgroundMonitorClass;
 typedef struct _PanelBackgroundMonitor      PanelBackgroundMonitor;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+gboolean                gdk_window_check_composited_wm          (GdkWindow* window);
+#endif
 GType                   panel_background_monitor_get_type       (void);
 PanelBackgroundMonitor *panel_background_monitor_get_for_screen (GdkScreen *screen);
 GdkPixbuf              *panel_background_monitor_get_region     (PanelBackgroundMonitor *monitor,

--- a/mate-panel/panel-background.h
+++ b/mate-panel/panel-background.h
@@ -54,11 +54,10 @@ struct _PanelBackground {
 
 	GtkOrientation          orientation;
 	GdkRectangle            region;
+	GdkPixbuf              *transformed_image;
 #if GTK_CHECK_VERSION (3, 0, 0)
-	cairo_pattern_t        *transformed_pattern;
 	cairo_pattern_t        *composited_pattern;
 #else
-	GdkPixbuf              *transformed_image;
 	GdkPixbuf              *composited_image;
 #endif
 
@@ -161,5 +160,9 @@ PanelBackgroundType
 
 void panel_background_change_background_on_widget (PanelBackground *background,
 						   GtkWidget       *widget);
+
+#if GTK_CHECK_VERSION (3, 0, 0)
+void panel_background_apply_css(GtkWidget* widget);
+#endif
 
 #endif /* __PANEL_BACKGROUND_H__ */

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -467,7 +467,11 @@ void panel_menu_bar_popup_menu(PanelMenuBar* menubar, guint32 activate_time)
 
 void panel_menu_bar_change_background(PanelMenuBar* menubar)
 {
+#if GTK_CHECK_VERSION (3, 0, 0)
+	panel_background_apply_css(GTK_WIDGET(menubar));
+#else
 	panel_background_change_background_on_widget(&menubar->priv->panel->background, GTK_WIDGET(menubar));
+#endif
 }
 
 static void set_item_text_gravity(GtkWidget* item)

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -50,23 +50,23 @@ panel_separator_paint (GtkWidget    *widget,
 #endif
 {
 	PanelSeparator *separator;
-	GdkWindow      *window;
 	GtkStyle       *style;
 #if GTK_CHECK_VERSION (3, 0, 0)
 	int             width;
 	int             height;
 #else
+	GdkWindow      *window;
 	GtkAllocation   allocation;
 #endif
 
 	separator = PANEL_SEPARATOR (widget);
 
-	window = gtk_widget_get_window (widget);
 	style = gtk_widget_get_style (widget);
 #if GTK_CHECK_VERSION (3, 0, 0)
 	width = gtk_widget_get_allocated_width (widget);
 	height = gtk_widget_get_allocated_height (widget);
 #else
+	window = gtk_widget_get_window (widget);
 	gtk_widget_get_allocation (widget, &allocation);
 #endif
 
@@ -321,6 +321,9 @@ panel_separator_create (PanelToplevel *toplevel,
 void
 panel_separator_change_background (PanelSeparator *separator)
 {
-	panel_background_change_background_on_widget (&separator->priv->panel->background,
-						      GTK_WIDGET (separator));
+#if GTK_CHECK_VERSION (3, 0, 0)
+	panel_background_apply_css(GTK_WIDGET(separator));
+#else
+	panel_background_change_background_on_widget(&separator->priv->panel->background, GTK_WIDGET(separator));
+#endif
 }

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -4940,6 +4940,18 @@ panel_toplevel_set_orientation (PanelToplevel    *toplevel,
 
 	toplevel->priv->orientation = orientation;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	GtkStyleContext* context = gtk_widget_get_style_context (GTK_WIDGET (toplevel));
+	if (orientation & PANEL_HORIZONTAL_MASK) {
+		gtk_style_context_add_class (context, GTK_STYLE_CLASS_HORIZONTAL);
+		gtk_style_context_remove_class (context, GTK_STYLE_CLASS_VERTICAL);
+	} else {
+		gtk_style_context_add_class (context, GTK_STYLE_CLASS_VERTICAL);
+		gtk_style_context_remove_class (context, GTK_STYLE_CLASS_HORIZONTAL);
+	}
+	gtk_widget_reset_style (GTK_WIDGET (toplevel));
+#endif
+
 	panel_toplevel_update_hide_buttons (toplevel);
 
 	panel_widget_set_orientation (

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1662,6 +1662,8 @@ panel_widget_style_set (GtkWidget *widget, GtkStyle  *previous_style)
 #if GTK_CHECK_VERSION (3, 0, 0)
 		context = gtk_widget_get_style_context (widget);
 		state = gtk_widget_get_state_flags (widget);
+		gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+		gtk_style_context_add_class(context,"mate-panel-menu-bar");
 
 		gtk_style_context_get_background_color (context, state, &bg_color);
 		gtk_style_context_get (context, state, "background-image", &bg_image, NULL);
@@ -1749,11 +1751,11 @@ panel_widget_realize (GtkWidget *widget)
 #if !GTK_CHECK_VERSION (3, 0, 0)
 	style = gtk_widget_get_style (widget);
 	state = gtk_widget_get_state (widget);
-#endif
 
 	/* For auto-hidden panels with a colored background, we need native
 	 * windows to avoid some uglyness on unhide */
 	gdk_window_ensure_native (window);
+#endif
 
 #if GTK_CHECK_VERSION (3, 0, 0)
 	panel_widget_set_background_default_style (widget);


### PR DESCRIPTION
Fix ALL RGBA issues for GTK3.
GTK3 Panel now can use real transparency.
Need testing for GTK2.

Fully fixes https://github.com/mate-desktop/mate-panel/issues/187.
