### PR TITLE
eliminate criticals

### DIFF
--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -654,6 +654,11 @@ button_widget_get_preferred_width (GtkWidget *widget,
 {
 	ButtonWidget *button_widget = BUTTON_WIDGET (widget);
 
+	if (button_widget->priv->pixbuf == NULL ) {
+		*minimal_width = *natural_width = 1;
+		return;
+	}
+
 	*minimal_width = *natural_width = gdk_pixbuf_get_width  (button_widget->priv->pixbuf);
 }
 
@@ -663,6 +668,11 @@ button_widget_get_preferred_height (GtkWidget *widget,
 				    gint *natural_height)
 {
 	ButtonWidget *button_widget = BUTTON_WIDGET (widget);
+
+	if (button_widget->priv->pixbuf == NULL ) {
+		*minimal_height = *natural_height = 1;
+		return;
+	}
 
 	*minimal_height = *natural_height = gdk_pixbuf_get_height (button_widget->priv->pixbuf);
 }

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -3095,7 +3095,7 @@ panel_toplevel_realize (GtkWidget *widget)
 	panel_struts_set_window_hint (toplevel);
 
 	gdk_window_set_group (window, window);
-	gdk_window_set_geometry_hints (window, NULL, GDK_HINT_POS);
+	gdk_window_set_geometry_hints (window, NULL, 0);
 
 	panel_toplevel_initially_hide (toplevel);
 


### PR DESCRIPTION
gdk_window_set_geometry_hints accept 0 as flags when geometry is null
return 1px width/height while image is not loadded