### PR TITLE
Remove remaining obsolete compatibility options

### DIFF
--- a/mate-panel/applet.c
+++ b/mate-panel/applet.c
@@ -65,8 +65,6 @@ mate_panel_applet_set_dnd_enabled (AppletInfo *info,
 		break;
 	case PANEL_OBJECT_APPLET:
 		break;
-	case PANEL_OBJECT_LOGOUT:
-	case PANEL_OBJECT_LOCK:
 	case PANEL_OBJECT_ACTION:
 		panel_action_button_set_dnd_enabled (PANEL_ACTION_BUTTON (info->widget),
 						     dnd_enabled);
@@ -263,8 +261,6 @@ applet_callback_callback (GtkWidget      *widget,
 			PANEL_MENU_BUTTON (menu->info->widget), menu->name);
 		break;
 	case PANEL_OBJECT_ACTION:
-	case PANEL_OBJECT_LOGOUT:
-	case PANEL_OBJECT_LOCK:
 		panel_action_button_invoke_menu (
 			PANEL_ACTION_BUTTON (menu->info->widget), menu->name);
 		break;

--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -40,7 +40,6 @@
 GSList *panels = NULL;
 GSList *panel_list = NULL;
 
-static char*    deprecated_profile;
 static char*    layout;
 static gboolean replace = FALSE;
 static gboolean reset = FALSE;
@@ -48,8 +47,6 @@ static gboolean run_dialog = FALSE;
 
 static const GOptionEntry options[] = {
   { "replace", 0, 0, G_OPTION_ARG_NONE, &replace, N_("Replace a currently running panel"), NULL },
-  /* keep this for compatibilty with old MATE < 2.10 */
-  { "profile", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &deprecated_profile, NULL, NULL },
   /* this feature was request in #mate irc channel */
   { "reset", 0, 0, G_OPTION_ARG_NONE, &reset, N_("Reset the panel configuration to default"), NULL },
   /* open run dialog */

--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -704,13 +704,11 @@ panel_action_button_load (PanelActionButtonType  type,
 			  const char            *id)
 {
 	PanelActionButton *button;
-	PanelObjectType    object_type;
 
 	g_return_if_fail (panel != NULL);
 
 	button = g_object_new (PANEL_TYPE_ACTION_BUTTON, "action-type", type, NULL);
 
-	object_type = PANEL_OBJECT_ACTION;
 
 	button->priv->info = mate_panel_applet_register (GTK_WIDGET (button),
 						    NULL, NULL,


### PR DESCRIPTION
Gnome-panel 2.32 contained code to upgrade from very old versions. These old versions have no corresponding MATE version, so the code doesn't do anything and is never called. Most of it is already removed, but this pull request removes the remainder.

Code taken from commits b9fc819b956319b6ae99fa13bf54c4f54d9e3a0e and e57b3afd9255671789ea6c1b6136bbad82573cdc of gnome-panel.