### PR TITLE
properly fit expanded panel to smaller screen size

### DIFF
--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1285,15 +1285,7 @@ panel_widget_get_preferred_size(GtkWidget	     *widget,
 		g_free (panel->applets_using_hint);
 	panel->applets_using_hint = NULL;
 
-	if (!panel->packed) {
-		if (panel->orient == GTK_ORIENTATION_HORIZONTAL) {
-			minimum_size->width = panel->size;
-			natural_size->width = panel->size;
-		} else {
-			minimum_size->height = panel->size;
-			natural_size->height = panel->size;
-		}
-	} else {
+	if (panel->packed) {
 		/* put the list in the correct order: this is important
 		 * since we'll use this order in the size_allocate() */
 		ad_with_hints = g_list_reverse (ad_with_hints);


### PR DESCRIPTION
when changing panel orientation or rotating the screen itself,
panel might keep its old size, so some applets might appear
behind screen edge (until you restart the panel). same thing
might happen when enabling hide buttons.

fixes https://github.com/mate-desktop/mate-panel/issues/552

upstream commit with detailed problem description:
https://git.gnome.org/browse/gnome-panel/commit/?id=fc24d8fa623c4cf841eb5168cb1c250b4a84d4da

upstream commit with the actual fix:
https://git.gnome.org/browse/gnome-panel/commit/?id=4511f4466df0b163906794b4a32196226ccf90f3

yes, it's somewhat messed up there :)