### PR TITLE
avoid deprecated device_ungrab

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -936,6 +936,23 @@ mate_panel_applet_button_event (GtkWidget      *widget,
 	socket_window = gtk_plug_get_socket_window (GTK_PLUG (widget));
 
 	if (event->type == GDK_BUTTON_PRESS) {
+#if GTK_CHECK_VERSION (3, 0, 0)
+#if GTK_CHECK_VERSION (3, 20, 0)
+		GdkDisplay *display;
+		GdkSeat *seat;
+
+		xevent.xbutton.type = ButtonPress;
+
+		display = gdk_display_get_default ();
+		seat = gdk_display_get_default_seat (display);
+
+		/* X does an automatic pointer grab on button press
+		 * if we have both button press and release events
+		 * selected.
+		 * We don't want to hog the pointer on our parent.
+		 */
+		gdk_seat_ungrab (seat);
+#else
 		xevent.xbutton.type = ButtonPress;
 
 		/* X does an automatic pointer grab on button press
@@ -943,9 +960,16 @@ mate_panel_applet_button_event (GtkWidget      *widget,
 		 * selected.
 		 * We don't want to hog the pointer on our parent.
 		 */
-#if GTK_CHECK_VERSION (3, 0, 0)
 		gdk_device_ungrab (event->device, GDK_CURRENT_TIME);
+#endif
 #else
+		xevent.xbutton.type = ButtonPress;
+
+		/* X does an automatic pointer grab on button press
+		 * if we have both button press and release events
+		 * selected.
+		 * We don't want to hog the pointer on our parent.
+		 */
 		gdk_display_pointer_ungrab
 			(gtk_widget_get_display (widget),
 			 GDK_CURRENT_TIME);

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -488,10 +488,10 @@ mate_panel_applet_frame_button_changed (GtkWidget      *widget,
 	gboolean              handled = FALSE;
 #if GTK_CHECK_VERSION (3, 0, 0)
 	GdkDisplay *display;
-	GdkDevice *pointer;
 #if GTK_CHECK_VERSION (3, 20, 0)
 	GdkSeat *seat;
 #else
+	GdkDevice *pointer;
 	GdkDeviceManager *device_manager;
 #endif
 #endif
@@ -526,8 +526,7 @@ mate_panel_applet_frame_button_changed (GtkWidget      *widget,
 #if GTK_CHECK_VERSION(3, 20, 0)
 			display = gtk_widget_get_display (widget);
 			seat = gdk_display_get_default_seat (display);
-			pointer = gdk_seat_get_pointer (seat);
-			gdk_device_ungrab (pointer, GDK_CURRENT_TIME);
+			gdk_seat_ungrab (seat);
 #elif GTK_CHECK_VERSION (3, 0, 0)
 			display = gtk_widget_get_display (widget);
 			device_manager = gdk_display_get_device_manager (display);

--- a/mate-panel/panel-force-quit.c
+++ b/mate-panel/panel-force-quit.c
@@ -114,11 +114,11 @@ remove_popup (GtkWidget *popup)
 	GdkWindow        *root;
 #if GTK_CHECK_VERSION (3, 0, 0)
 	GdkDisplay       *display;
-	GdkDevice        *pointer;
-	GdkDevice        *keyboard;
 #if GTK_CHECK_VERSION (3, 20, 0)
 	GdkSeat          *seat;
 #else
+	GdkDevice        *pointer;
+	GdkDevice        *keyboard;
 	GdkDeviceManager *device_manager;
 #endif
 #endif
@@ -133,15 +133,16 @@ remove_popup (GtkWidget *popup)
 	display = gdk_window_get_display (root);
 #if GTK_CHECK_VERSION (3, 20, 0)
 	seat = gdk_display_get_default_seat (display);
-	pointer = gdk_seat_get_pointer (seat);
+
+	gdk_seat_ungrab (seat);
 #else
 	device_manager = gdk_display_get_device_manager (display);
 	pointer = gdk_device_manager_get_client_pointer (device_manager);
-#endif
 	keyboard = gdk_device_get_associated_device (pointer);
 
 	gdk_device_ungrab (pointer, GDK_CURRENT_TIME);
 	gdk_device_ungrab (keyboard, GDK_CURRENT_TIME);
+#endif
 #else
 	gdk_pointer_ungrab (GDK_CURRENT_TIME);
 	gdk_keyboard_ungrab (GDK_CURRENT_TIME);

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -2095,10 +2095,10 @@ panel_widget_applet_drag_start (PanelWidget *panel,
 		GdkCursor     *fleur_cursor;
 #if GTK_CHECK_VERSION (3, 0, 0)
 		GdkDisplay *display;
-		GdkDevice *pointer;
 #if GTK_CHECK_VERSION(3, 20, 0)
 		GdkSeat *seat;
 #else
+		GdkDevice *pointer;
 		GdkDeviceManager *device_manager;
 #endif
 #endif
@@ -2110,15 +2110,17 @@ panel_widget_applet_drag_start (PanelWidget *panel,
 		display = gdk_window_get_display (window);
 #if GTK_CHECK_VERSION(3, 20, 0)
 		seat = gdk_display_get_default_seat (display);
-		pointer = gdk_seat_get_pointer (seat);
+
+		status = gdk_seat_grab (seat, window, GDK_SEAT_CAPABILITY_POINTER,
+		                        FALSE, fleur_cursor, NULL, NULL, NULL);
 #else
 		device_manager = gdk_display_get_device_manager (display);
 		pointer = gdk_device_manager_get_client_pointer (device_manager);
-#endif
 		status = gdk_device_grab (pointer, window,
 					  GDK_OWNERSHIP_NONE, FALSE,
 					  APPLET_EVENT_MASK,
 					  fleur_cursor, time_);
+#endif
 
 		g_object_unref (fleur_cursor);
 #else
@@ -2142,7 +2144,6 @@ panel_widget_applet_drag_end (PanelWidget *panel)
 {
 #if GTK_CHECK_VERSION(3, 20, 0)
 	GdkDisplay *display;
-	GdkDevice *pointer;
 	GdkSeat *seat;
 #elif GTK_CHECK_VERSION (3, 0, 0)
 	GdkDisplay *display;
@@ -2157,9 +2158,8 @@ panel_widget_applet_drag_end (PanelWidget *panel)
 #if GTK_CHECK_VERSION(3, 20, 0)
 	display = gtk_widget_get_display (GTK_WIDGET (panel));
 	seat = gdk_display_get_default_seat (display);
-	pointer = gdk_seat_get_pointer (seat);
 
-	gdk_device_ungrab (pointer, GDK_CURRENT_TIME);
+	gdk_seat_ungrab (seat);
 #elif GTK_CHECK_VERSION (3, 0, 0)
 	display = gtk_widget_get_display (GTK_WIDGET (panel));
 	device_manager = gdk_display_get_device_manager (display);


### PR DESCRIPTION
Gtk_Seat is already used but this way it fixes also deprecated device_ungrab.
Taken from https://git.gnome.org/browse/gnome-panel/log/?qt=grep&q=device
Also, some Gtk_Version_Checks are corrected from previous commits.
See, https://github.com/mate-desktop/mate-panel/pull/466