### PR TITLE
Fix most GTK warnings from mate-panel

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1256,6 +1256,8 @@ do_not_eat_button_press (GtkWidget      *widget,
    jumping when proportional fonts are used.  We must take care to
    call "unfix_size" whenever options are changed or such where
    we'd want to forget the fixed size */
+/*FIXME-this cannot be used because size request gsignal invalid for label */
+/*
 static void
 clock_size_request (GtkWidget *clock, GtkRequisition *req, gpointer data)
 {
@@ -1268,7 +1270,7 @@ clock_size_request (GtkWidget *clock, GtkRequisition *req, gpointer data)
         req->width = cd->fixed_width;
         req->height = cd->fixed_height;
 }
-
+*/
 static void
 clock_update_text_gravity (GtkWidget *label)
 {
@@ -1328,9 +1330,12 @@ create_main_clock_label (ClockData *cd)
         GtkWidget *label;
 
         label = gtk_label_new (NULL);
+/*Fixme-this is invalid for labels with any recent GTK3 version, maybe all of them*/
+/*
         g_signal_connect (label, "size_request",
                           G_CALLBACK (clock_size_request),
                           cd);
+*/
         g_signal_connect_swapped (label, "style_set",
                                   G_CALLBACK (unfix_size),
                                   cd);

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1286,7 +1286,6 @@ clock_update_text_gravity (GtkWidget *label)
 static inline void
 force_no_button_padding (GtkWidget *widget)
 {
-        static gboolean first_time = TRUE;
         GtkCssProvider  *provider;
 
         provider = gtk_css_provider_new ();

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1282,7 +1282,28 @@ clock_update_text_gravity (GtkWidget *label)
         pango_context_set_base_gravity (context, PANGO_GRAVITY_AUTO);
 }
 
-#if !GTK_CHECK_VERSION (3, 20, 0)
+#if GTK_CHECK_VERSION (3, 20, 0)
+static inline void
+force_no_button_padding (GtkWidget *widget)
+{
+        static gboolean first_time = TRUE;
+        GtkCssProvider  *provider;
+
+        provider = gtk_css_provider_new ();
+        gtk_css_provider_load_from_data (provider,
+                                         "#clock-applet-button {\n"
+                                         " padding: 0px;\n"
+                                         " margin: 0px;\n }",
+                                         -1, NULL);
+        gtk_style_context_add_provider (gtk_widget_get_style_context (widget),
+                                        GTK_STYLE_PROVIDER (provider),
+                                        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+        g_object_unref (provider);
+
+
+        gtk_widget_set_name (widget, "clock-applet-button");
+}
+#else
 static inline void
 force_no_focus_padding (GtkWidget *widget)
 {
@@ -1316,7 +1337,7 @@ create_main_clock_button (void)
         gtk_button_set_relief (GTK_BUTTON (button), GTK_RELIEF_NONE);
 
 #if GTK_CHECK_VERSION (3, 20, 0)
-        gtk_widget_set_name (button, "clock-applet-button");
+         force_no_button_padding (button);
 #else
         force_no_focus_padding (button);
 #endif

--- a/applets/wncklet/showdesktop.c
+++ b/applets/wncklet/showdesktop.c
@@ -387,9 +387,7 @@ gboolean show_desktop_applet_fill(MatePanelApplet* applet)
 	GtkActionGroup* action_group;
 	gchar* ui_path;
 	AtkObject* atk_obj;
-#if !GTK_CHECK_VERSION (3, 20, 0)
 	GtkCssProvider *provider;
-#endif
 
 	mate_panel_applet_set_flags(applet, MATE_PANEL_APPLET_EXPAND_MINOR);
 
@@ -419,8 +417,20 @@ gboolean show_desktop_applet_fill(MatePanelApplet* applet)
 	sdd->button = gtk_toggle_button_new ();
 
 	gtk_widget_set_name (sdd->button, "showdesktop-button");
-#if !GTK_CHECK_VERSION (3, 20, 0)
-	provider = gtk_css_provider_new ();
+    provider = gtk_css_provider_new ();
+#if GTK_CHECK_VERSION (3, 20, 0)
+	gtk_css_provider_load_from_data (provider,
+					 "#showdesktop-button {\n"
+                     "border-width: 0px; \n" /*a border here causes GTK warnings */
+					 " padding: 0px;\n"
+					 " margin: 0px; }",
+					 -1, NULL);
+
+	gtk_style_context_add_provider (gtk_widget_get_style_context (sdd->button),
+					GTK_STYLE_PROVIDER (provider),
+					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+					g_object_unref (provider);
+#else
 	gtk_css_provider_load_from_data (provider,
 					 "#showdesktop-button {\n"
 					 " -GtkWidget-focus-line-width: 0px;\n"

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -384,10 +384,25 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 	TasklistData* tasklist;
 	GtkActionGroup* action_group;
 	gchar* ui_path;
+    GtkCssProvider  *provider;
+    GdkScreen *screen;
 
 	tasklist = g_new0(TasklistData, 1);
 
 	tasklist->applet = GTK_WIDGET(applet);
+
+    provider = gtk_css_provider_new ();
+    screen = gdk_screen_get_default ();
+    gtk_css_provider_load_from_data (provider,
+                                         ".mate-panel-menu-bar button,\n"
+                                         " #tasklist-button {\n"
+                                         " padding: 0px;\n"
+                                         " margin: 0px;\n }",
+                                         -1, NULL);
+    gtk_style_context_add_provider_for_screen (screen,
+                                        GTK_STYLE_PROVIDER (provider),
+                                        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    g_object_unref (provider);
 
 	mate_panel_applet_set_flags(MATE_PANEL_APPLET(tasklist->applet), MATE_PANEL_APPLET_EXPAND_MAJOR | MATE_PANEL_APPLET_EXPAND_MINOR | MATE_PANEL_APPLET_HAS_HANDLE);
 

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -384,25 +384,25 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 	TasklistData* tasklist;
 	GtkActionGroup* action_group;
 	gchar* ui_path;
-    GtkCssProvider  *provider;
-    GdkScreen *screen;
+	GtkCssProvider  *provider;
+	GdkScreen *screen;
 
 	tasklist = g_new0(TasklistData, 1);
 
 	tasklist->applet = GTK_WIDGET(applet);
 
-    provider = gtk_css_provider_new ();
-    screen = gdk_screen_get_default ();
-    gtk_css_provider_load_from_data (provider,
-                                         ".mate-panel-menu-bar button,\n"
-                                         " #tasklist-button {\n"
-                                         " padding: 0px;\n"
-                                         " margin: 0px;\n }",
-                                         -1, NULL);
-    gtk_style_context_add_provider_for_screen (screen,
-                                        GTK_STYLE_PROVIDER (provider),
-                                        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-    g_object_unref (provider);
+	provider = gtk_css_provider_new ();
+	screen = gdk_screen_get_default ();
+	gtk_css_provider_load_from_data (provider,
+										".mate-panel-menu-bar button,\n"
+										" #tasklist-button {\n"
+										" padding: 0px;\n"
+										" margin: 0px;\n }",
+										-1, NULL);
+	gtk_style_context_add_provider_for_screen (screen,
+										GTK_STYLE_PROVIDER (provider),
+										GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+	g_object_unref (provider);
 
 	mate_panel_applet_set_flags(MATE_PANEL_APPLET(tasklist->applet), MATE_PANEL_APPLET_EXPAND_MAJOR | MATE_PANEL_APPLET_EXPAND_MINOR | MATE_PANEL_APPLET_HAS_HANDLE);
 


### PR DESCRIPTION
This stops most GTK warnings from the panel itself, except that themes putting a non-zero width border on the clock button will still throw a 1px underallocation warning.  With no border there no warnings from clock but themers should not lose this. The rest of the warnings from the panel itself are gone. 