### PR TITLE
Add (optional) support for menulibre.

### DIFF
--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -355,7 +355,7 @@ static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int positio
 	mate_panel_applet_add_callback(menubar->priv->info, "help", GTK_STOCK_HELP, _("_Help"), NULL);
 
 	/* Menu editors */
-	if (!panel_lockdown_get_locked_down () && (panel_is_program_in_path("mozo") || panel_is_program_in_path("matemenu-simple-editor")))
+	if (!panel_lockdown_get_locked_down () && (panel_is_program_in_path("mozo") || panel_is_program_in_path("menulibre")))
 	{
 		mate_panel_applet_add_callback (menubar->priv->info, "edit", NULL, _("_Edit Menus"), NULL);
 	}
@@ -402,12 +402,12 @@ void panel_menu_bar_invoke_menu(PanelMenuBar* menubar, const char* callback_name
 	{
 		GError* error = NULL;
 
-		panel_launch_desktop_file_with_fallback("mozo.desktop", "mozo", screen, &error);
+		panel_launch_desktop_file_with_fallback("menulibre.desktop", "menulibre", screen, &error);
 
 		if (error)
 		{
 			g_error_free(error);
-			panel_launch_desktop_file_with_fallback("matemenu-simple-editor.desktop", "matemenu-simple-editor", screen, NULL);
+			panel_launch_desktop_file_with_fallback("mozo.desktop", "mozo", screen, NULL);
 		}
 	}
 }

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -667,7 +667,7 @@ panel_menu_button_load (const char  *menu_path,
 
         if (!panel_lockdown_get_locked_down () &&
             (panel_is_program_in_path ("mozo") ||
-	    panel_is_program_in_path ("matemenu-simple-editor")))
+	    panel_is_program_in_path ("menulibre")))
 		mate_panel_applet_add_callback (info, "edit", NULL,
 					   _("_Edit Menus"), NULL);
 
@@ -988,14 +988,14 @@ panel_menu_button_invoke_menu (PanelMenuButton *button,
 	} else if (!strcmp (callback_name, "edit")) {
                 GError *error = NULL;
 
-		panel_launch_desktop_file_with_fallback ("mozo.desktop",
-							 "mozo",
+		panel_launch_desktop_file_with_fallback ("menulibre.desktop",
+							 "menulibre",
 							 screen, &error);
 		if (error) {
 			g_error_free (error);
 			panel_launch_desktop_file_with_fallback (
-						"matemenu-simple-editor.desktop",
-						"matemenu-simple-editor",
+						"mozo.desktop",
+						"mozo",
 						screen, NULL);
 		}
 	}


### PR DESCRIPTION
This patch re-purposes the existing fallback support for the now obsolete
`matemenu-simple-editor` to add (optional) support for [menulibre](https://smdavis.us/projects/menulibre/). The logic is simple, if `menulibre` is installed use it in preference to `mozo`. If `menulibre` is not available, fallback to `mozo`.

The rationale is this; if you've installed `menulibre` you want to use it in preference to `mozo`. Menulibre offers a super-set of menu editing capabilities compared to `mozo` and is growing in popularity. This change will allow distro maintainers to chose which menu editor they want to offer.