### PR TITLE
notification area: Fix system tray icons forced ordering

### DIFF
--- a/applets/notification_area/system-tray/na-tray-child.c
+++ b/applets/notification_area/system-tray/na-tray-child.c
@@ -327,11 +327,11 @@ static const struct
   NaItemCategory category;
 } wmclass_categories[] = {
   /* order is LTR, so higher category and higher ASCII ordering on the right */
-  { "Mate-power-manager",         "~01-battery",   NA_ITEM_CATEGORY_HARDWARE },
-  { "Nm-applet",                  "~02-network",   NA_ITEM_CATEGORY_HARDWARE },
+  { "keyboard",                   "~01-keyboard",  NA_ITEM_CATEGORY_HARDWARE },
+  { "Mate-volume-control-applet", "~02-volume",    NA_ITEM_CATEGORY_HARDWARE },
   { "Bluetooth-applet",           "~03-bluetooth", NA_ITEM_CATEGORY_HARDWARE },
-  { "Mate-volume-control-applet", "~04-volume",    NA_ITEM_CATEGORY_HARDWARE },
-  { "keyboard",                   "~05-keyboard",  NA_ITEM_CATEGORY_HARDWARE },
+  { "Nm-applet",                  "~04-network",   NA_ITEM_CATEGORY_HARDWARE },
+  { "Mate-power-manager",         "~05-battery",   NA_ITEM_CATEGORY_HARDWARE },
 };
 
 static const gchar *


### PR DESCRIPTION
The order was reversed when porting from the previous sorting method.

Part of #521.