### PR TITLE
Remove change_background_for_widget from GTK3 build (it is useless.)

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1653,111 +1653,42 @@ mate_panel_applet_set_background_string (MatePanelApplet *applet,
 	g_object_notify (G_OBJECT (applet), "background");
 }
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-static GtkStyleProperties *
-_mate_panel_applet_get_widget_style_properties (GtkWidget *widget, gboolean create_if_needed)
-{
-	GtkStyleProperties *properties;
-
-	properties = g_object_get_data (G_OBJECT (widget), "panel-applet-style-props");
-	if (!properties && create_if_needed) {
-		properties = gtk_style_properties_new ();
-		g_object_set_data_full (G_OBJECT (widget), "panel-applet-style-props",
-					properties, (GDestroyNotify) g_object_unref);
-	}
-	return properties;
-}
-
-static void
-_mate_panel_applet_reset_widget_style_properties (GtkWidget *widget)
-{
-	GtkStyleProperties *properties;
-
-	properties = _mate_panel_applet_get_widget_style_properties (widget, FALSE);
-
-	if (properties)
-		gtk_style_context_remove_provider (gtk_widget_get_style_context (widget),
-						   GTK_STYLE_PROVIDER (properties));
-
-	g_object_set_data (G_OBJECT (widget), "panel-applet-style-props", NULL);
-}
-#endif
-
+#if !GTK_CHECK_VERSION (3, 0, 0)
 static void
 mate_panel_applet_update_background_for_widget (GtkWidget                 *widget,
 					   MatePanelAppletBackgroundType  type,
-#if GTK_CHECK_VERSION (3, 0, 0)
-					   GdkRGBA                   *color,
-					   cairo_pattern_t           *pattern)
-#else
 					   GdkColor                  *color,
 					   GdkPixmap                 *pixmap)
-#endif
 {
-#if GTK_CHECK_VERSION (3, 0, 0)
-	GtkStyleProperties *properties;
-#else
 	GtkRcStyle *rc_style;
 	GtkStyle   *style;
-#endif
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-	gtk_widget_reset_style (widget);
-	if (!pattern) {
-		_mate_panel_applet_reset_widget_style_properties (widget);
-		return;
-	}
-	properties = _mate_panel_applet_get_widget_style_properties (widget, TRUE);
-#else
 	/* reset style */
 	gtk_widget_set_style (widget, NULL);
 	rc_style = gtk_rc_style_new ();
 	gtk_widget_modify_style (widget, rc_style);
 	g_object_unref (rc_style);
-#endif
 
 	switch (type) {
 	case PANEL_NO_BACKGROUND:
 		break;
 	case PANEL_COLOR_BACKGROUND:
-#if GTK_CHECK_VERSION (3, 0, 0)
-		gtk_style_properties_set (properties, GTK_STATE_FLAG_NORMAL,
-					  "background-color", &color,
-					  "background-image", NULL,
-					  NULL);
-#else
 		gtk_widget_modify_bg (widget, GTK_STATE_NORMAL, color);
-#endif
 		break;
 	case PANEL_PIXMAP_BACKGROUND:
-#if GTK_CHECK_VERSION (3, 0, 0)
-		gtk_style_properties_set (properties, GTK_STATE_FLAG_NORMAL,
-					  /* background-color can't be NULL,
-					   * but is ignored anyway */
-					  "background-image", pattern,
-					  NULL);
-#else
 		style = gtk_style_copy (gtk_widget_get_style (widget));
 		if (style->bg_pixmap[GTK_STATE_NORMAL])
 			g_object_unref (style->bg_pixmap[GTK_STATE_NORMAL]);
 		style->bg_pixmap[GTK_STATE_NORMAL] = g_object_ref (pixmap);
 		gtk_widget_set_style (widget, style);
 		g_object_unref (style);
-#endif
 		break;
 	default:
 		g_assert_not_reached ();
 		break;
 	}
-
-#if GTK_CHECK_VERSION (3, 0, 0)
-	/* Note: this actually replaces the old properties, since it's the same
-	 * pointer */
-	gtk_style_context_add_provider (gtk_widget_get_style_context (widget),
-					GTK_STYLE_PROVIDER (properties),
-					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-#endif
 }
+#endif
 
 static void
 mate_panel_applet_handle_background (MatePanelApplet *applet)
@@ -1768,15 +1699,6 @@ mate_panel_applet_handle_background (MatePanelApplet *applet)
 	cairo_pattern_t           *pattern;
 
 	type = mate_panel_applet_get_background (applet, &color, &pattern);
-
-
-	if (applet->priv->background_widget)
-	{
-		mate_panel_applet_update_background_for_widget (applet->priv->background_widget,
-							   type, &color, pattern);
-		_mate_panel_applet_apply_css(applet->priv->background_widget,type);
-	}
-
 #else
 	GdkColor                   color;
 	GdkPixmap                 *pixmap;
@@ -2609,8 +2531,6 @@ mate_panel_applet_set_background_widget (MatePanelApplet *applet,
 		GdkRGBA                    color;
 		cairo_pattern_t           *pattern;
 		type = mate_panel_applet_get_background (applet, &color, &pattern);
-		mate_panel_applet_update_background_for_widget (widget, type,
-							   &color, pattern);
 		_mate_panel_applet_apply_css(widget,type);
 
 		if (type == PANEL_PIXMAP_BACKGROUND)

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -1494,83 +1494,11 @@ panel_background_set_color_background_on_widget (PanelBackground *background,
 
 	gtk_widget_modify_bg (widget, GTK_STATE_NORMAL, &color->gdk);
 }
-#endif
-
-#if GTK_CHECK_VERSION (3, 0, 0)
-static GtkStyleProperties *
-_panel_background_get_widget_style_properties (GtkWidget *widget, gboolean create_if_needed)
-{
-	GtkStyleProperties *properties;
-
-	properties = g_object_get_data (G_OBJECT (widget), "panel-object-style-props");
-	if (!properties && create_if_needed) {
-		properties = gtk_style_properties_new ();
-		g_object_set_data_full (G_OBJECT (widget), "panel-object-style-props",
-					properties, (GDestroyNotify) g_object_unref);
-	}
-	return properties;
-}
-
-static void
-_panel_background_reset_widget_style_properties (GtkWidget *widget)
-{
-	GtkStyleProperties *properties;
-
-	properties = _panel_background_get_widget_style_properties (widget, FALSE);
-
-	if (properties)
-		gtk_style_context_remove_provider (gtk_widget_get_style_context (widget),
-						   GTK_STYLE_PROVIDER (properties));
-
-	g_object_set_data (G_OBJECT (widget), "panel-object-style-props", NULL);
-}
-#endif
 
 void
 panel_background_change_background_on_widget (PanelBackground *background,
 					      GtkWidget       *widget)
 {
-#if GTK_CHECK_VERSION (3, 0, 0)
-	GtkStyleProperties *properties;
-
-	gtk_widget_reset_style (widget);
-
-	switch (panel_background_get_type (background)) {
-	case PANEL_BACK_NONE:
-		_panel_background_reset_widget_style_properties (widget);
-		return;
-	case PANEL_BACK_COLOR:
-			properties = _panel_background_get_widget_style_properties (widget, TRUE);
-			gtk_style_properties_set (properties, GTK_STATE_FLAG_NORMAL,
-						  "background-color", &background->color,
-						  "background-image", NULL,
-						  NULL);
-		break;
-	case PANEL_BACK_IMAGE: {
-		cairo_pattern_t *pattern;
-
-		properties = _panel_background_get_widget_style_properties (widget, TRUE);
-		pattern = panel_background_get_pattern_for_widget (background, widget);
-		if (pattern) {
-			gtk_style_properties_set (properties, GTK_STATE_FLAG_NORMAL,
-						  "background-image", pattern,
-						  NULL);
-			cairo_pattern_destroy (pattern);
-		} else {
-			_panel_background_reset_widget_style_properties (widget);
-			return;
-		}
-	}
-		break;
-	default:
-		g_assert_not_reached ();
-		break;
-	}
-
-	gtk_style_context_add_provider (gtk_widget_get_style_context (widget),
-					GTK_STYLE_PROVIDER (properties),
-					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-#else
 	PanelBackgroundType type;
 
 	panel_background_set_no_background_on_widget (background, widget);
@@ -1592,6 +1520,6 @@ panel_background_change_background_on_widget (PanelBackground *background,
 		g_assert_not_reached ();
 		break;
 	}
-#endif
 }
+#endif
 

--- a/mate-panel/panel-background.h
+++ b/mate-panel/panel-background.h
@@ -158,10 +158,11 @@ const GdkPixmap     *panel_background_get_pixmap (PanelBackground *background);
 PanelBackgroundType
       panel_background_effective_type    (PanelBackground     *background);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 void panel_background_change_background_on_widget (PanelBackground *background,
 						   GtkWidget       *widget);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
+#else
 void panel_background_apply_css(GtkWidget* widget);
 #endif
 


### PR DESCRIPTION
Working with style properties is useless, because GTK have only stubs here. 
GTK3 Background logic already in panel_background_prepare.