### PR TITLE
applets/clock: add missing pkgconfig flags for NetworkManager

### DIFF
--- a/applets/clock/Makefile.am
+++ b/applets/clock/Makefile.am
@@ -39,6 +39,7 @@ CLOCK_CPPFLAGS =						\
 	$(AM_CPPFLAGS)						\
 	$(LIBMATE_PANEL_APPLET_CFLAGS)				\
 	$(CLOCK_CFLAGS)						\
+	$(NETWORK_MANAGER_CFLAGS)				\
 	-I$(srcdir)/../../libmate-panel-applet			\
 	-I$(top_builddir)/libmate-panel-applet			\
 	-DMATELOCALEDIR=\""$(prefix)/$(DATADIRNAME)/locale"\"	\
@@ -51,6 +52,7 @@ CLOCK_LDADD =						\
 	../../libmate-panel-applet/libmate-panel-applet-4.la	\
 	$(CLOCK_LIBS)					\
 	$(LIBMATE_PANEL_APPLET_LIBS)				\
+	$(NETWORK_MANAGER_LIBS)					\
 	libsystem-timezone.la				\
 	-lm
 

--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,8 @@ else
 fi
 if test "x$HAVE_NETWORK_MANAGER" = "xyes" ; then
     AC_DEFINE(HAVE_NETWORK_MANAGER, 1, [Defined if NetworkManager support is enabled])
+    AC_SUBST(NETWORK_MANAGER_CFLAGS)
+    AC_SUBST(NETWORK_MANAGER_LIBS)
 fi
 
 # Make it possible to compile the applets in-process


### PR DESCRIPTION
mate-panel-1.8 fails to compile with NetworkManager >=1.0.8 due to a
missing include directive ('-I'). Substitute network manager CFLAGS
and LIBS supplied by the pkgconfig macro in configure.ac and use it
for applets/clock.

Signed-off-by: Gokturk Yuksek <gokturk@binghamton.edu>