### PR TITLE
Gtk 3.18 & 3.20-move bg handling with correct applet colors in GTK 3.18

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -47,7 +47,7 @@
 #include "mate-panel-applet-factory.h"
 #include "mate-panel-applet-marshal.h"
 #include "mate-panel-applet-enums.h"
-#if GTK_CHECK_VERSION (3, 19, 0)
+#if GTK_CHECK_VERSION (3, 18, 0)
 #include "panel-plug-private.h"
 #endif
 #define MATE_PANEL_APPLET_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PANEL_TYPE_APPLET, MatePanelAppletPrivate))
@@ -71,7 +71,7 @@ struct _MatePanelAppletPrivate {
 	MatePanelAppletOrient  orient;
 	guint              size;
 	char              *background;
-#if !GTK_CHECK_VERSION (3, 19, 0)
+#if !GTK_CHECK_VERSION (3, 18, 0)
 	GtkWidget         *background_widget;
 #endif
 
@@ -1023,7 +1023,7 @@ mate_panel_applet_popup_menu (GtkWidget *widget)
 }
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-#if !GTK_CHECK_VERSION (3, 19, 0)
+#if !GTK_CHECK_VERSION (3, 18, 0)
 static void
 mate_panel_applet_get_preferred_width (GtkWidget *widget,
 				       int       *minimum_width,
@@ -1119,7 +1119,7 @@ mate_panel_applet_size_allocate (GtkWidget     *widget,
 	GtkBin        *bin;
 	GtkWidget     *child;
 	int            border_width;
-#if !GTK_CHECK_VERSION (3, 19, 0)
+#if !GTK_CHECK_VERSION (3, 18, 0)
 	int            focus_width = 0;
 #endif
 	MatePanelApplet   *applet;
@@ -1127,7 +1127,7 @@ mate_panel_applet_size_allocate (GtkWidget     *widget,
 	if (!mate_panel_applet_can_focus (widget)) {
 		GTK_WIDGET_CLASS (mate_panel_applet_parent_class)->size_allocate (widget, allocation);
 	} else {
-#if !GTK_CHECK_VERSION (3, 19, 0)
+#if !GTK_CHECK_VERSION (3, 18, 0)
 		/*
 		 * We are deliberately ignoring focus-padding here to
 		 * save valuable panel real estate.
@@ -1142,7 +1142,7 @@ mate_panel_applet_size_allocate (GtkWidget     *widget,
 		gtk_widget_set_allocation (widget, allocation);
 		bin = GTK_BIN (widget);
 
-#if GTK_CHECK_VERSION (3, 19, 0)
+#if GTK_CHECK_VERSION (3, 18, 0)
 		child_allocation.x = 0;
 		child_allocation.y = 0;
 #else
@@ -1160,7 +1160,7 @@ mate_panel_applet_size_allocate (GtkWidget     *widget,
 						child_allocation.width,
 						child_allocation.height);
 
-#if !GTK_CHECK_VERSION (3, 19, 0)
+#if !GTK_CHECK_VERSION (3, 18, 0)
 		child_allocation.width  = MAX (child_allocation.width  - 2 * focus_width, 0);
 		child_allocation.height = MAX (child_allocation.height - 2 * focus_width, 0);
 #endif
@@ -1193,7 +1193,7 @@ static gboolean mate_panel_applet_expose(GtkWidget* widget, GdkEventExpose* even
 	GtkAllocation allocation;
 #endif
 	int border_width;
-#if !GTK_CHECK_VERSION (3, 19, 0)
+#if !GTK_CHECK_VERSION (3, 18, 0)
 	int focus_width = 0;
 #endif
 #if GTK_CHECK_VERSION (3, 0, 0)
@@ -1223,7 +1223,7 @@ static gboolean mate_panel_applet_expose(GtkWidget* widget, GdkEventExpose* even
 	gtk_widget_get_allocation(widget, &allocation);
 #endif
 
-#if !GTK_CHECK_VERSION (3, 19, 0)
+#if !GTK_CHECK_VERSION (3, 18, 0)
 	/*
 	 * We are deliberately ignoring focus-padding here to
 	 * save valuable panel real estate.
@@ -1817,7 +1817,7 @@ mate_panel_applet_move_focus_out_of_applet (MatePanelApplet      *applet,
 	applet->priv->moving_focus_out = FALSE;
 }
 
-#if GTK_CHECK_VERSION (3, 19, 0)
+#if GTK_CHECK_VERSION (3, 18, 0)
 static void
 mate_panel_applet_change_background(MatePanelApplet *applet,
 				    MatePanelAppletBackgroundType type,
@@ -2166,7 +2166,7 @@ mate_panel_applet_class_init (MatePanelAppletClass *klass)
 	widget_class->button_release_event = mate_panel_applet_button_release;
 #if GTK_CHECK_VERSION (3, 0, 0)
 	widget_class->get_request_mode = mate_panel_applet_get_request_mode;
-#if !GTK_CHECK_VERSION (3, 19, 0)
+#if !GTK_CHECK_VERSION (3, 18, 0)
 	widget_class->get_preferred_width = mate_panel_applet_get_preferred_width;
 	widget_class->get_preferred_height = mate_panel_applet_get_preferred_height;
 #endif
@@ -2614,7 +2614,7 @@ int mate_panel_applet_factory_main(const gchar* factory_id, gboolean out_process
  **/
 
 
-#if GTK_CHECK_VERSION (3, 19, 0)
+#if GTK_CHECK_VERSION (3, 18, 0)
 
 void
 mate_panel_applet_set_background_widget (MatePanelApplet *applet,

--- a/libmate-panel-applet/panel-plug-private.h
+++ b/libmate-panel-applet/panel-plug-private.h
@@ -19,7 +19,7 @@
 #define PANEL_PLUG_PRIVATE_H
 
 #include <gtk/gtk.h>
-#if GTK_CHECK_VERSION (3, 19, 0) && GLIB_CHECK_VERSION (2, 44, 0)
+#if GTK_CHECK_VERSION (3, 18, 0) && GLIB_CHECK_VERSION (2, 44, 0)
 
 #include <gtk/gtkx.h>
 

--- a/libmate-panel-applet/panel-plug.c
+++ b/libmate-panel-applet/panel-plug.c
@@ -16,7 +16,7 @@
  */
 
 #include <gtk/gtk.h>
-#if GTK_CHECK_VERSION (3, 19, 0) && GLIB_CHECK_VERSION (2, 44, 0)
+#if GTK_CHECK_VERSION (3, 18, 0) && GLIB_CHECK_VERSION (2, 44, 0)
 #include "config.h"
 
 #include "panel-plug-private.h"

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -123,8 +123,12 @@ mate_panel_applet_frame_draw (GtkWidget *widget,
 	gtk_style_context_get (context, state,
 			       "background-image", &bg_pattern,
 			       NULL);
-	background = &frame->priv->panel->background;
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &frame->priv->panel->toplevel->background;
+#else
+	background = &frame->priv->panel->background;
+#endif
 	if (bg_pattern && (background->type == PANEL_BACK_IMAGE ||
 	    (background->type == PANEL_BACK_COLOR && background->has_alpha))) {
 		cairo_matrix_t ptm;
@@ -223,9 +227,11 @@ mate_panel_applet_frame_update_background_size (MatePanelAppletFrame *frame,
 	    old_allocation->width  == new_allocation->width &&
 	    old_allocation->height == new_allocation->height)
 		return;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &frame->priv->panel->toplevel->background;
+#else
 	background = &frame->priv->panel->background;
-
+#endif
 	if (background->type == PANEL_BACK_NONE ||
 	   (background->type == PANEL_BACK_COLOR && !background->has_alpha))
 		return;
@@ -647,8 +653,11 @@ mate_panel_applet_frame_change_background (MatePanelAppletFrame    *frame,
 
 	if (frame->priv->has_handle) {
 		PanelBackground *background;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+		background = &PANEL_WIDGET (parent)->toplevel->background;
+#else
 		background = &PANEL_WIDGET (parent)->background;
+#endif
 #if GTK_CHECK_VERSION (3, 0, 0)
 		panel_background_apply_css (background, GTK_WIDGET (frame));
 #else
@@ -744,7 +753,11 @@ _mate_panel_applet_frame_update_flags (MatePanelAppletFrame *frame,
 		 * it */
 		PanelBackground *background;
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+		background = &frame->priv->panel->toplevel->background;
+#else
 		background = &frame->priv->panel->background;
+#endif
 		mate_panel_applet_frame_change_background (frame, background->type);
 	}
 }
@@ -800,8 +813,11 @@ _mate_panel_applet_frame_get_background_string (MatePanelAppletFrame    *frame,
 			break;
 		}
 	}
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	return panel_background_make_string (&panel->toplevel->background, x, y);
+#else
 	return panel_background_make_string (&panel->background, x, y);
+#endif
 }
 
 static void

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -554,13 +554,8 @@ panel_background_composite (PanelBackground *background)
 		break;
 	}
 
-#if GTK_CHECK_VERSION (3, 18, 0)
-    /* FIXME, Hack, panel user background fix for gtk+-3.18+ */
-    /* this is actually WRONG but fixes rendering of user selected color BG */
-	background->composited = FALSE;
-#else
 	background->composited = TRUE;
-#endif
+
 
 	panel_background_prepare (background);
 
@@ -1500,4 +1495,3 @@ panel_background_change_background_on_widget (PanelBackground *background,
 	}
 }
 #endif
-

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -274,8 +274,11 @@ static void panel_menu_bar_size_allocate(GtkWidget* widget, GtkAllocation* alloc
 		return;
 	}
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &PANEL_MENU_BAR(widget)->priv->panel->toplevel->background;
+#else
 	background = &PANEL_MENU_BAR(widget)->priv->panel->background;
-
+#endif
 	if (background->type == PANEL_BACK_NONE || (background->type == PANEL_BACK_COLOR && !background->has_alpha))
 	{
 		return;
@@ -483,7 +486,9 @@ void panel_menu_bar_popup_menu(PanelMenuBar* menubar, guint32 activate_time)
 
 void panel_menu_bar_change_background(PanelMenuBar* menubar)
 {
-#if GTK_CHECK_VERSION (3, 0, 0)
+#if GTK_CHECK_VERSION (3, 18, 0)
+	panel_background_apply_css(&menubar->priv->panel->toplevel->background, GTK_WIDGET(menubar));
+#elif GTK_CHECK_VERSION (3, 0, 0)
 	panel_background_apply_css(&menubar->priv->panel->background, GTK_WIDGET(menubar));
 #else
 	panel_background_change_background_on_widget(&menubar->priv->panel->background, GTK_WIDGET(menubar));

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -620,8 +620,12 @@ panel_profile_load_background (PanelToplevel *toplevel)
 	gboolean             rotate;
 
 	panel_widget = panel_toplevel_get_panel_widget (toplevel);
-	background = &panel_widget->background;
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &panel_widget->toplevel->background;
+#else
+	background = &panel_widget->background;
+#endif
 	background_type = panel_profile_get_background_type (toplevel);
 
 	get_background_color (toplevel, &color);
@@ -906,8 +910,11 @@ panel_profile_background_change_notify (GSettings *settings,
 	if (panel_widget == NULL)
 		return;
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &panel_widget->toplevel->background;
+#else
 	background = &panel_widget->background;
-
+#endif
 	if (!strcmp (key, "type")) {
 		PanelBackgroundType  background_type;
 		background_type = g_settings_get_enum (settings, key);

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -220,9 +220,11 @@ panel_separator_size_allocate (GtkWidget     *widget,
 	    old_allocation.width  == allocation->width &&
 	    old_allocation.height == allocation->height)
 		return;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &PANEL_SEPARATOR (widget)->priv->panel->toplevel->background;
+#else
 	background = &PANEL_SEPARATOR (widget)->priv->panel->background;
-
+#endif
 	if (background->type == PANEL_BACK_NONE ||
 	   (background->type == PANEL_BACK_COLOR && !background->has_alpha))
 		return;
@@ -348,7 +350,9 @@ panel_separator_create (PanelToplevel *toplevel,
 void
 panel_separator_change_background (PanelSeparator *separator)
 {
-#if GTK_CHECK_VERSION (3, 0, 0)
+#if GTK_CHECK_VERSION (3, 18, 0)
+	panel_background_apply_css(&separator->priv->panel->toplevel->background, GTK_WIDGET(separator));
+#elif GTK_CHECK_VERSION (3, 0, 0)
 	panel_background_apply_css(&separator->priv->panel->background, GTK_WIDGET(separator));
 #else
 	panel_background_change_background_on_widget(&separator->priv->panel->background, GTK_WIDGET(separator));

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -1569,9 +1569,11 @@ void panel_toplevel_update_edges(PanelToplevel* toplevel)
 	height = toplevel->priv->geometry.height;
 
 	edges = PANEL_EDGE_NONE;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &toplevel->background;
+#else
 	background = &toplevel->priv->panel_widget->background;
-
+#endif
 
 	/* We don't want any bevels with a color/image background */
 #if !GTK_CHECK_VERSION(3, 0, 0)
@@ -2302,7 +2304,11 @@ panel_toplevel_update_position (PanelToplevel *toplevel)
 	 * x = 1 => outer bevel => x = 0 => no outer bevel = > x = 1 => ...
 	 * FIXME: maybe the real bug is that we enter into this loop (see bug
 	 * #160748 to learn how to reproduce.) */
+#if GTK_CHECK_VERSION (3, 18, 0)
+	background = &toplevel->background;
+#else
 	background = &toplevel->priv->panel_widget->background;
+#endif
 	/* There's no bevels with a color/image background */
 	if (panel_background_effective_type (background) == PANEL_BACK_NONE) {
 #if GTK_CHECK_VERSION (3, 0, 0)
@@ -3089,21 +3095,79 @@ panel_toplevel_initially_hide (PanelToplevel *toplevel)
 		toplevel->priv->initial_animation_done = TRUE;
 }
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+static void
+set_background_default_style (GtkWidget *widget)
+{
+	PanelToplevel *toplevel;
+	GtkStyleContext *context;
+	GtkStateFlags state;
+	GdkRGBA *bg_color;
+	cairo_pattern_t *bg_image;
+
+	if (!gtk_widget_get_realized (widget))
+		return;
+
+	toplevel = PANEL_TOPLEVEL (widget);
+ 
+	context = gtk_widget_get_style_context (widget);
+	state = gtk_style_context_get_state (context);
+
+	gtk_style_context_get (context, state,
+	                       "background-color", &bg_color,
+	                       "background-image", &bg_image,
+	                       NULL);
+
+	panel_background_set_default_style (&toplevel->background,
+	                                    bg_color, bg_image);
+
+	if (bg_color)
+		gdk_rgba_free (bg_color);
+
+	if (bg_image)
+		cairo_pattern_destroy (bg_image);
+}
+#endif
+
 static void
 panel_toplevel_realize (GtkWidget *widget)
 {
+#if GTK_CHECK_VERSION (3, 18, 0)
+	PanelToplevel *toplevel;
+	GdkScreen *screen;
+	GdkVisual *visual;
+	GdkWindow *window;
+	GdkGeometry geometry;
+
+	toplevel = PANEL_TOPLEVEL (widget);
+
+	screen = gtk_widget_get_screen (widget);
+	visual = gdk_screen_get_rgba_visual (screen);
+
+	if (visual == NULL)
+		visual = gdk_screen_get_system_visual (screen);
+
+	gtk_widget_set_visual (widget, visual);
+ 	gtk_window_stick (GTK_WINDOW (widget));
+#else
 	PanelToplevel *toplevel = (PanelToplevel *) widget;
 	GdkWindow     *window;
-
+#endif
 	gtk_window_set_decorated (GTK_WINDOW (widget), FALSE);
 	gtk_window_stick (GTK_WINDOW (widget));
 	gtk_window_set_type_hint (GTK_WINDOW (widget), GDK_WINDOW_TYPE_HINT_DOCK);
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+	GTK_WIDGET_CLASS (panel_toplevel_parent_class)->realize (widget);
+#else
 	if (GTK_WIDGET_CLASS (panel_toplevel_parent_class)->realize)
 		GTK_WIDGET_CLASS (panel_toplevel_parent_class)->realize (widget);
-
+#endif
 	window = gtk_widget_get_window (widget);
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	set_background_default_style (widget);
+	panel_background_realized (&toplevel->background, window);
+#endif
 	panel_struts_set_window_hint (toplevel);
 
 	gdk_window_set_group (window, window);
@@ -3133,10 +3197,18 @@ panel_toplevel_disconnect_timeouts (PanelToplevel *toplevel)
 static void
 panel_toplevel_unrealize (GtkWidget *widget)
 {
+#if GTK_CHECK_VERSION (3, 18, 0)
+	PanelToplevel *toplevel;
+	toplevel = PANEL_TOPLEVEL (widget);
+	panel_toplevel_disconnect_timeouts (toplevel);
+	panel_background_unrealized (&toplevel->background);
+	GTK_WIDGET_CLASS (panel_toplevel_parent_class)->unrealize (widget);
+#else
 	panel_toplevel_disconnect_timeouts (PANEL_TOPLEVEL (widget));
 
 	if (GTK_WIDGET_CLASS (panel_toplevel_parent_class)->unrealize)
 		GTK_WIDGET_CLASS (panel_toplevel_parent_class)->unrealize (widget);
+#endif
 }
 
 static void
@@ -3254,6 +3326,38 @@ panel_toplevel_get_preferred_height (GtkWidget *widget,
 }
 #endif
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+set_background_region (PanelToplevel *toplevel)
+{
+	GtkWidget *widget;
+	GdkWindow *window;
+	gint origin_x;
+	gint origin_y;
+	GtkAllocation allocation;
+	GtkOrientation orientation;
+
+	widget = GTK_WIDGET (toplevel);
+
+	if (!gtk_widget_get_realized (widget))
+		return;
+
+	window = gtk_widget_get_window (widget);
+	origin_x = -1;
+	origin_y = -1;
+
+	gdk_window_get_origin (window, &origin_x, &origin_y);
+	gtk_widget_get_allocation (widget, &allocation);
+
+	orientation = GTK_ORIENTATION_HORIZONTAL;
+	if (toplevel->priv->orientation & PANEL_VERTICAL_MASK)
+		orientation = GTK_ORIENTATION_VERTICAL;
+
+	panel_background_change_region (&toplevel->background, orientation,
+	                                origin_x, origin_y,
+	                                allocation.width, allocation.height);
+}
+#endif
+
 static void
 panel_toplevel_size_allocate (GtkWidget     *widget,
 			      GtkAllocation *allocation)
@@ -3350,6 +3454,10 @@ panel_toplevel_size_allocate (GtkWidget     *widget,
 
 	if (child && gtk_widget_get_visible (child))
 		gtk_widget_size_allocate (child, &challoc);
+
+#if GTK_CHECK_VERSION (3, 18, 0)
+	set_background_region (toplevel);
+#endif
 }
 
 #if GTK_CHECK_VERSION (3, 0, 0)
@@ -3649,6 +3757,20 @@ panel_toplevel_button_release_event (GtkWidget      *widget,
 
 	return TRUE;
 }
+#if GTK_CHECK_VERSION (3, 18, 0)
+static void
+panel_toplevel_configure_event (GtkWidget	  *widget,
+				GdkEventConfigure *event)
+{	
+	PanelToplevel *toplevel;
+
+	toplevel = PANEL_TOPLEVEL (widget);
+
+	set_background_region (toplevel);
+
+	return;
+}
+#endif
 
 static gboolean
 panel_toplevel_key_press_event (GtkWidget   *widget,
@@ -3665,6 +3787,18 @@ panel_toplevel_key_press_event (GtkWidget   *widget,
 
 	return FALSE;
 }
+
+#if GTK_CHECK_VERSION (3, 18, 0)
+static void
+panel_toplevel_state_flags_changed (GtkWidget     *widget,
+                                    GtkStateFlags  previous_state)
+{
+	GTK_WIDGET_CLASS (panel_toplevel_parent_class)->state_flags_changed (widget,
+	                                                                     previous_state);
+
+	set_background_default_style (widget);
+}
+#endif
 
 static gboolean
 panel_toplevel_motion_notify_event (GtkWidget      *widget,
@@ -4156,6 +4290,10 @@ panel_toplevel_style_updated (GtkWidget *widget)
 
 	if (GTK_WIDGET_CLASS (panel_toplevel_parent_class)->style_updated)
 		GTK_WIDGET_CLASS (panel_toplevel_parent_class)->style_updated (widget);
+
+#if GTK_CHECK_VERSION (3, 18, 0)
+	set_background_default_style (widget);
+#endif
 }
 #else
 panel_toplevel_style_set (GtkWidget *widget,
@@ -4438,6 +4576,9 @@ panel_toplevel_finalize (GObject *object)
 						      G_CALLBACK (panel_toplevel_drag_threshold_changed),
 						      toplevel);
 		toplevel->priv->gtk_settings = NULL;
+#if GTK_CHECK_VERSION (3, 18, 0)
+		panel_background_free (&toplevel->background);
+#endif
 	}
 
 	if (toplevel->priv->attached) {
@@ -4479,6 +4620,9 @@ panel_toplevel_class_init (PanelToplevelClass *klass)
 
 	widget_class->realize              = panel_toplevel_realize;
 	widget_class->unrealize            = panel_toplevel_unrealize;
+#if GTK_CHECK_VERSION (3, 18, 0)
+	widget_class->state_flags_changed  = panel_toplevel_state_flags_changed;
+#endif
 #if GTK_CHECK_VERSION (3, 0, 0)
 	widget_class->draw                 = panel_toplevel_draw;
 	widget_class->get_preferred_width  = panel_toplevel_get_preferred_width;
@@ -4492,6 +4636,10 @@ panel_toplevel_class_init (PanelToplevelClass *klass)
 	widget_class->size_allocate        = panel_toplevel_size_allocate;
 	widget_class->button_press_event   = panel_toplevel_button_press_event;
 	widget_class->button_release_event = panel_toplevel_button_release_event;
+#if GTK_CHECK_VERSION (3, 18, 0)
+	widget_class->configure_event      = panel_toplevel_configure_event;	
+#endif
+
 	widget_class->key_press_event      = panel_toplevel_key_press_event;
 	widget_class->motion_notify_event  = panel_toplevel_motion_notify_event;
 	widget_class->enter_notify_event   = panel_toplevel_enter_notify_event;
@@ -4908,9 +5056,22 @@ panel_toplevel_setup_widgets (PanelToplevel *toplevel)
 	gtk_widget_show(toplevel->priv->table);
 }
 
+#if GTK_CHECK_VERSION (3, 18, 0)
+static void
+background_changed (PanelBackground *background,
+                    PanelToplevel   *toplevel)
+{
+	panel_toplevel_update_edges (toplevel);
+	panel_widget_emit_background_changed (toplevel->priv->panel_widget);
+}
+
+#endif
 static void
 panel_toplevel_init (PanelToplevel *toplevel)
 {
+#if GTK_CHECK_VERSION (3, 18, 0)
+	GtkWidget *widget;
+#endif
 	int i;
 
 	toplevel->priv = PANEL_TOPLEVEL_GET_PRIVATE (toplevel);
@@ -4992,14 +5153,20 @@ panel_toplevel_init (PanelToplevel *toplevel)
 	toplevel->priv->attach_hidden     = FALSE;
 	toplevel->priv->updated_geometry_initial = FALSE;
 	toplevel->priv->initial_animation_done   = FALSE;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	widget = GTK_WIDGET (toplevel);
+	gtk_widget_add_events (widget,
+#else
 	gtk_widget_add_events (GTK_WIDGET (toplevel),
+#endif
 			       GDK_BUTTON_PRESS_MASK |
 			       GDK_BUTTON_RELEASE_MASK |
 			       GDK_POINTER_MOTION_MASK |
 			       GDK_ENTER_NOTIFY_MASK |
 			       GDK_LEAVE_NOTIFY_MASK);
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	gtk_widget_set_app_paintable (widget, TRUE);
+#endif
 	panel_toplevel_setup_widgets (toplevel);
 	panel_toplevel_update_description (toplevel);
 	panel_toplevel_update_gtk_settings (toplevel);
@@ -5010,7 +5177,12 @@ panel_toplevel_init (PanelToplevel *toplevel)
 	 * happens with "alternative" window managers such as Sawfish or XFWM4.
 	 */
 	g_signal_connect(GTK_WIDGET(toplevel), "delete-event", G_CALLBACK(gtk_true), NULL);
-	
+
+#if GTK_CHECK_VERSION (3, 18, 0)
+	panel_background_init (&toplevel->background,
+			       (PanelBackgroundChangedNotify) background_changed,
+			       toplevel);	
+#endif	
 #if GTK_CHECK_VERSION (3, 0, 0) 	
 	/*ensure the panel BG can always be themed*/
 	/*Without this gtk3.19/20 cannot set the BG color and resetting the bg to system is not immediately applied*/

--- a/mate-panel/panel-toplevel.h
+++ b/mate-panel/panel-toplevel.h
@@ -27,7 +27,11 @@
 
 #include <gtk/gtk.h>
 
+#include "panel-background.h"
+
+#if GTK_CHECK_VERSION (3, 18, 0)
 #include "panel-enums.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,7 +60,9 @@ struct _PanelToplevel {
 	GSettings             *settings;
 	GSettings             *queued_settings;
 	GSettings             *background_settings;
-
+#if GTK_CHECK_VERSION (3, 18, 0)
+	PanelBackground        background;
+#endif
 	PanelToplevelPrivate  *priv;
 };
 

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -159,7 +159,12 @@ back_change (AppletInfo  *info,
 	switch (info->type) {
 	case PANEL_OBJECT_APPLET:
 		mate_panel_applet_frame_change_background (
-			MATE_PANEL_APPLET_FRAME (info->widget), panel->background.type);
+
+#if GTK_CHECK_VERSION (3, 18, 0)
+		MATE_PANEL_APPLET_FRAME (info->widget), panel->toplevel->background.type);
+#else
+		MATE_PANEL_APPLET_FRAME (info->widget), panel->background.type);
+#endif
 		break;
 	case PANEL_OBJECT_MENU_BAR:
 		panel_menu_bar_change_background (PANEL_MENU_BAR (info->widget));


### PR DESCRIPTION
Rebase https://github.com/mate-desktop/mate-panel/pull/419 to current master,  then apply the panel-plug changes from https://github.com/mate-desktop/mate-panel/pull/415 to GTK 3.18 as well. These need to always be used together, as they render transparent backgrounds differently. 

Otherwise GTK 3.18 users get applets that are a different opacity than the panel if a transparent custom background (image or color) is used. This is because some versions (not the newest) of GTK 3.18 have issues of double application of an alpha value. Had trouble with that in my theme, and in testing I noticed that with compositing (my default) transparent images render darker than in GTK 3.16 or 3.20, at least this way the difference is all the way across panel and applets.

Note that this requires Glib 2.44 or later, but that is used all the way back to Ubuntu Vivid (15.04), meaning distros released in Spring 2015 or later. To break this would require GTK 3.18 (as in Ubuntu 16.04) or later plus mate-panel 1.14 in an older distro than that. Alternate approach would be to simply limit both the panel plug and panel background work to GTK 3.20 or later. That would work but sacrifice the reduction in applet crashes in GTK 3.18.  Only turning compositing on and off seems to crash applets when this is in use.

This change also permits GTK 3.18 builds to be used with GTK 3.20 with some themes or with a custom background. GTK 3.20 theme support elements are of course absent in such cases.

This branch fixes the temporary loss of custom panel backgrounds when changing GTK themes in GTK 3.20. Also stopped the applet crashes on theme change or loading the panel with a custom background applied, so applied it to GTK 3.18 as well. Do NOT apply it to GTK3.16 or earlier builds, as moving the panel background handling to the toplevel does not work with them.
Based on gnome-panel's
GNOME/gnome-panel@4774177
move background handling from PanelWidget to PanelToplevel
and
GNOME/gnome-panel@08e2e24
set rgba visual on PanelToplevel not PanelWidget 

Tested with a partially transparent image background, partially transparent color background, and theme background  in GTK 3.16, 3.18, and  3.20