### PR TITLE
Gtk 3.18 &  3.20-move bg handling

### DIFF
--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -123,8 +123,12 @@ mate_panel_applet_frame_draw (GtkWidget *widget,
 	gtk_style_context_get (context, state,
 			       "background-image", &bg_pattern,
 			       NULL);
-	background = &frame->priv->panel->background;
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &frame->priv->panel->toplevel->background;
+#else
+	background = &frame->priv->panel->background;
+#endif
 	if (bg_pattern && (background->type == PANEL_BACK_IMAGE ||
 	    (background->type == PANEL_BACK_COLOR && background->has_alpha))) {
 		cairo_matrix_t ptm;
@@ -223,9 +227,11 @@ mate_panel_applet_frame_update_background_size (MatePanelAppletFrame *frame,
 	    old_allocation->width  == new_allocation->width &&
 	    old_allocation->height == new_allocation->height)
 		return;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &frame->priv->panel->toplevel->background;
+#else
 	background = &frame->priv->panel->background;
-
+#endif
 	if (background->type == PANEL_BACK_NONE ||
 	   (background->type == PANEL_BACK_COLOR && !background->has_alpha))
 		return;
@@ -647,8 +653,11 @@ mate_panel_applet_frame_change_background (MatePanelAppletFrame    *frame,
 
 	if (frame->priv->has_handle) {
 		PanelBackground *background;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+		background = &PANEL_WIDGET (parent)->toplevel->background;
+#else
 		background = &PANEL_WIDGET (parent)->background;
+#endif
 #if GTK_CHECK_VERSION (3, 0, 0)
 		panel_background_apply_css (background, GTK_WIDGET (frame));
 #else
@@ -744,7 +753,11 @@ _mate_panel_applet_frame_update_flags (MatePanelAppletFrame *frame,
 		 * it */
 		PanelBackground *background;
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+		background = &frame->priv->panel->toplevel->background;
+#else
 		background = &frame->priv->panel->background;
+#endif
 		mate_panel_applet_frame_change_background (frame, background->type);
 	}
 }
@@ -800,8 +813,11 @@ _mate_panel_applet_frame_get_background_string (MatePanelAppletFrame    *frame,
 			break;
 		}
 	}
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	return panel_background_make_string (&panel->toplevel->background, x, y);
+#else
 	return panel_background_make_string (&panel->background, x, y);
+#endif
 }
 
 static void

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -554,13 +554,8 @@ panel_background_composite (PanelBackground *background)
 		break;
 	}
 
-#if GTK_CHECK_VERSION (3, 18, 0)
-    /* FIXME, Hack, panel user background fix for gtk+-3.18+ */
-    /* this is actually WRONG but fixes rendering of user selected color BG */
-	background->composited = FALSE;
-#else
 	background->composited = TRUE;
-#endif
+
 
 	panel_background_prepare (background);
 
@@ -1500,4 +1495,3 @@ panel_background_change_background_on_widget (PanelBackground *background,
 	}
 }
 #endif
-

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -274,8 +274,11 @@ static void panel_menu_bar_size_allocate(GtkWidget* widget, GtkAllocation* alloc
 		return;
 	}
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &PANEL_MENU_BAR(widget)->priv->panel->toplevel->background;
+#else
 	background = &PANEL_MENU_BAR(widget)->priv->panel->background;
-
+#endif
 	if (background->type == PANEL_BACK_NONE || (background->type == PANEL_BACK_COLOR && !background->has_alpha))
 	{
 		return;
@@ -483,7 +486,9 @@ void panel_menu_bar_popup_menu(PanelMenuBar* menubar, guint32 activate_time)
 
 void panel_menu_bar_change_background(PanelMenuBar* menubar)
 {
-#if GTK_CHECK_VERSION (3, 0, 0)
+#if GTK_CHECK_VERSION (3, 18, 0)
+	panel_background_apply_css(&menubar->priv->panel->toplevel->background, GTK_WIDGET(menubar));
+#elif GTK_CHECK_VERSION (3, 0, 0)
 	panel_background_apply_css(&menubar->priv->panel->background, GTK_WIDGET(menubar));
 #else
 	panel_background_change_background_on_widget(&menubar->priv->panel->background, GTK_WIDGET(menubar));

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -620,8 +620,12 @@ panel_profile_load_background (PanelToplevel *toplevel)
 	gboolean             rotate;
 
 	panel_widget = panel_toplevel_get_panel_widget (toplevel);
-	background = &panel_widget->background;
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &panel_widget->toplevel->background;
+#else
+	background = &panel_widget->background;
+#endif
 	background_type = panel_profile_get_background_type (toplevel);
 
 	get_background_color (toplevel, &color);
@@ -906,8 +910,11 @@ panel_profile_background_change_notify (GSettings *settings,
 	if (panel_widget == NULL)
 		return;
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &panel_widget->toplevel->background;
+#else
 	background = &panel_widget->background;
-
+#endif
 	if (!strcmp (key, "type")) {
 		PanelBackgroundType  background_type;
 		background_type = g_settings_get_enum (settings, key);

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -220,9 +220,11 @@ panel_separator_size_allocate (GtkWidget     *widget,
 	    old_allocation.width  == allocation->width &&
 	    old_allocation.height == allocation->height)
 		return;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &PANEL_SEPARATOR (widget)->priv->panel->toplevel->background;
+#else
 	background = &PANEL_SEPARATOR (widget)->priv->panel->background;
-
+#endif
 	if (background->type == PANEL_BACK_NONE ||
 	   (background->type == PANEL_BACK_COLOR && !background->has_alpha))
 		return;
@@ -348,7 +350,9 @@ panel_separator_create (PanelToplevel *toplevel,
 void
 panel_separator_change_background (PanelSeparator *separator)
 {
-#if GTK_CHECK_VERSION (3, 0, 0)
+#if GTK_CHECK_VERSION (3, 18, 0)
+	panel_background_apply_css(&separator->priv->panel->toplevel->background, GTK_WIDGET(separator));
+#elif GTK_CHECK_VERSION (3, 0, 0)
 	panel_background_apply_css(&separator->priv->panel->background, GTK_WIDGET(separator));
 #else
 	panel_background_change_background_on_widget(&separator->priv->panel->background, GTK_WIDGET(separator));

--- a/mate-panel/panel-toplevel.h
+++ b/mate-panel/panel-toplevel.h
@@ -27,7 +27,11 @@
 
 #include <gtk/gtk.h>
 
+#include "panel-background.h"
+
+#if GTK_CHECK_VERSION (3, 18, 0)
 #include "panel-enums.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,7 +60,9 @@ struct _PanelToplevel {
 	GSettings             *settings;
 	GSettings             *queued_settings;
 	GSettings             *background_settings;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	PanelBackground        background;
+#endif
 	PanelToplevelPrivate  *priv;
 };
 

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -159,7 +159,12 @@ back_change (AppletInfo  *info,
 	switch (info->type) {
 	case PANEL_OBJECT_APPLET:
 		mate_panel_applet_frame_change_background (
-			MATE_PANEL_APPLET_FRAME (info->widget), panel->background.type);
+
+#if GTK_CHECK_VERSION (3, 19, 0)
+		MATE_PANEL_APPLET_FRAME (info->widget), panel->toplevel->background.type);
+#else
+		MATE_PANEL_APPLET_FRAME (info->widget), panel->background.type);
+#endif
 		break;
 	case PANEL_OBJECT_MENU_BAR:
 		panel_menu_bar_change_background (PANEL_MENU_BAR (info->widget));


### PR DESCRIPTION
This branch fixes the temporary loss of custom panel backgrounds when changing GTK themes in GTK 3.20. Also stopped the applet crashes on theme change or loading the panel with a custom background applied, so applied it to GTK 3.18 as well. Do NOT apply it to GTK3.16 or earlier builds, as moving the panel background handling to the toplevel does not work with them.
Based on gnome-panel's
https://github.com/GNOME/gnome-panel/commit/47741777c3115b9700fd762ab7543a81d2ed92dc
 move background handling from PanelWidget to PanelToplevel 
and
https://github.com/GNOME/gnome-panel/commit/08e2e24c21694fc835c98166ff1b0cf5bba42c1c
set rgba visual on PanelToplevel not PanelWidget 

Tested with gtk 3.14, 3.16, 3.18, and today's newly-released GTK 3.20. Needs testing in GTK 2 as I don't have a GTK 2 build environment set up

Note that some early commits were named as gtk3.18/3.10 by mistake, those are GTK 3.18/3.20 commits. I cannot change the names from the website except by starting over with a new branch.