### PR TITLE
fix missing focus for panel widgets

### DIFF
--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -460,6 +460,7 @@ panel_widget_class_init (PanelWidgetClass *class)
 	widget_class->style_set = panel_widget_style_set;
 #endif
 
+	widget_class->focus = panel_widget_real_focus;
 	container_class->add = panel_widget_cadd;
 	container_class->remove = panel_widget_cremove;
 }


### PR DESCRIPTION
credits and thanks to Joanmarie from orca project

fixes
partially https://github.com/mate-desktop/mate-panel/issues/441
https://github.com/mate-desktop/mate-panel/issues/440
https://github.com/mate-desktop/mate-panel/issues/444

@monsta @lukefromdc @coffeeking @Texou-
Please test, this is a urgent PR for mentioned reports.
I tested it it with both toolkit versions, and applets don't crash in gtk3 version if you change gtk theme if a custom background is selected, which was the intention for 9bf088c
