### PR TITLE
Run dialog: Fix wrong history order

### DIFF
--- a/mate-panel/panel-run-dialog.c
+++ b/mate-panel/panel-run-dialog.c
@@ -132,7 +132,7 @@ _panel_run_get_recent_programs_list (PanelRunDialog *dialog)
 	     items[i] && i < PANEL_RUN_MAX_HISTORY;
 	     i++) {
 		GtkTreeIter iter;
-		gtk_list_store_prepend (list, &iter);
+		gtk_list_store_append (list, &iter);
 		gtk_list_store_set (list, &iter, 0, items[i], -1);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/mate-panel/issues/559.

Initially the `org.mate.panel.general.history-mate-run` key was saved with
the most recent command last. In combination with wrong code this led to
scrambling the history.

This commit changes the history storage in a way that most recent
elements are stored first. The code adapts to this change by changing
only one function to prepend instead of append in the list store. (Any
old histories might therefore be wrong for a short time, but that's
probably worth it to fix this bug.)