### PR TITLE
status notifier: follow same menu theme as rest of panel

### DIFF
--- a/applets/notification_area/status-notifier/sn-dbus-menu.c
+++ b/applets/notification_area/status-notifier/sn-dbus-menu.c
@@ -352,9 +352,24 @@ static void
 sn_dbus_menu_constructed (GObject *object)
 {
   SnDBusMenu *menu;
+  GtkWidget *toplevel;
+  GdkScreen *screen;
+  GdkVisual *visual;
+  GtkStyleContext *context;
 
   G_OBJECT_CLASS (sn_dbus_menu_parent_class)->constructed (object);
   menu = SN_DBUS_MENU (object);
+
+  /*Set up theme and transparency support*/
+  toplevel = gtk_widget_get_toplevel(GTK_WIDGET(menu));
+  /* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+  screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+  visual = gdk_screen_get_rgba_visual(screen);
+  gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+  /* Set menu and it's toplevel window to follow panel theme */
+  context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+  gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+  gtk_style_context_add_class(context,"mate-panel-menu-bar");
 
   menu->name_id = g_bus_watch_name (G_BUS_TYPE_SESSION, menu->bus_name,
                                     G_BUS_NAME_WATCHER_FLAGS_NONE,


### PR DESCRIPTION
Support any menu theme set up for the panel's menus differing from the rest of the Gtk theme using the .mate-panel-menu-bar style class Without this, anything using the status notifier will have mismatched menus if the GTK theme sets a different menu style for the panel (as mine does)

Tested with the "drop all elevated privileges" menu from mate-polkit built with appindicator support, which has an unrelated issue with the status icon (not the menu) not disappearing after dropping priviliges
https://github.com/mate-desktop/mate-polkit/issues/35

 Needs testing with another program using it, preferably one producing multiple menu items