### PR TITLE
mate-panel: Dynamically apply a wmclass to control panel shadow

### DIFF
--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -544,6 +544,13 @@ panel_profile_load_background (PanelToplevel *toplevel)
 
 	image = get_background_image (toplevel, &fit, &stretch, &rotate);
 
+	/* Only allow transparency for non themed panels */
+	if (background_type == PANEL_BACK_NONE)
+		panel_toplevel_update_wmclass (toplevel, FALSE);
+	else
+		panel_toplevel_update_wmclass (toplevel, TRUE);
+
+
 	panel_background_set (background,
 			      background_type,
 			      &color,
@@ -832,6 +839,12 @@ panel_profile_background_change_notify (GSettings *settings,
 		background_type = g_settings_get_enum (settings, key);
 		panel_background_set_type (background, background_type);
 		panel_toplevel_update_edges (toplevel);
+		/* Only allow transparency for non themed panels */
+		if (background_type == PANEL_BACK_NONE)
+			panel_toplevel_update_wmclass (toplevel, FALSE);
+		else
+			panel_toplevel_update_wmclass (toplevel, TRUE);
+
 	} else if (!strcmp (key, "color")) {
 		GdkRGBA color;
 		gchar *str;

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -197,6 +197,9 @@ struct _PanelToplevelPrivate {
 	guint                   updated_geometry_initial : 1;
 	/* flag to see if we have done the initial animation */
 	guint                   initial_animation_done : 1;
+
+        /* wm_class set dynamically to control shadows in marco */
+	const gchar             *panel_wmclass;
 };
 
 enum {
@@ -5606,4 +5609,23 @@ panel_toplevel_get_maximum_size (PanelToplevel *toplevel)
 		return monitor_height / MAXIMUM_SIZE_SCREEN_RATIO;
 	else
 		return monitor_width / MAXIMUM_SIZE_SCREEN_RATIO;
+}
+
+void
+panel_toplevel_update_wmclass (PanelToplevel *toplevel, gboolean transparency)
+{
+	g_return_if_fail (PANEL_IS_TOPLEVEL (toplevel));
+
+	const gchar *target_wmclass = transparency ? PACKAGE_NAME "-alpha" : PACKAGE_NAME;
+
+	if (toplevel->priv->panel_wmclass == target_wmclass || gtk_widget_get_visible (GTK_WIDGET (toplevel)))
+		return;
+
+	toplevel->priv->panel_wmclass = target_wmclass;
+
+	/* We can only change the wmclass once and this is done at startup, as we're
+	 * not able to unrealize the window. */
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	gtk_window_set_wmclass (GTK_WINDOW (toplevel), target_wmclass, target_wmclass);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 }

--- a/mate-panel/panel-toplevel.h
+++ b/mate-panel/panel-toplevel.h
@@ -180,6 +180,8 @@ int                  panel_toplevel_get_minimum_size       (PanelToplevel *tople
 int                  panel_toplevel_get_maximum_size       (PanelToplevel *toplevel);
 GSList              *panel_toplevel_list_toplevels         (void);
 
+void                 panel_toplevel_update_wmclass         (PanelToplevel *tpolevel, gboolean transparency);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
In order to further facilitate mate-desktop/marco#327, this change
will dynamically set the wmclass on each panel start to one respecting
alpha settings.

That is to say, in only the themed (PANEL_BACK_NONE) mode, do we want
to actually have a shadow on mate-panel. To do this, we'll maintain
the "mate-panel" wmclass, which will be dealt with by Marco on map.
For all other cases we'll change the wmclass to "mate-panel-alpha"
to indicate that we're an RGBA window with non theme styling, and
as such do not expect any shadowing.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>