### PR TITLE
remove link to system-admin-guide

### DIFF
--- a/help/mate-panel/C/goseditmainmenu.xml
+++ b/help/mate-panel/C/goseditmainmenu.xml
@@ -115,6 +115,5 @@
     <para>The <guilabel>Menu Layout</guilabel> window lists the menus in the left pane. Click on the expander arrows to show or hide submenus. Choose a menu in the left pane to see its items listed in the right pane.</para>
     <para>To remove an item from a menu, deselect it in the list. The item can be added back to the menu by selecting it once again.</para>
 
-    <note><para>The <ulink type="help" url="help:system-admin-guide?menustructure-0">System Administration Guide</ulink> has more information on how MATE implements menus and how administrators can customize them.</para></note>
   </section>
 </chapter>


### PR DESCRIPTION
- this is part of gnome and named as mate guide which is confusing