### PR TITLE
clock applet: fix ubuntu ambiant-mate gtk2 theming

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -877,12 +877,12 @@ create_calendar (ClockData *cd)
 			  G_CALLBACK (delete_event), cd->panel_button);
 	g_signal_connect (window, "key_press_event",
 			  G_CALLBACK (close_on_escape), cd->panel_button);
-			  
+
+#if GTK_CHECK_VERSION (3, 0, 0)
         /*Name this window so the default theme can be overridden in panel theme,
         otherwise default GtkWindow bg will be pulled in and override transparency */ 
         gtk_widget_set_name(window, "MatePanelPopupWindow");
 
-#if GTK_CHECK_VERSION (3, 0, 0)
         /* Make transparency possible in the theme */              
         GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(window));
         GdkVisual *visual = gdk_screen_get_rgba_visual(screen);


### PR DESCRIPTION
this fixes https://github.com/mate-desktop/mate-panel/commit/c71b55007d73485bfc3fc1d30c42cb329bc30125