### PR TITLE
Run dialog: Allow changing history size

### DIFF
--- a/data/org.mate.panel.gschema.xml.in
+++ b/data/org.mate.panel.gschema.xml.in
@@ -23,7 +23,12 @@
     <key name="history-mate-run" type="as">
       <default>[]</default>
       <summary>History for "Run Application" dialog</summary>
-      <description>This is the list of commands used in "Run Application" dialog.</description>
+      <description>This is the list of commands used in "Run Application" dialog. The commands are sorted descendingly by recency (e.g., most recent command comes first).</description>
+    </key>
+    <key name="history-max-size-mate-run" type="u">
+      <default>10</default>
+      <summary>Maximum history size for "Run Application" dialog</summary>
+      <description>Controls the maximum size of the history of the "Run Application" dialog. A value of 0 will disable the history.</description>
     </key>
     <key name="toplevel-id-list" type="as">
       <default>[]</default>

--- a/mate-panel/panel-run-dialog.c
+++ b/mate-panel/panel-run-dialog.c
@@ -155,31 +155,30 @@ _panel_run_save_recent_programs_list (PanelRunDialog   *dialog,
 
 	history_max_size = g_settings_get_uint (dialog->settings, PANEL_RUN_HISTORY_MAX_SIZE_KEY);
 
+	items = g_array_new (TRUE, TRUE, sizeof (gchar *));
 	if (history_max_size > 0) {
-		items = g_array_new (TRUE, TRUE, sizeof (gchar *));
 		g_array_append_val (items, lastcommand);
 		i++;
 
 		model = gtk_combo_box_get_model (GTK_COMBO_BOX (entry));
 
-		if (gtk_tree_model_get_iter_first (model, &iter)) {
-			char *command;
-			do {
-				gtk_tree_model_get (model, &iter, 0, &command, -1);
-				if (g_strcmp0 (command, lastcommand) == 0)
-					continue;
-				g_array_append_val (items, command);
-				i++;
-			} while (gtk_tree_model_iter_next (model, &iter) &&
-				 i < history_max_size);
+		if (history_max_size > 1) {
+			if (gtk_tree_model_get_iter_first (model, &iter)) {
+				char *command;
+				do {
+					gtk_tree_model_get (model, &iter, 0, &command, -1);
+					if (g_strcmp0 (command, lastcommand) == 0)
+						continue;
+					g_array_append_val (items, command);
+					i++;
+				} while (gtk_tree_model_iter_next (model, &iter) &&
+					 i < history_max_size);
+			}
 		}
-
-		g_settings_set_strv (dialog->settings, PANEL_RUN_HISTORY_KEY,
-				     (const gchar **) items->data);
-
-		g_array_free (items, TRUE);
-
 	}
+	g_settings_set_strv (dialog->settings, PANEL_RUN_HISTORY_KEY,
+			     (const gchar **) items->data);
+	g_array_free (items, TRUE);
 }
 
 static void


### PR DESCRIPTION
A key has been added to the gsettings schema that controls history size and the code of the run dialog has been changed to use that key. The default of 10 is preserved and the setting is only exposed via gsettings.

Note that this *pull request* includes https://github.com/mate-desktop/mate-panel/pull/560 because it is based on it.