### PR TITLE
Gtk3: Support icon-padding and icon-size for NotificationArea applet

### DIFF
--- a/applets/notification_area/Makefile.am
+++ b/applets/notification_area/Makefile.am
@@ -26,7 +26,7 @@ libtray_la_SOURCES =		\
 	na-tray-manager.c	\
 	na-tray-manager.h
 
-NOTIFICATION_AREA_SOURCES = main.c
+NOTIFICATION_AREA_SOURCES = main.c main.h
 
 NOTIFICATION_AREA_LDADD =				\
 	../../libmate-panel-applet/libmate-panel-applet-4.la	\

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -188,6 +188,7 @@ na_tray_applet_unrealize (GtkWidget *widget)
   GTK_WIDGET_CLASS (na_tray_applet_parent_class)->unrealize (widget);
 }
 
+#if GTK_CHECK_VERSION (3, 0, 0)
 static inline gboolean
 style_context_lookup_color (GtkStyleContext *context,
                             const gchar     *color_name,
@@ -245,6 +246,7 @@ na_tray_applet_style_updated (GtkWidget *widget)
   gtk_widget_style_get (widget, "icon-size", &icon_size, NULL);
   na_tray_set_icon_size (applet->priv->tray, icon_size);
 }
+#endif
 
 #if GTK_CHECK_VERSION (3, 0, 0)
 static void
@@ -313,7 +315,9 @@ na_tray_applet_class_init (NaTrayAppletClass *class)
 
   widget_class->realize = na_tray_applet_realize;
   widget_class->unrealize = na_tray_applet_unrealize;
+#if GTK_CHECK_VERSION (3, 0, 0)
   widget_class->style_updated = na_tray_applet_style_updated;
+#endif
   applet_class->change_background = na_tray_applet_change_background;
   applet_class->change_orient = na_tray_applet_change_orient;
 

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -123,6 +123,7 @@ na_tray_applet_style_updated (GtkWidget *widget)
   GdkColor         warning;
   GdkColor         success;
   gint             padding;
+  gint             icon_size;
 
   GTK_WIDGET_CLASS (na_tray_applet_parent_class)->style_updated (widget);
 
@@ -146,8 +147,10 @@ na_tray_applet_style_updated (GtkWidget *widget)
   na_tray_set_colors (applet->priv->tray, &fg, &error, &warning, &success);
 
   gtk_widget_style_get (widget, "icon-padding", &padding, NULL);
-
   na_tray_set_padding (applet->priv->tray, padding);
+
+  gtk_widget_style_get (widget, "icon-size", &icon_size, NULL);
+  na_tray_set_icon_size (applet->priv->tray, icon_size);
 }
 
 static void
@@ -222,6 +225,14 @@ na_tray_applet_class_init (NaTrayAppletClass *class)
           g_param_spec_int ("icon-padding",
                             "Padding around icons",
                             "Padding that should be put around icons, in pixels",
+                            0, G_MAXINT, 0,
+                            G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
+
+  gtk_widget_class_install_style_property (
+          widget_class,
+          g_param_spec_int ("icon-size",
+                            "Icon size",
+                            "If non-zero, hardcodes the size of the icons in pixels",
                             0, G_MAXINT, 0,
                             G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
 

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -122,6 +122,7 @@ na_tray_applet_style_updated (GtkWidget *widget)
   GdkColor         error;
   GdkColor         warning;
   GdkColor         success;
+  gint             padding;
 
   GTK_WIDGET_CLASS (na_tray_applet_parent_class)->style_updated (widget);
 
@@ -143,6 +144,10 @@ na_tray_applet_style_updated (GtkWidget *widget)
     success = fg;
 
   na_tray_set_colors (applet->priv->tray, &fg, &error, &warning, &success);
+
+  gtk_widget_style_get (widget, "icon-padding", &padding, NULL);
+
+  na_tray_set_padding (applet->priv->tray, padding);
 }
 
 static void
@@ -211,6 +216,14 @@ na_tray_applet_class_init (NaTrayAppletClass *class)
   widget_class->style_updated = na_tray_applet_style_updated;
   applet_class->change_background = na_tray_applet_change_background;
   applet_class->change_orient = na_tray_applet_change_orient;
+
+  gtk_widget_class_install_style_property (
+          widget_class,
+          g_param_spec_int ("icon-padding",
+                            "Padding around icons",
+                            "Padding that should be put around icons, in pixels",
+                            0, G_MAXINT, 0,
+                            G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
 
   g_type_class_add_private (class, sizeof (NaTrayAppletPrivate));
 }

--- a/applets/notification_area/main.h
+++ b/applets/notification_area/main.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2002 Red Hat, Inc.
+ * Copyright (C) 2003-2006 Vincent Untz
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+
+
+#ifndef __NA_TRAY_APPLET_H__
+#define __NA_TRAY_APPLET_H__
+
+#include <panel-applet.h>
+
+G_BEGIN_DECLS
+
+#define NA_TYPE_TRAY_APPLET             (na_tray_applet_get_type ())
+#define NA_TRAY_APPLET(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), NA_TYPE_TRAY_APPLET, NaTrayApplet))
+#define NA_TRAY_APPLET_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), NA_TYPE_TRAY_APPLET, NaTrayAppletClass))
+#define NA_IS_TRAY_APPLET(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), NA_TYPE_TRAY_APPLET))
+#define NA_IS_TRAY_APPLET_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), NA_TYPE_TRAY_APPLET))
+#define NA_TRAY_APPLET_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), NA_TYPE_TRAY_APPLET, NaTrayAppletClass))
+
+typedef struct _NaTrayApplet        NaTrayApplet;
+typedef struct _NaTrayAppletClass   NaTrayAppletClass;
+typedef struct _NaTrayAppletPrivate NaTrayAppletPrivate;
+
+struct _NaTrayApplet
+{
+  PanelApplet parent_object;
+
+  /*< private >*/
+  NaTrayAppletPrivate *priv;
+};
+
+struct _NaTrayAppletClass
+{
+  PanelAppletClass parent_class;
+};
+
+GType na_tray_applet_get_type (void) G_GNUC_CONST;
+
+G_END_DECLS
+
+#endif /* __NA_TRAY_APPLET_H__ */

--- a/applets/notification_area/main.h
+++ b/applets/notification_area/main.h
@@ -22,7 +22,7 @@
 #ifndef __NA_TRAY_APPLET_H__
 #define __NA_TRAY_APPLET_H__
 
-#include <panel-applet.h>
+#include <mate-panel-applet.h>
 
 G_BEGIN_DECLS
 
@@ -39,7 +39,7 @@ typedef struct _NaTrayAppletPrivate NaTrayAppletPrivate;
 
 struct _NaTrayApplet
 {
-  PanelApplet parent_object;
+  MatePanelApplet parent_object;
 
   /*< private >*/
   NaTrayAppletPrivate *priv;
@@ -47,7 +47,7 @@ struct _NaTrayApplet
 
 struct _NaTrayAppletClass
 {
-  PanelAppletClass parent_class;
+  MatePanelAppletClass parent_class;
 };
 
 GType na_tray_applet_get_type (void) G_GNUC_CONST;

--- a/applets/notification_area/na-tray-manager.c
+++ b/applets/notification_area/na-tray-manager.c
@@ -97,6 +97,25 @@ na_tray_manager_init (NaTrayManager *manager)
 {
   manager->invisible = NULL;
   manager->socket_table = g_hash_table_new (NULL, NULL);
+
+  manager->padding = 0;
+  manager->icon_size = 0;
+
+  manager->fg.red = 0;
+  manager->fg.green = 0;
+  manager->fg.blue = 0;
+
+  manager->error.red = 0xffff;
+  manager->error.green = 0;
+  manager->error.blue = 0;
+
+  manager->warning.red = 0xffff;
+  manager->warning.green = 0xffff;
+  manager->warning.blue = 0;
+
+  manager->success.red = 0;
+  manager->success.green = 0xffff;
+  manager->success.blue = 0;
 }
 
 static void
@@ -298,8 +317,8 @@ na_tray_manager_handle_dock_request (NaTrayManager       *manager,
   if (!gtk_socket_get_plug_window (GTK_SOCKET (child)))
     {
       /* Embedding failed, we won't get a plug-removed signal */
+      /* This signal destroys the socket */
       g_signal_emit (manager, manager_signals[TRAY_ICON_REMOVED], 0, child);
-      gtk_widget_destroy (child);
       return;
     }
 
@@ -413,8 +432,6 @@ na_tray_manager_handle_begin_message (NaTrayManager       *manager,
 	  break;
 	}
     }
-
-
 
   if (len == 0)
     {
@@ -631,11 +648,9 @@ na_tray_manager_set_orientation_property (NaTrayManager *manager)
   Atom        orientation_atom;
   gulong      data[1];
 
-  if (!manager->invisible)
-    return;
+  g_return_if_fail (manager->invisible != NULL);
   window = gtk_widget_get_window (manager->invisible);
-  if (!window)
-    return;
+  g_return_if_fail (window != NULL);
 
   display = gtk_widget_get_display (manager->invisible);
   orientation_atom = gdk_x11_get_xatom_by_name_for_display (display,
@@ -664,11 +679,9 @@ na_tray_manager_set_visual_property (NaTrayManager *manager)
   Atom        visual_atom;
   gulong      data[1];
 
-  if (!manager->invisible)
-    return;
+  g_return_if_fail (manager->invisible != NULL);
   window = gtk_widget_get_window (manager->invisible);
-  if (!window)
-    return;
+  g_return_if_fail (window != NULL);
 
   /* The visual property is a hint to the tray icons as to what visual they
    * should use for their windows. If the X server has RGBA colormaps, then
@@ -711,6 +724,101 @@ na_tray_manager_set_visual_property (NaTrayManager *manager)
                    XA_VISUALID, 32,
                    PropModeReplace,
                    (guchar *) &data, 1);
+#endif
+}
+
+static void
+na_tray_manager_set_padding_property (NaTrayManager *manager)
+{
+#ifdef GDK_WINDOWING_X11
+  GdkWindow  *window;
+  GdkDisplay *display;
+  Atom        atom;
+  gulong      data[1];
+
+  g_return_if_fail (manager->invisible != NULL);
+  window = gtk_widget_get_window (manager->invisible);
+  g_return_if_fail (window != NULL);
+
+  display = gtk_widget_get_display (manager->invisible);
+  atom = gdk_x11_get_xatom_by_name_for_display (display,
+                                                "_NET_SYSTEM_TRAY_PADDING");
+
+  data[0] = manager->padding;
+
+  XChangeProperty (GDK_DISPLAY_XDISPLAY (display),
+                   GDK_WINDOW_XID (window),
+                   atom,
+                   XA_CARDINAL, 32,
+                   PropModeReplace,
+                   (guchar *) &data, 1);
+#endif
+}
+
+static void
+na_tray_manager_set_icon_size_property (NaTrayManager *manager)
+{
+#ifdef GDK_WINDOWING_X11
+  GdkWindow  *window;
+  GdkDisplay *display;
+  Atom        atom;
+  gulong      data[1];
+
+  g_return_if_fail (manager->invisible != NULL);
+  window = gtk_widget_get_window (manager->invisible);
+  g_return_if_fail (window != NULL);
+
+  display = gtk_widget_get_display (manager->invisible);
+  atom = gdk_x11_get_xatom_by_name_for_display (display,
+                                                "_NET_SYSTEM_TRAY_ICON_SIZE");
+
+  data[0] = manager->icon_size;
+
+  XChangeProperty (GDK_DISPLAY_XDISPLAY (display),
+                   GDK_WINDOW_XID (window),
+                   atom,
+                   XA_CARDINAL, 32,
+                   PropModeReplace,
+                   (guchar *) &data, 1);
+#endif
+}
+
+static void
+na_tray_manager_set_colors_property (NaTrayManager *manager)
+{
+#ifdef GDK_WINDOWING_X11
+  GdkWindow  *window;
+  GdkDisplay *display;
+  Atom        atom;
+  gulong      data[12];
+
+  g_return_if_fail (manager->invisible != NULL);
+  window = gtk_widget_get_window (manager->invisible);
+  g_return_if_fail (window != NULL);
+
+  display = gtk_widget_get_display (manager->invisible);
+  atom = gdk_x11_get_xatom_by_name_for_display (display,
+                                                "_NET_SYSTEM_TRAY_COLORS");
+
+  data[0] = manager->fg.red;
+  data[1] = manager->fg.green;
+  data[2] = manager->fg.blue;
+  data[3] = manager->error.red;
+  data[4] = manager->error.green;
+  data[5] = manager->error.blue;
+  data[6] = manager->warning.red;
+  data[7] = manager->warning.green;
+  data[8] = manager->warning.blue;
+  data[9] = manager->success.red;
+  data[10] = manager->success.green;
+  data[11] = manager->success.blue;
+
+  XChangeProperty (GDK_DISPLAY_XDISPLAY (display),
+                   GDK_WINDOW_XID (window),
+                   atom,
+                   XA_CARDINAL, 32,
+                   PropModeReplace,
+                   (guchar *) &data, 12);
 #endif
 }
 
@@ -759,7 +867,10 @@ na_tray_manager_manage_screen_x11 (NaTrayManager *manager,
 
   na_tray_manager_set_orientation_property (manager);
   na_tray_manager_set_visual_property (manager);
-
+  na_tray_manager_set_padding_property (manager);
+  na_tray_manager_set_icon_size_property (manager);
+  na_tray_manager_set_colors_property (manager);
+  
   window = gtk_widget_get_window (invisible);
 
   timestamp = gdk_x11_get_server_time (window);
@@ -905,6 +1016,57 @@ na_tray_manager_set_orientation (NaTrayManager  *manager,
       na_tray_manager_set_orientation_property (manager);
 
       g_object_notify (G_OBJECT (manager), "orientation");
+    }
+}
+
+void
+na_tray_manager_set_padding (NaTrayManager *manager,
+                             gint           padding)
+{
+  g_return_if_fail (NA_IS_TRAY_MANAGER (manager));
+
+  if (manager->padding != padding)
+    {
+      manager->padding = padding;
+
+      na_tray_manager_set_padding_property (manager);
+    }
+}
+
+void
+na_tray_manager_set_icon_size (NaTrayManager *manager,
+                               gint           icon_size)
+{
+  g_return_if_fail (NA_IS_TRAY_MANAGER (manager));
+
+  if (manager->icon_size != icon_size)
+    {
+      manager->icon_size = icon_size;
+
+      na_tray_manager_set_icon_size_property (manager);
+    }
+}
+
+void
+na_tray_manager_set_colors (NaTrayManager *manager,
+                            GdkColor      *fg,
+                            GdkColor      *error,
+                            GdkColor      *warning,
+                            GdkColor      *success)
+{
+  g_return_if_fail (NA_IS_TRAY_MANAGER (manager));
+
+  if (!gdk_color_equal (&manager->fg, fg) ||
+      !gdk_color_equal (&manager->error, error) ||
+      !gdk_color_equal (&manager->warning, warning) ||
+      !gdk_color_equal (&manager->success, success))
+    {
+      manager->fg = *fg;
+      manager->error = *error;
+      manager->warning = *warning;
+      manager->success = *success;
+
+      na_tray_manager_set_colors_property (manager);
     }
 }
 

--- a/applets/notification_area/na-tray-manager.c
+++ b/applets/notification_area/na-tray-manager.c
@@ -870,7 +870,7 @@ na_tray_manager_manage_screen_x11 (NaTrayManager *manager,
   na_tray_manager_set_padding_property (manager);
   na_tray_manager_set_icon_size_property (manager);
   na_tray_manager_set_colors_property (manager);
-  
+
   window = gtk_widget_get_window (invisible);
 
   timestamp = gdk_x11_get_server_time (window);

--- a/applets/notification_area/na-tray-manager.h
+++ b/applets/notification_area/na-tray-manager.h
@@ -31,9 +31,7 @@
 
 #include "na-tray-child.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 #define NA_TYPE_TRAY_MANAGER			(na_tray_manager_get_type ())
 #define NA_TRAY_MANAGER(obj)			(G_TYPE_CHECK_INSTANCE_CAST ((obj), NA_TYPE_TRAY_MANAGER, NaTrayManager))
@@ -60,6 +58,12 @@ struct _NaTrayManager
   GtkWidget *invisible;
   GdkScreen *screen;
   GtkOrientation orientation;
+  gint padding;
+  gint icon_size;
+  GdkColor fg;
+  GdkColor error;
+  GdkColor warning;
+  GdkColor success;
 
   GList *messages;
   GHashTable *socket_table;
@@ -96,9 +100,17 @@ gboolean        na_tray_manager_manage_screen   (NaTrayManager      *manager,
 void            na_tray_manager_set_orientation (NaTrayManager      *manager,
 						 GtkOrientation      orientation);
 GtkOrientation  na_tray_manager_get_orientation (NaTrayManager      *manager);
+void            na_tray_manager_set_padding     (NaTrayManager      *manager,
+						 gint                padding);
+void            na_tray_manager_set_icon_size   (NaTrayManager      *manager,
+						 gint                padding);
+void            na_tray_manager_set_colors      (NaTrayManager      *manager,
+						 GdkColor           *fg,
+						 GdkColor           *error,
+						 GdkColor           *warning,
+						 GdkColor           *success);
 
-#ifdef __cplusplus
-}
-#endif
+
+G_END_DECLS
 
 #endif /* __NA_TRAY_MANAGER_H__ */

--- a/applets/notification_area/na-tray.c
+++ b/applets/notification_area/na-tray.c
@@ -240,6 +240,7 @@ tray_removed (NaTrayManager *manager,
     return;
 
   priv = tray->priv;
+
   g_assert (tray->priv->trays_screen == trays_screen);
 
   gtk_container_remove (GTK_CONTAINER (priv->box), icon);
@@ -872,6 +873,39 @@ idle_redraw_cb (NaTray *tray)
   priv->idle_redraw_id = 0;
 
   return FALSE;
+}
+
+void
+na_tray_set_padding (NaTray *tray,
+                     gint    padding)
+{
+  NaTrayPrivate *priv = tray->priv;
+
+  if (get_tray (priv->trays_screen) == tray)
+    na_tray_manager_set_padding (priv->trays_screen->tray_manager, padding);
+}
+
+void
+na_tray_set_icon_size (NaTray *tray,
+                       gint    size)
+{
+  NaTrayPrivate *priv = tray->priv;
+
+  if (get_tray (priv->trays_screen) == tray)
+    na_tray_manager_set_icon_size (priv->trays_screen->tray_manager, size);
+}
+
+void
+na_tray_set_colors (NaTray   *tray,
+                    GdkColor *fg,
+                    GdkColor *error,
+                    GdkColor *warning,
+                    GdkColor *success)
+{
+  NaTrayPrivate *priv = tray->priv;
+
+  if (get_tray (priv->trays_screen) == tray)
+    na_tray_manager_set_colors (priv->trays_screen->tray_manager, fg, error, warning, success);
 }
 
 void

--- a/applets/notification_area/na-tray.c
+++ b/applets/notification_area/na-tray.c
@@ -89,6 +89,27 @@ static TraysScreen *trays_screens = NULL;
 
 static void icon_tip_show_next (IconTip *icontip);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
+/* NaBox, an instantiable GtkBox */
+
+typedef GtkBox      NaBox;
+typedef GtkBoxClass NaBoxClass;
+
+static GType na_box_get_type (void);
+
+G_DEFINE_TYPE (NaBox, na_box, GTK_TYPE_BOX)
+
+static void
+na_box_init (NaBox *box)
+{
+}
+
+static void
+na_box_class_init (NaBoxClass *klass)
+{
+}
+#endif
+
 /* NaTray */
 
 G_DEFINE_TYPE (NaTray, na_tray, GTK_TYPE_BIN)

--- a/applets/notification_area/na-tray.c
+++ b/applets/notification_area/na-tray.c
@@ -89,27 +89,6 @@ static TraysScreen *trays_screens = NULL;
 
 static void icon_tip_show_next (IconTip *icontip);
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-/* NaBox, an instantiable GtkBox */
-
-typedef GtkBox      NaBox;
-typedef GtkBoxClass NaBoxClass;
-
-static GType na_box_get_type (void);
-
-G_DEFINE_TYPE (NaBox, na_box, GTK_TYPE_BOX)
-
-static void
-na_box_init (NaBox *box)
-{
-}
-
-static void
-na_box_class_init (NaBoxClass *klass)
-{
-}
-#endif
-
 /* NaTray */
 
 G_DEFINE_TYPE (NaTray, na_tray, GTK_TYPE_BIN)
@@ -545,7 +524,7 @@ na_tray_expose_icon (GtkWidget *widget,
 #endif
 		     gpointer   data)
 {
-  cairo_t *cr = data;
+  cairo_t *cr = (cairo_t *) data;
 
   if (na_tray_child_has_alpha (NA_TRAY_CHILD (widget)))
     {

--- a/applets/notification_area/na-tray.h
+++ b/applets/notification_area/na-tray.h
@@ -29,9 +29,7 @@
 #endif
 #include <gtk/gtk.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 #define NA_TYPE_TRAY			(na_tray_get_type ())
 #define NA_TRAY(obj)			(G_TYPE_CHECK_INSTANCE_CAST ((obj), NA_TYPE_TRAY, NaTray))
@@ -62,10 +60,17 @@ NaTray         *na_tray_new_for_screen  (GdkScreen     *screen,
 void            na_tray_set_orientation	(NaTray        *tray,
 					 GtkOrientation orientation);
 GtkOrientation  na_tray_get_orientation (NaTray        *tray);
+void            na_tray_set_padding     (NaTray        *tray,
+					 gint           padding);
+void            na_tray_set_icon_size   (NaTray        *tray,
+					 gint           icon_size);
+void            na_tray_set_colors      (NaTray        *tray,
+					 GdkColor      *fg,
+					 GdkColor      *error,
+					 GdkColor      *warning,
+					 GdkColor      *success);
 void		na_tray_force_redraw	(NaTray        *tray);
 
-#ifdef __cplusplus
-}
-#endif
+G_END_DECLS
 
 #endif /* __NA_TRAY_H__ */


### PR DESCRIPTION
Merge gnome-panel changes
Fix for https://github.com/mate-desktop/mate-panel/issues/189

Known issues: na-tray lost real transparency with gtk3