### PR TITLE
clock: remove useless duplication

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -640,8 +640,6 @@ update_clock (ClockData * cd)
 	gboolean use_markup;
         char *utf8;
 
-        use_markup = FALSE;
-
 	time (&cd->current_time);
         utf8 = format_time (cd);
 


### PR DESCRIPTION
Unless I'm missing something I don't see a reason for setting "use_markup = FALSE;" at 643 and then again at 648