### PR TITLE
Fix missing gettext setup for panel applet common parts

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -2005,6 +2005,7 @@ mate_panel_applet_init (MatePanelApplet *applet)
 	applet->priv->size   = 24;
 
 	applet->priv->panel_action_group = gtk_action_group_new ("PanelActions");
+	_MATE_PANEL_APPLET_SETUP_GETTEXT(FALSE);
 	gtk_action_group_set_translation_domain (applet->priv->panel_action_group, GETTEXT_PACKAGE);
 	gtk_action_group_add_actions (applet->priv->panel_action_group,
 				      menu_entries,


### PR DESCRIPTION
This is required for following situations:
1. MATELOCALEDIR is not a default location
2. applet's textdomain is not "mate-panel"
