### PR TITLE
don't destroy a widget in its draw/expose signal

### DIFF
--- a/mate-panel/xstuff.c
+++ b/mate-panel/xstuff.c
@@ -310,6 +310,14 @@ zoom_timeout (GtkWidget *window)
 }
 
 static gboolean
+idle_destroy (gpointer data)
+{
+	gtk_widget_destroy (GTK_WIDGET (data));
+
+	return FALSE;
+}
+
+static gboolean
 #if GTK_CHECK_VERSION (3, 0, 0)
 zoom_draw (GtkWidget *widget,
 	     cairo_t *cr,
@@ -328,12 +336,13 @@ zoom_expose (GtkWidget      *widget,
 			g_source_remove (zoom->timeout_id);
 		zoom->timeout_id = 0;
 
+		gtk_widget_hide (widget);
+		g_idle_add (idle_destroy, widget);
+
 		g_object_unref (zoom->pixbuf);
 		zoom->pixbuf = NULL;
 
 		g_slice_free (CompositedZoomData, zoom);
-
-		gtk_widget_destroy (widget);
 	} else {
 		GdkPixbuf *scaled;
 		int width, height;


### PR DESCRIPTION
ported from:
https://git.gnome.org/browse/gnome-panel/commit/?id=8c275a2adf4ad99297a17cabf251344837620831
https://git.gnome.org/browse/gnome-panel/commit/?id=be33e799d968a073c0a8856c96d11e8594b88bc4