### PR TITLE
GTK 3.18+ Make transparent panel BG set in GTK theme work again

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1538,7 +1538,8 @@ mate_panel_applet_change_background(MatePanelApplet *applet,
 	_mate_panel_applet_apply_css(GTK_WIDGET(applet->priv->plug),type);
 	switch (type) {
 	case PANEL_NO_BACKGROUND:
-		gdk_window_set_background_pattern(window,NULL);
+		pattern = cairo_pattern_create_rgba (0,0,0,0);     /* Using NULL here breaks transparent */
+		gdk_window_set_background_pattern(window,pattern); /* backgrounds set by GTK theme */
 		break;
 	case PANEL_COLOR_BACKGROUND:
 		gdk_window_set_background_rgba(window,color);


### PR DESCRIPTION
Transparent panel backgrounds set in GTK themes have not worked since the GTK 3.20 PanelPlug work. This was because NULL in gtk_window_set_background_pattern breaks on alpha values. Force this transparent and the GTK background is properly drawn

Fixes https://github.com/mate-desktop/mate-panel/issues/596