### PR TITLE
Calendar Window: force minimum size

### DIFF
--- a/applets/clock/calendar-window.c
+++ b/applets/clock/calendar-window.c
@@ -123,6 +123,9 @@ calendar_window_create_calendar (CalendarWindow *calwin)
 	struct tm                  tm1;
 
 	calendar = gtk_calendar_new ();
+	#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_widget_set_size_request(GTK_WIDGET(calendar), 260, 100);
+	#endif
 	options = gtk_calendar_get_display_options (GTK_CALENDAR (calendar));
 	if (calwin->priv->show_weeks)
 		options |= GTK_CALENDAR_SHOW_WEEK_NUMBERS;


### PR DESCRIPTION
Force minimum width for calendar window to stop jumping (on locations open/close) in themes that don't enlarge calendar from the rather small default. Set the minimum height smaller than any theme would set it as it otherwise just puts blank space under the last row rather than spacing out the numbers.

Fix for https://github.com/mate-desktop/mate-panel/issues/491