### PR TITLE
[1.8] notification area: prevent crash

### DIFF
--- a/applets/notification_area/na-tray-manager.c
+++ b/applets/notification_area/na-tray-manager.c
@@ -303,8 +303,8 @@ na_tray_manager_handle_dock_request (NaTrayManager       *manager,
   if (!gtk_socket_get_plug_window (GTK_SOCKET (child)))
     {
       /* Embedding failed, we won't get a plug-removed signal */
+      /* This signal destroys the socket */
       g_signal_emit (manager, manager_signals[TRAY_ICON_REMOVED], 0, child);
-      gtk_widget_destroy (child);
       return;
     }
 


### PR DESCRIPTION
from upstream commit:
https://git.gnome.org/browse/gnome-panel/commit/applets/notification_area/na-tray-manager.c?id=2adbcc5308577d864b09062a3343b9f8dbcdcd7f