### PR TITLE
GSettings key for icon sizes, change default menubar icon size to 22px + some fixes

### DIFF
--- a/applets/clock/clock-location.c
+++ b/applets/clock/clock-location.c
@@ -66,7 +66,7 @@ static guint location_signals[LAST_SIGNAL] = { 0 };
 static void clock_location_finalize (GObject *);
 static void clock_location_set_tz (ClockLocation *this);
 static void clock_location_unset_tz (ClockLocation *this);
-static gboolean update_weather_info (ClockLocation *loc);
+static gboolean update_weather_info (gpointer data);
 static void setup_weather_updates (ClockLocation *loc);
 
 static gchar *clock_location_get_valid_weather_code (const gchar *code);
@@ -680,8 +680,9 @@ weather_info_updated (WeatherInfo *info, gpointer data)
 }
 
 static gboolean
-update_weather_info (ClockLocation *loc)
+update_weather_info (gpointer data)
 {
+	ClockLocation *loc = (ClockLocation *) data;
 	ClockLocationPrivate *priv = PRIVATE (loc);
 	WeatherPrefs prefs = {
 		FORECAST_STATE,

--- a/applets/clock/system-timezone.c
+++ b/applets/clock/system-timezone.c
@@ -877,7 +877,6 @@ system_timezone_is_zone_file_valid (const char  *zone_file,
 {
         GError     *our_error;
         GIOChannel *channel;
-        GIOStatus   status;
         char        buffer[strlen (TZ_MAGIC)];
         gsize       read;
 
@@ -904,9 +903,9 @@ system_timezone_is_zone_file_valid (const char  *zone_file,
         our_error = NULL;
         channel = g_io_channel_new_file (zone_file, "r", &our_error);
         if (!our_error)
-                status = g_io_channel_read_chars (channel,
-                                                  buffer, strlen (TZ_MAGIC),
-                                                  &read, &our_error);
+                g_io_channel_read_chars (channel,
+                                         buffer, strlen (TZ_MAGIC),
+                                         &read, &our_error);
         if (channel)
                 g_io_channel_unref (channel);
 

--- a/data/org.mate.panel.menubar.gschema.xml.in
+++ b/data/org.mate.panel.menubar.gschema.xml.in
@@ -1,4 +1,14 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
+
+  <enum id="org.mate.panel.menubar.icon-size">
+    <value nick="default" value="-1"/>
+    <value nick="16px" value="16"/>
+    <value nick="22px" value="22"/>
+    <value nick="24px" value="24"/>
+    <value nick="32px" value="32"/>
+    <value nick="48px" value="48"/>
+  </enum>
+
   <schema id="org.mate.panel.menubar" path="/org/mate/panel/menubar/">
     <key name="show-applications" type="b">
       <default>true</default>
@@ -24,6 +34,16 @@
       <default>'start-here'</default>
       <summary>Icon to show in menu bar</summary>
       <description>Set the theme icon name to use in menu bar.</description>
+    </key>
+    <key name="icon-size" enum="org.mate.panel.menubar.icon-size">
+      <default>'default'</default>
+      <summary>Menu bar icon size</summary>
+      <description>Set the size of an icon used in menu bar. The panel must be restarted for this to take effect.</description>
+    </key>
+    <key name="item-icon-size" enum="org.mate.panel.menubar.icon-size">
+      <default>'default'</default>
+      <summary>Menu items icon size</summary>
+      <description>Set the size of icons used in the menu. The panel must be restarted for this to take effect.</description>
     </key>
   </schema>
 </schemalist>

--- a/mate-panel/menu.h
+++ b/mate-panel/menu.h
@@ -36,12 +36,11 @@ void		setup_menuitem		  (GtkWidget        *menuitem,
 					   GtkIconSize       icon_size,
 					   GtkWidget        *pixmap,
 					   const char       *title);
-void            setup_menu_item_with_icon (GtkWidget        *item,
-					   GtkIconSize       icon_size,
-					   const char       *icon_name,
-					   const char       *stock_id,
-					   GIcon            *gicon,
-					   const char       *title);
+void            setup_menuitem_with_icon (GtkWidget         *menuitem,
+					  GtkIconSize       icon_size,
+					  GIcon             *gicon,
+					  const char        *image_filename,
+					  const char        *title);
 
 GtkWidget      *create_empty_menu         (void);
 GtkWidget      *create_applications_menu  (const char  *menu_file,

--- a/mate-panel/panel-layout.c
+++ b/mate-panel/panel-layout.c
@@ -125,7 +125,7 @@ panel_layout_append_group_helper (GKeyFile                  *keyfile,
                                   const char                *type_for_error_message)
 {
     gboolean    retval = FALSE;
-    char       *id;
+    const char *id;
     char       *unique_id = NULL;
     char       *path = NULL;
     GSettings  *settings = NULL;

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -114,6 +114,8 @@ static void panel_menu_bar_update_visibility (GSettings* settings, gchar* key, P
 {
 	GtkWidget* image;
 	gchar *str;
+	GtkIconSize icon_size;
+	gint icon_height;
 
 	if (!GTK_IS_WIDGET (menubar))
 		return;
@@ -125,15 +127,18 @@ static void panel_menu_bar_update_visibility (GSettings* settings, gchar* key, P
 	if (g_settings_get_boolean (settings, PANEL_MENU_BAR_SHOW_ICON_KEY))
 	{
 		str = g_settings_get_string (settings, PANEL_MENU_BAR_ICON_NAME_KEY);
+		icon_size = panel_menu_bar_icon_get_size ();
+		gtk_icon_size_lookup (icon_size, NULL, &icon_height);
 		if (str != NULL && str[0] != 0)
-			image = gtk_image_new_from_icon_name(str, panel_menu_bar_icon_get_size());
+			image = gtk_image_new_from_icon_name(str, icon_size);
 		else
-			image = gtk_image_new_from_icon_name(PANEL_ICON_MAIN_MENU, panel_menu_bar_icon_get_size());
+			image = gtk_image_new_from_icon_name(PANEL_ICON_MAIN_MENU, icon_size);
+		gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (menubar->priv->applications_item), image);
+		gtk_image_set_pixel_size (GTK_IMAGE (image), icon_height);
 		g_free (str);
 	}
 	else
-		image = NULL;
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menubar->priv->applications_item), image);
+		gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (menubar->priv->applications_item), NULL);
 }
 
 static void panel_menu_bar_init(PanelMenuBar* menubar)

--- a/mate-panel/panel-menu-items.c
+++ b/mate-panel/panel-menu-items.c
@@ -246,8 +246,8 @@ panel_menu_items_append_from_desktop (GtkWidget *menu,
 		item = gtk_image_menu_item_new ();
 	}
 
-	setup_menu_item_with_icon (item, panel_menu_icon_get_size (),
-				   icon, NULL, NULL, name);
+	setup_menuitem_with_icon (item, panel_menu_icon_get_size (),
+				  NULL, icon, name);
 
 	panel_util_set_tooltip_text (item, comment);
 
@@ -292,10 +292,10 @@ panel_menu_items_append_place_item (const char *icon_name,
 	char      *user_data;
 
 	item = panel_image_menu_item_new ();
-	setup_menu_item_with_icon (item,
-				   panel_menu_icon_get_size (),
-				   icon_name, NULL, gicon,
-				   title);
+	setup_menuitem_with_icon (item,
+				  panel_menu_icon_get_size (),
+				  gicon, icon_name,
+				  title);
 
 	panel_util_set_tooltip_text (item, tooltip);
 
@@ -323,11 +323,11 @@ panel_menu_items_create_action_item_full (PanelActionButtonType  action_type,
 		return NULL;
 
 	item = gtk_image_menu_item_new ();
-        setup_menu_item_with_icon (item,
-				   panel_menu_icon_get_size (),
-				   panel_action_get_icon_name (action_type),
-				   NULL, NULL,
-				   label ? label : panel_action_get_text (action_type));
+        setup_menuitem_with_icon (item,
+				  panel_menu_icon_get_size (),
+				  NULL,
+				  panel_action_get_icon_name (action_type),
+				  label ? label : panel_action_get_text (action_type));
 
 	panel_util_set_tooltip_text (item,
 				     tooltip ?
@@ -468,9 +468,9 @@ panel_place_menu_item_append_gtk_bookmarks (GtkWidget *menu)
 		GtkWidget *item;
 
 		item = gtk_image_menu_item_new ();
-		setup_menu_item_with_icon (item, panel_menu_icon_get_size (),
-					   PANEL_ICON_BOOKMARKS, NULL, NULL,
-					   _("Bookmarks"));
+		setup_menuitem_with_icon (item, panel_menu_icon_get_size (),
+					  NULL, PANEL_ICON_BOOKMARKS,
+					  _("Bookmarks"));
 
 		gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
 		gtk_widget_show (item);
@@ -601,10 +601,10 @@ panel_menu_item_append_drive (GtkWidget *menu,
 	title = g_drive_get_name (drive);
 
 	item = panel_image_menu_item_new ();
-	setup_menu_item_with_icon (item,
-				   panel_menu_icon_get_size (),
-				   NULL, NULL, icon,
-				   title);
+	setup_menuitem_with_icon (item,
+				  panel_menu_icon_get_size (),
+				  icon, NULL,
+				  title);
 	g_object_unref (icon);
 
 	tooltip = g_strdup_printf (_("Rescan %s"), title);
@@ -701,10 +701,10 @@ panel_menu_item_append_volume (GtkWidget *menu,
 	title = g_volume_get_name (volume);
 
 	item = panel_image_menu_item_new ();
-	setup_menu_item_with_icon (item,
-				   panel_menu_icon_get_size (),
-				   NULL, NULL, icon,
-				   title);
+	setup_menuitem_with_icon (item,
+				  panel_menu_icon_get_size (),
+				  icon, NULL,
+				  title);
 	g_object_unref (icon);
 
 	tooltip = g_strdup_printf (_("Mount %s"), title);
@@ -912,9 +912,9 @@ panel_place_menu_item_append_local_gio (PanelPlaceMenuItem *place_item,
 		GtkWidget  *item;
 
 		item = gtk_image_menu_item_new ();
-		setup_menu_item_with_icon (item, panel_menu_icon_get_size (),
-					   PANEL_ICON_REMOVABLE_MEDIA,
-					   NULL, NULL,
+		setup_menuitem_with_icon (item, panel_menu_icon_get_size (),
+					  NULL,
+					  PANEL_ICON_REMOVABLE_MEDIA,
 					   _("Removable Media"));
 
 		gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
@@ -999,10 +999,10 @@ panel_place_menu_item_append_remote_gio (PanelPlaceMenuItem *place_item,
 		GtkWidget  *item;
 
 		item = panel_image_menu_item_new ();
-		setup_menu_item_with_icon (item, panel_menu_icon_get_size (),
-					   PANEL_ICON_NETWORK_SERVER,
-					   NULL, NULL,
-					   _("Network Places"));
+		setup_menuitem_with_icon (item, panel_menu_icon_get_size (),
+					  NULL,
+					  PANEL_ICON_NETWORK_SERVER,
+					  _("Network Places"));
 
 		gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
 		gtk_widget_show (item);

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -1587,7 +1587,7 @@ panel_profile_toplevel_id_list_notify (GSettings *settings,
 
 	toplevel_ids_strv = g_settings_get_strv (settings, key);
 
-	toplevel_ids = mate_gsettings_strv_to_gslist (toplevel_ids_strv);
+	toplevel_ids = mate_gsettings_strv_to_gslist ((const gchar **) toplevel_ids_strv);
 	toplevel_ids = panel_g_slist_make_unique (toplevel_ids,
 						  (GCompareFunc) g_strcmp0,
 						  FALSE);
@@ -1631,7 +1631,7 @@ panel_profile_object_id_list_update (gchar **objects)
 	GSList *sublist = NULL, *l;
 	GSList *object_ids;
 
-	object_ids = mate_gsettings_strv_to_gslist (objects);
+	object_ids = mate_gsettings_strv_to_gslist ((const gchar **) objects);
 	object_ids = panel_g_slist_make_unique (object_ids,
 						(GCompareFunc) g_strcmp0,
 						FALSE);

--- a/mate-panel/panel-recent.c
+++ b/mate-panel/panel-recent.c
@@ -189,11 +189,11 @@ panel_recent_append_documents_menu (GtkWidget        *top_menu,
 	int             size;
 
 	menu_item = gtk_image_menu_item_new ();
-	setup_menu_item_with_icon (menu_item,
-				   panel_menu_icon_get_size (),
-				   PANEL_ICON_RECENT,
-				   NULL, NULL,
-				   _("Recent Documents"));
+	setup_menuitem_with_icon (menu_item,
+				  panel_menu_icon_get_size (),
+				  NULL,
+				  PANEL_ICON_RECENT,
+				  _("Recent Documents"));
 	recent_menu = gtk_recent_chooser_menu_new_for_manager (manager);
 	gtk_menu_item_set_submenu (GTK_MENU_ITEM (menu_item), recent_menu);
 
@@ -228,10 +228,10 @@ panel_recent_append_documents_menu (GtkWidget        *top_menu,
 	add_menu_separator (recent_menu);
 
 	menu_item = gtk_image_menu_item_new ();
-	setup_menu_item_with_icon (menu_item,
+	setup_menuitem_with_icon (menu_item,
 				   panel_menu_icon_get_size (),
 				   NULL,
-				   GTK_STOCK_CLEAR, NULL,
+				   "edit-clear",
 				   _("Clear Recent Documents..."));
 	panel_util_set_tooltip_text (menu_item,
 				     _("Clear all items from the recent documents list"));

--- a/mate-panel/panel-stock-icons.c
+++ b/mate-panel/panel-stock-icons.c
@@ -30,6 +30,7 @@
 #include <gtk/gtk.h>
 
 #include "panel-icon-names.h"
+#include "panel-schemas.h"
 
 static GtkIconSize panel_menu_icon_size = 0;
 static GtkIconSize panel_menu_bar_icon_size = 0;
@@ -128,14 +129,33 @@ void
 panel_init_stock_icons_and_items (void)
 {
 	GtkIconFactory *factory;
+	GSettings      *settings;
+	gint		icon_size;
 
-	panel_menu_icon_size = gtk_icon_size_register ("panel-menu",
-						       PANEL_DEFAULT_MENU_ICON_SIZE,
-						       PANEL_DEFAULT_MENU_ICON_SIZE);
+	settings = g_settings_new (PANEL_MENU_BAR_SCHEMA);
 
-	panel_menu_bar_icon_size = gtk_icon_size_register ("panel-foobar",
-							   PANEL_DEFAULT_MENU_BAR_ICON_SIZE,
-							   PANEL_DEFAULT_MENU_BAR_ICON_SIZE);
+	icon_size = g_settings_get_enum (settings, "item-icon-size");
+	if (icon_size <= 0) {
+		panel_menu_icon_size = gtk_icon_size_register ("panel-menu",
+							       PANEL_DEFAULT_MENU_ICON_SIZE,
+							       PANEL_DEFAULT_MENU_ICON_SIZE);
+	} else {
+		/* underscores to prevent themes from altering these settings */
+		panel_menu_icon_size = gtk_icon_size_register ("__panel-menu",
+							       icon_size,
+							       icon_size);
+	}
+
+	icon_size = g_settings_get_enum (settings, "icon-size");
+	if (icon_size <= 0) {
+		panel_menu_bar_icon_size = gtk_icon_size_register ("panel-foobar",
+								   PANEL_DEFAULT_MENU_BAR_ICON_SIZE,
+								   PANEL_DEFAULT_MENU_BAR_ICON_SIZE);
+	} else {
+		panel_menu_bar_icon_size = gtk_icon_size_register ("__panel-foobar",
+								   icon_size,
+								   icon_size);
+	}
 
 	panel_add_to_icon_size = gtk_icon_size_register ("panel-add-to",
 							 PANEL_ADD_TO_DEFAULT_ICON_SIZE,
@@ -148,4 +168,5 @@ panel_init_stock_icons_and_items (void)
 	panel_init_stock_items (factory);
 
 	g_object_unref (factory);
+	g_object_unref (settings);
 }

--- a/mate-panel/panel-stock-icons.h
+++ b/mate-panel/panel-stock-icons.h
@@ -33,12 +33,12 @@ extern "C" {
 #endif
 
 /* themeable size - "panel-menu" -- This is used for the icons in the menus */
-#define PANEL_DEFAULT_MENU_ICON_SIZE 		24
+#define PANEL_DEFAULT_MENU_ICON_SIZE		24
 /* themeable size - "panel-foobar" -- This is only used for the icon of the
  * Applications item in the menu bar */
-#define PANEL_DEFAULT_MENU_BAR_ICON_SIZE 	24
+#define PANEL_DEFAULT_MENU_BAR_ICON_SIZE	22
 
-#define PANEL_ADD_TO_DEFAULT_ICON_SIZE          32
+#define PANEL_ADD_TO_DEFAULT_ICON_SIZE		32
 
 /* stock icons */
 #define PANEL_STOCK_FORCE_QUIT          "mate-panel-force-quit"
@@ -51,7 +51,7 @@ extern "C" {
 #define PANEL_STOCK_CLEAR               "panel-clear"
 #define PANEL_STOCK_DONT_DELETE         "panel-dont-delete"
 /* FIXME: put a more representative icon here */
-#define PANEL_STOCK_DEFAULT_ICON		"application-default-icon"
+#define PANEL_STOCK_DEFAULT_ICON	"application-default-icon"
 
 void        panel_init_stock_icons_and_items (void);
 GtkIconSize panel_menu_icon_get_size         (void);

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -2517,7 +2517,11 @@ panel_widget_applet_key_press_event (GtkWidget   *widget,
 	if (!mate_panel_applet_in_drag)
 		return FALSE;
 
+#if GTK_CHECK_VERSION (3, 0, 0)
 	return gtk_bindings_activate (G_OBJECT (panel),
+#else
+	return gtk_bindings_activate (GTK_OBJECT (panel),
+#endif
 				      ((GdkEventKey *)event)->keyval, 
 				      ((GdkEventKey *)event)->state);	
 }

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -399,7 +399,11 @@ panel_key_press_event (GtkWidget   *widget,
 	if (GTK_IS_SOCKET (gtk_window_get_focus (GTK_WINDOW (widget))) &&
 	    event->keyval == GDK_KEY_F10 &&
 	    (event->state & gtk_accelerator_get_default_mod_mask ()) == GDK_CONTROL_MASK)
+#if GTK_CHECK_VERSION (3, 0, 0)
 		return gtk_bindings_activate (G_OBJECT (widget),
+#else
+		return gtk_bindings_activate (GTK_OBJECT (widget),
+#endif
 					      event->keyval,
 					      event->state);
 


### PR DESCRIPTION
 * Add a GSchema for changing icon size of menubar icon and menu item icons.
 * Default menubar icon is too big for a 24px panel as it touches the panel borders, so make it 22px.
 * Fix Gtk 3.16+ dishonouring mate-panel's defaults on menu icons size.
 * Also I cleaned code around icon loading a bit, fixed some warnings.