### PR TITLE
[1.8] fix logic a bit - avoid dereferencing NULL pointer

### DIFF
--- a/mate-panel/libpanel-util/panel-list.c
+++ b/mate-panel/libpanel-util/panel-list.c
@@ -166,7 +166,7 @@ panel_g_list_resort_item (GList        *list,
 
 	dl = g_list_find (list, data);
 
-	if (dl != NULL)
+	if (dl == NULL)
 		return list;
 
 	while (dl->next &&


### PR DESCRIPTION
backport of https://github.com/mate-desktop/mate-panel/pull/257 to 1.8 branch