### PR TITLE
setup custom icon

### DIFF
--- a/mate-panel/launcher.c
+++ b/mate-panel/launcher.c
@@ -738,6 +738,8 @@ launcher_saved (GtkWidget *dialog,
 	location = g_filename_from_uri (uri, NULL, NULL);
 	launcher->app_info = g_desktop_app_info_new_from_filename (location);
 	g_free (location);
+
+	setup_button (launcher);
 }
 
 static void

--- a/mate-panel/panel-ditem-editor.c
+++ b/mate-panel/panel-ditem-editor.c
@@ -919,9 +919,12 @@ static void
 panel_ditem_editor_icon_changed (PanelDItemEditor *dialog,
 				 const char       *icon)
 {
-	if (icon)
+	if (icon) {
+		panel_key_file_set_string (dialog->priv->key_file,
+						  "Icon", icon);
 		panel_key_file_set_locale_string (dialog->priv->key_file,
 						  "Icon", icon);
+	}
 	else
 		panel_key_file_remove_all_locale_key (dialog->priv->key_file,
 						      "Icon");


### PR DESCRIPTION
restore ability to configure launcher's custom icon which degradated after switching on g_app_info_get_icon
also update launcher state after saving launcher's properties.

https://github.com/mate-desktop/mate-panel/issues/538