### PR TITLE
Gtk 3.20-custom applet bg fix2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@ case "$with_gtk" in
 esac
 
 AC_SUBST(GTK_API_VERSION)
-
+AM_CONDITIONAL([HAVE_GTK3], [test "x$GTK_API_VERSION" = "x3.0"])
 dnl pkg-config dependency checks
 
 PKG_CHECK_MODULES(EGG_SMCLIENT, ice sm gtk+-$GTK_API_VERSION)

--- a/libmate-panel-applet/Makefile.am
+++ b/libmate-panel-applet/Makefile.am
@@ -22,7 +22,9 @@ libmate_panel_applet_4_la_SOURCES =		\
 	mate-panel-applet-factory.h		\
 	mate-panel-applet-factory.c		\
 	mate-panel-applet-gsettings.c		\
-	mate-panel-applet-gsettings.h
+	mate-panel-applet-gsettings.h       \
+	panel-plug.c			\
+	panel-plug-private.h
 
 libmate_panel_applet_4_la_LIBADD  = \
 	$(LIBMATE_PANEL_APPLET_LIBS) \

--- a/libmate-panel-applet/Makefile.am
+++ b/libmate-panel-applet/Makefile.am
@@ -14,7 +14,7 @@ libmate_panel_appletinclude_HEADERS =	\
 	mate-panel-applet.h			\
 	mate-panel-applet-gsettings.h		\
 	mate-panel-applet-enums.h
-
+if HAVE_GTK3
 libmate_panel_applet_4_la_SOURCES =		\
 	$(BUILT_SOURCES)		\
 	mate-panel-applet.h			\
@@ -25,6 +25,16 @@ libmate_panel_applet_4_la_SOURCES =		\
 	mate-panel-applet-gsettings.h       \
 	panel-plug.c			\
 	panel-plug-private.h
+else
+libmate_panel_applet_4_la_SOURCES =		\
+	$(BUILT_SOURCES)		\
+	mate-panel-applet.h			\
+	mate-panel-applet.c			\
+	mate-panel-applet-factory.h		\
+	mate-panel-applet-factory.c		\
+	mate-panel-applet-gsettings.c		\
+	mate-panel-applet-gsettings.h
+endif
 
 libmate_panel_applet_4_la_LIBADD  = \
 	$(LIBMATE_PANEL_APPLET_LIBS) \

--- a/libmate-panel-applet/panel-plug-private.h
+++ b/libmate-panel-applet/panel-plug-private.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016 Alberts Muktupāvels
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PANEL_PLUG_PRIVATE_H
+#define PANEL_PLUG_PRIVATE_H
+
+#include <gtk/gtkx.h>
+
+G_BEGIN_DECLS
+
+#define PANEL_TYPE_PLUG panel_plug_get_type ()
+G_DECLARE_FINAL_TYPE (PanelPlug, panel_plug, PANEL, PLUG, GtkPlug)
+
+GtkWidget *panel_plug_new (void);
+
+G_END_DECLS
+
+#endif

--- a/libmate-panel-applet/panel-plug.c
+++ b/libmate-panel-applet/panel-plug.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016 Alberts Muktupāvels
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "panel-plug-private.h"
+
+struct _PanelPlug
+{
+  GtkPlug parent;
+};
+
+G_DEFINE_TYPE (PanelPlug, panel_plug, GTK_TYPE_PLUG)
+
+static gboolean
+panel_plug_draw (GtkWidget *widget,
+                 cairo_t   *cr)
+{
+  GdkWindow *window;
+  cairo_pattern_t *pattern;
+
+  if (!gtk_widget_get_realized (widget))
+    return GTK_WIDGET_CLASS (panel_plug_parent_class)->draw (widget, cr);
+
+  window = gtk_widget_get_window (widget);
+  pattern = gdk_window_get_background_pattern (window);
+
+  if (!pattern)
+    {
+      GtkStyleContext *context;
+      gint width;
+      gint height;
+
+      context = gtk_widget_get_style_context (widget);
+      width = gtk_widget_get_allocated_width (widget);
+      height = gtk_widget_get_allocated_height (widget);
+
+      gtk_render_background (context, cr, 0, 0, width, height);
+    }
+
+  return GTK_WIDGET_CLASS (panel_plug_parent_class)->draw (widget, cr);
+}
+
+static void
+panel_plug_realize (GtkWidget *widget)
+{
+  GdkScreen *screen;
+  GdkVisual *visual;
+
+  screen = gdk_screen_get_default ();
+  visual = gdk_screen_get_rgba_visual (screen);
+
+  if (!visual)
+    visual = gdk_screen_get_system_visual (screen);
+
+  gtk_widget_set_visual (widget, visual);
+
+  GTK_WIDGET_CLASS (panel_plug_parent_class)->realize (widget);
+}
+
+static void
+panel_plug_class_init (PanelPlugClass *plug_class)
+{
+  GtkWidgetClass *widget_class;
+
+  widget_class = GTK_WIDGET_CLASS (plug_class);
+
+  widget_class->draw = panel_plug_draw;
+  widget_class->realize = panel_plug_realize;
+
+#if GTK_CHECK_VERSION (3, 19, 0)
+	gtk_widget_class_set_css_name (widget_class, "PanelApplet");
+#endif
+}
+
+static void
+panel_plug_init (PanelPlug *plug)
+{
+  gtk_widget_set_app_paintable (GTK_WIDGET (plug), TRUE);
+}
+
+GtkWidget *
+panel_plug_new (void)
+{
+  return g_object_new (PANEL_TYPE_PLUG, NULL);
+}

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1650,10 +1650,11 @@ panel_widget_set_background_default_style (GtkWidget *widget)
 		background = &PANEL_WIDGET (widget)->background;
 #if GTK_CHECK_VERSION (3, 19, 0)
 		gtk_style_context_add_class(context,GTK_STYLE_CLASS_BACKGROUND);
+#else
+		panel_background_apply_css (&PANEL_WIDGET (widget)->background, widget);
 #endif	
 		gtk_style_context_add_class(context,"gnome-panel-menu-bar");
-		gtk_style_context_add_class(context,"mate-panel-menu-bar");
-		panel_background_apply_css (&PANEL_WIDGET (widget)->background, widget);
+		gtk_style_context_add_class(context,"mate-panel-menu-bar");		
 
 		gtk_style_context_get (context, state,
 		                       "background-color", &bg_color,


### PR DESCRIPTION
GTK 3.20-Apply the gnome-panel commits to restore applet backgrounds on gnome-panel (with considerable modificaton to mate-panel-applet.c due to differences) to gtk3.19 and later builds of mate-panel. Remove gdk_window_ensure_native from mate-panel-applet.c and use the new panel plug files from GNOME intact. They and their associated code in mate-panel-applet permit custom backgrounds to show on applets, and backgrounds on applets are changed immediately from custom to system and back again. So are changes to alpha values in a color background.

Keep this whole mess off of GTK 3.18 and earlier builds, otherwise panel applets in an alpha background are almost twice as dark due to double application of the transparent color. 

based on 
github.com/GNOME/gnome-panel/commit/3115f77b536a7c79c7d43ded0591e2b8f45219c4

I recommend building the clock, tray, wncklet, and fish in-process as this stops most of the applet crashes on panel startup with a custom background(especially image backgrounds) selected.

With a png image custom background I got these warnings but the panel rendered normally and so did all the applets:

** (mate-panel:32657): WARNING **: Failed to get pattern 20974650,40,0

** (mate-panel:32657): WARNING **: Failed to get pattern 20974650,393,0

** (mate-panel:32657): WARNING **: Failed to get pattern 20974650,1143,0

** (mate-panel:32657): WARNING **: Failed to get pattern 20974650,1588,0

** (mate-panel:32657): WARNING **: Failed to get pattern 20974650,1677,0