### PR TITLE
Make MAX_ITEMS_OR_SUBMENU configurable.

### DIFF
--- a/data/org.mate.panel.menubar.gschema.xml.in
+++ b/data/org.mate.panel.menubar.gschema.xml.in
@@ -45,5 +45,10 @@
       <summary>Menu items icon size</summary>
       <description>Set the size of icons used in the menu. The panel must be restarted for this to take effect.</description>
     </key>
+    <key name="max-items-or-submenu" type="i">
+      <default>8</default>
+      <summary>Threshold of menu items before submenu is created</summary>
+      <description>Maximum number of menu items (i.e. bookmarks) that are displayed without being put in a submenu.</description>
+    </key>
   </schema>
 </schemalist>

--- a/mate-panel/panel-schemas.h
+++ b/mate-panel/panel-schemas.h
@@ -65,6 +65,7 @@
 #define PANEL_MENU_BAR_SHOW_DESKTOP_KEY       "show-desktop"
 #define PANEL_MENU_BAR_SHOW_ICON_KEY          "show-icon"
 #define PANEL_MENU_BAR_ICON_NAME_KEY          "icon-name"
+#define PANEL_MENU_BAR_MAX_ITEMS_OR_SUBMENU   "max-items-or-submenu"
 
 /* external schemas */
 


### PR DESCRIPTION
Hi everyone!

It annoyed me for some time that I could only have 8 bookmarks in the places menu before a submenu was created, even though my screen resolution would allow for quite a few more...
Upon investigating, I could only find this: http://ubuntuforums.org/showthread.php?t=1066964
I was thinking "This should really be a setting in dconf or something". Some tinkering later, I got it working and here it is! ;)

Please review. I'm sure I made some stupid rookie mistake or two.
For example the new gschema.xml; I had to manually copy it to /usr/share/glib-2.0/schemas and run glib-compile-schemas after make install. What's the right way to fix that?
Do I need to check the GSettings pointer for NULL before using g_settings_get_int() ?
If the schema does not exist, the pointer is NULL and I think get_int() returns 0 or something negative, so you get a submenu even for a single bookmark. It does not crash or anything, so do I need to handle this case?

Thanks guys!