### PR TITLE
gtk3: fix infinite loop with Traditional themes

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1981,7 +1981,6 @@ void _mate_panel_applet_apply_css(GtkWidget* widget, MatePanelAppletBackgroundTy
 	GtkStyleContext* context;
 
 	context = gtk_widget_get_style_context (widget);
-	gtk_widget_reset_style (widget);
 
 	switch (type) {
 	case PANEL_NO_BACKGROUND:

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -104,7 +104,6 @@ void panel_background_apply_css (GtkWidget* widget, PanelBackground *background)
 
 	context = gtk_widget_get_style_context (widget);
 	effective_type = panel_background_effective_type (background);
-	gtk_widget_reset_style (widget);
 
 	switch (effective_type) {
 	case PANEL_BACK_NONE:


### PR DESCRIPTION
We don't need to reset style when adding/removing classes. It was a regression in commit 6f634c680fbc5ee5051253554f2710e39f9ea80a