### PR TITLE
GTK+3.20: add new CSS name for WnckPager

### DIFF
--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -567,6 +567,7 @@ gboolean workspace_switcher_applet_fill(MatePanelApplet* applet)
 
 	provider = gtk_css_provider_new ();
 	gtk_css_provider_load_from_data (provider,
+                                         "wnck-pager:selected,\n"
                                          "WnckPager:selected {\n"
                                          "background-color: #4A90D9; }",
                                          -1, NULL);


### PR DESCRIPTION
The old one will no longer work. The new name was added here:
https://git.gnome.org/browse/libwnck/commit/?id=36c9e4a823cf78f2f5ffe7863acb68f015ea430a