### PR TITLE
Fixing  Window List - stretched buttons on vertical orientation #269

### DIFF
--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -122,7 +122,11 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 
 	tasklist->orientation = new_orient;
 
-	wnck_tasklist_set_orientation (WNCK_TASKLIST (tasklist->tasklist), new_orient);
+#ifdef WNCK_CHECK_VERSION
+#if WNCK_CHECK_VERSION (3, 4, 6)
+	wnck_tasklist_set_orientation (tasklist->tasklist, new_orient);
+#endif
+#endif
 	tasklist_update(tasklist);
 }
 
@@ -444,8 +448,12 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 	tasklist->tasklist = wnck_tasklist_new(NULL);
 #endif
 
+#ifdef WNCK_CHECK_VERSION
+#if WNCK_CHECK_VERSION (3, 4, 6)
 	wnck_tasklist_set_orientation (WNCK_TASKLIST (tasklist->tasklist), tasklist->orientation);
 	wnck_tasklist_set_middle_click_close (WNCK_TASKLIST (tasklist->tasklist), TRUE);
+#endif
+#endif
 
 	wnck_tasklist_set_icon_loader(WNCK_TASKLIST(tasklist->tasklist), icon_loader_func, tasklist, NULL);
 

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -122,11 +122,7 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 
 	tasklist->orientation = new_orient;
 
-#ifdef WNCK_CHECK_VERSION
-#if WNCK_CHECK_VERSION (3, 4, 6)
-	wnck_tasklist_set_orientation (tasklist->tasklist, new_orient);
-#endif
-#endif
+	wnck_tasklist_set_orientation (WNCK_TASKLIST (tasklist->tasklist), new_orient);
 	tasklist_update(tasklist);
 }
 
@@ -450,11 +446,11 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 
 #ifdef WNCK_CHECK_VERSION
 #if WNCK_CHECK_VERSION (3, 4, 6)
-	wnck_tasklist_set_orientation (WNCK_TASKLIST (tasklist->tasklist), tasklist->orientation);
 	wnck_tasklist_set_middle_click_close (WNCK_TASKLIST (tasklist->tasklist), TRUE);
 #endif
 #endif
 
+	wnck_tasklist_set_orientation (WNCK_TASKLIST (tasklist->tasklist), tasklist->orientation);
 	wnck_tasklist_set_icon_loader(WNCK_TASKLIST(tasklist->tasklist), icon_loader_func, tasklist, NULL);
 
 	g_signal_connect(G_OBJECT(tasklist->tasklist), "destroy", G_CALLBACK(destroy_tasklist), tasklist);

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -122,11 +122,7 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 
 	tasklist->orientation = new_orient;
 
-#ifdef WNCK_CHECK_VERSION
-#if WNCK_CHECK_VERSION (3, 4, 6)
-	wnck_tasklist_set_orientation (tasklist->tasklist, new_orient);
-#endif
-#endif
+	wnck_tasklist_set_orientation (WNCK_TASKLIST (tasklist->tasklist), new_orient);
 	tasklist_update(tasklist);
 }
 
@@ -448,12 +444,8 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 	tasklist->tasklist = wnck_tasklist_new(NULL);
 #endif
 
-#ifdef WNCK_CHECK_VERSION
-#if WNCK_CHECK_VERSION (3, 4, 6)
 	wnck_tasklist_set_orientation (WNCK_TASKLIST (tasklist->tasklist), tasklist->orientation);
 	wnck_tasklist_set_middle_click_close (WNCK_TASKLIST (tasklist->tasklist), TRUE);
-#endif
-#endif
 
 	wnck_tasklist_set_icon_loader(WNCK_TASKLIST(tasklist->tasklist), icon_loader_func, tasklist, NULL);
 


### PR DESCRIPTION
Hi,
This is fixing the bug #269.  I am wondering if it is OK to remove the `ifdef WNCK_CHECK_VERSION`. I did a grep for `WNCK_CHECK_VERSION` and didn't find it defined on my system.

The fix was tested on linux mint 17 and on debian 8. 

Thanks,
Mihai