### PR TITLE
replace panel_xutils_set_window_type with gtk_window_set_type_hint

### DIFF
--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -3044,6 +3044,7 @@ panel_toplevel_realize (GtkWidget *widget)
 
 	gtk_window_set_decorated (GTK_WINDOW (widget), FALSE);
 	gtk_window_stick (GTK_WINDOW (widget));
+	gtk_window_set_type_hint (GTK_WINDOW (widget), GDK_WINDOW_TYPE_HINT_DOCK);
 
 	if (GTK_WIDGET_CLASS (panel_toplevel_parent_class)->realize)
 		GTK_WIDGET_CLASS (panel_toplevel_parent_class)->realize (widget);
@@ -3051,7 +3052,6 @@ panel_toplevel_realize (GtkWidget *widget)
 	window = gtk_widget_get_window (widget);
 
 	panel_struts_set_window_hint (toplevel);
-	panel_xutils_set_window_type (window, PANEL_XUTILS_TYPE_DOCK);
 
 	gdk_window_set_group (window, window);
 	gdk_window_set_geometry_hints (window, NULL, GDK_HINT_POS);

--- a/mate-panel/panel-xutils.c
+++ b/mate-panel/panel-xutils.c
@@ -39,56 +39,6 @@ static Atom net_wm_window_type_normal = None;
 static Atom net_wm_strut              = None;
 static Atom net_wm_strut_partial      = None;
 
-void
-panel_xutils_set_window_type (GdkWindow             *gdk_window,	
-			      PanelXUtilsWindowType  type)
-{
-	Display *display;
-	Window   window;
-	Atom     atoms [2];
-	int      i = 0;
-
-	g_return_if_fail (GDK_IS_WINDOW (gdk_window));
-
-	display = GDK_WINDOW_XDISPLAY (gdk_window);
-	window = GDK_WINDOW_XID (gdk_window);
-
-	if (net_wm_window_type == None)
-		net_wm_window_type = XInternAtom (display,
-						  "_NET_WM_WINDOW_TYPE",
-						  False);
-
-	switch (type) {
-	case PANEL_XUTILS_TYPE_DOCK:
-		if (net_wm_window_type_dock == None)
-			net_wm_window_type_dock = XInternAtom (display,
-							       "_NET_WM_WINDOW_TYPE_DOCK",
-							       False);
-		atoms [i++] = net_wm_window_type_dock;
-		break;
-	case PANEL_XUTILS_TYPE_NORMAL:
-		if (net_wm_window_type_normal == None)
-			net_wm_window_type_normal = XInternAtom (display,
-								 "_NET_WM_WINDOW_TYPE_NORMAL",
-								 False);
-		atoms [i++] = net_wm_window_type_normal;
-		break;
-	default:
-		g_assert_not_reached ();
-		break;
-	}
-
-	gdk_error_trap_push ();
-	XChangeProperty (display, window, net_wm_window_type,
-			 XA_ATOM, 32, PropModeReplace,
-			 (guchar *) &atoms, i);
-#if GTK_CHECK_VERSION (3, 0, 0)
-	gdk_error_trap_pop_ignored ();
-#else
-	gdk_error_trap_pop ();
-#endif
-}
-
 enum {
 	STRUT_LEFT = 0,
 	STRUT_RIGHT = 1,

--- a/mate-panel/panel-xutils.h
+++ b/mate-panel/panel-xutils.h
@@ -37,14 +37,6 @@
 extern "C" {
 #endif
 
-typedef enum {
-	PANEL_XUTILS_TYPE_NORMAL,
-	PANEL_XUTILS_TYPE_DOCK
-} PanelXUtilsWindowType;
-
-void panel_xutils_set_window_type (GdkWindow             *gdk_window,
-				   PanelXUtilsWindowType  type);
-
 void panel_xutils_set_strut       (GdkWindow             *gdk_window,
 				   PanelOrientation       orientation,
 				   guint32                strut,


### PR DESCRIPTION
Both functions have exactly the same semantics, so prefer the Gtk+ builtin. That's one function less to worry about Gtk+2 vs 3 compatibility (or Wayland).

In addition, this also fixes issue #280.