### PR TITLE
gtk3: correct css theme selector widget name

### DIFF
--- a/applets/wncklet/window-menu.c
+++ b/applets/wncklet/window-menu.c
@@ -177,7 +177,7 @@ static inline void force_no_focus_padding(GtkWidget* widget)
 
 	provider = gtk_css_provider_new ();
 	gtk_css_provider_load_from_data (provider,
-					 "#window-menu-applet-button {\n"
+					 "#PanelApplet-window-menu-applet-button {\n"
 					 " border-width: 0px;\n"
 					 " -GtkWidget-focus-line-width: 0px;\n"
 					 " -GtkWidget-focus-padding: 0px; }",


### PR DESCRIPTION
Window Selector widget name is "PanelApplet-window-menu-applet-button".
This fix 1px focus width