### PR TITLE
Don't set the panel transparent by default

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1979,33 +1979,39 @@ mate_panel_applet_setup (MatePanelApplet *applet)
 void _mate_panel_applet_apply_css(GtkWidget* widget, MatePanelAppletBackgroundType type)
 {
 	GtkStyleContext* context;
-	GtkCssProvider  *provider;
 
 	context = gtk_widget_get_style_context (widget);
-	gtk_widget_reset_style(widget);
+	gtk_widget_reset_style (widget);
 
 	switch (type) {
 	case PANEL_NO_BACKGROUND:
-		gtk_style_context_remove_class(context,"mate-custom-panel-background");
+		gtk_style_context_remove_class (context, "mate-custom-panel-background");
 		break;
 	case PANEL_COLOR_BACKGROUND:
 	case PANEL_PIXMAP_BACKGROUND:
-		provider = gtk_css_provider_new ();
-		gtk_css_provider_load_from_data (provider,
-						".mate-custom-panel-background{\n"
-						" background-color: rgba (0, 0, 0, 0);\n"
-						" background-image: none;\n"
-						"}",
-						-1, NULL);
 		gtk_style_context_add_class (context, "mate-custom-panel-background");
-		gtk_style_context_add_provider (context,
-						GTK_STYLE_PROVIDER (provider),
-						GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 		break;
 	default:
 		g_assert_not_reached ();
 		break;
 	}
+}
+
+void _mate_panel_applet_prepare_css (GtkStyleContext *context)
+{
+	GtkCssProvider  *provider;
+
+	provider = gtk_css_provider_new ();
+	gtk_css_provider_load_from_data (provider,
+					 ".mate-custom-panel-background{\n"
+					 " background-color: rgba (0, 0, 0, 0);\n"
+					 " background-image: none;\n"
+					 "}",
+					 -1, NULL);
+	gtk_style_context_add_provider (context,
+					GTK_STYLE_PROVIDER (provider),
+					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+	g_object_unref (provider);
 }
 #endif
 
@@ -2045,10 +2051,10 @@ mate_panel_applet_init (MatePanelApplet *applet)
 	gtk_widget_set_visual(GTK_WIDGET(applet->priv->plug), visual);
 	GtkStyleContext *context;
 	context = gtk_widget_get_style_context (GTK_WIDGET(applet->priv->plug));
-	gtk_style_context_remove_class (context,GTK_STYLE_CLASS_BACKGROUND);
 	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
 	gtk_style_context_add_class(context,"mate-panel-menu-bar");
 	gtk_widget_set_name(GTK_WIDGET(applet->priv->plug), "PanelPlug");
+	_mate_panel_applet_prepare_css(context);
 #endif
 	g_signal_connect_swapped (G_OBJECT (applet->priv->plug), "embedded",
 				  G_CALLBACK (mate_panel_applet_setup),

--- a/mate-panel/mate-panel-applet-frame.c
+++ b/mate-panel/mate-panel-applet-frame.c
@@ -640,15 +640,17 @@ mate_panel_applet_frame_change_background (MatePanelAppletFrame    *frame,
 
 	g_return_if_fail (PANEL_IS_WIDGET (parent));
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
 	if (frame->priv->has_handle) {
 		PanelBackground *background;
 
 		background = &PANEL_WIDGET (parent)->background;
+#if GTK_CHECK_VERSION (3, 0, 0)
+		panel_background_apply_css (GTK_WIDGET (frame), background);
+#else
 		panel_background_change_background_on_widget (background,
 							      GTK_WIDGET (frame));
-	}
 #endif
+	}
 
 	MATE_PANEL_APPLET_FRAME_GET_CLASS (frame)->change_background (frame, type);
 }

--- a/mate-panel/panel-background.h
+++ b/mate-panel/panel-background.h
@@ -163,7 +163,7 @@ void panel_background_change_background_on_widget (PanelBackground *background,
 						   GtkWidget       *widget);
 
 #else
-void panel_background_apply_css(GtkWidget* widget);
+void panel_background_apply_css(GtkWidget* widget, PanelBackground *background);
 #endif
 
 #endif /* __PANEL_BACKGROUND_H__ */

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -479,7 +479,7 @@ void panel_menu_bar_popup_menu(PanelMenuBar* menubar, guint32 activate_time)
 void panel_menu_bar_change_background(PanelMenuBar* menubar)
 {
 #if GTK_CHECK_VERSION (3, 0, 0)
-	panel_background_apply_css(GTK_WIDGET(menubar));
+	panel_background_apply_css(GTK_WIDGET(menubar), &menubar->priv->panel->background);
 #else
 	panel_background_change_background_on_widget(&menubar->priv->panel->background, GTK_WIDGET(menubar));
 #endif

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -350,7 +350,7 @@ void
 panel_separator_change_background (PanelSeparator *separator)
 {
 #if GTK_CHECK_VERSION (3, 0, 0)
-	panel_background_apply_css(GTK_WIDGET(separator));
+	panel_background_apply_css(GTK_WIDGET(separator), &separator->priv->panel->background);
 #else
 	panel_background_change_background_on_widget(&separator->priv->panel->background, GTK_WIDGET(separator));
 #endif

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1657,6 +1657,7 @@ panel_widget_style_set (GtkWidget *widget, GtkStyle  *previous_style)
 		state = gtk_widget_get_state_flags (widget);
 		gtk_style_context_add_class(context,"gnome-panel-menu-bar");
 		gtk_style_context_add_class(context,"mate-panel-menu-bar");
+		panel_background_apply_css (widget, &PANEL_WIDGET (widget)->background);
 
 		gtk_style_context_get_background_color (context, state, &bg_color);
 		gtk_style_context_get (context, state, "background-image", &bg_image, NULL);


### PR DESCRIPTION
This fixes the background for GTK+ 3 themes which don't support mate-panel explicitly. Themes could still overwrite the background if they want in the usual way.

To get back exactly the previous state, you can add the following lines to your themes:
Before other declarations: `.mate-panel-menu-bar {background: transparent;} `
After other declarations (these background settings were ignored previously): `PanelToplevel, PanelMenuBar, PanelSeparator {background: transparent;} `