### PR TITLE
Make bg image set in GTK theme work

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1776,18 +1776,23 @@ static void _mate_panel_applet_prepare_css (GtkStyleContext *context)
 	GtkCssProvider  *provider;
 
 	provider = gtk_css_provider_new ();
+
 	gtk_css_provider_load_from_data (provider,
-					 ".mate-custom-panel-background{\n"
+					 "#PanelPlug {\n"
+					 " background-repeat: no-repeat;\n" /*disable in gtk theme features */
+					 " background-size: cover; "        /*that don't work on panel-toplevel */
+					 " }\n"
+					 ".mate-custom-panel-background{\n" /*prepare CSS for user set theme */
 					 " background-color: rgba (0, 0, 0, 0);\n"
 					 " background-image: none;\n"
 					 "}",
 					 -1, NULL);
+
 	gtk_style_context_add_provider (context,
 					GTK_STYLE_PROVIDER (provider),
 					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 	g_object_unref (provider);
 }
-
 static void
 mate_panel_applet_init (MatePanelApplet *applet)
 {

--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1776,7 +1776,7 @@ static void _mate_panel_applet_prepare_css (GtkStyleContext *context)
 	GtkCssProvider  *provider;
 
 	provider = gtk_css_provider_new ();
-
+#if GTK_CHECK_VERSION (3, 18, 0)
 	gtk_css_provider_load_from_data (provider,
 					 "#PanelPlug {\n"
 					 " background-repeat: no-repeat;\n" /*disable in gtk theme features */
@@ -1787,7 +1787,14 @@ static void _mate_panel_applet_prepare_css (GtkStyleContext *context)
 					 " background-image: none;\n"
 					 "}",
 					 -1, NULL);
-
+#else
+gtk_css_provider_load_from_data (provider,
+					 ".mate-custom-panel-background{\n" /*prepare CSS for user set theme */
+					 " background-color: rgba (0, 0, 0, 0);\n"
+					 " background-image: none;\n"
+					 "}",
+					 -1, NULL);
+#endif
 	gtk_style_context_add_provider (context,
 					GTK_STYLE_PROVIDER (provider),
 					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -112,7 +112,9 @@ panel_background_prepare (PanelBackground *background)
 			cairo_surface_t *surface;
 			double width, height;
 
+			surface = NULL;
 			cairo_pattern_get_surface(background->default_pattern, &surface);
+			cairo_surface_reference(surface);
 			width = cairo_image_surface_get_width (surface);
 			height = cairo_image_surface_get_height (surface);
 
@@ -124,6 +126,7 @@ panel_background_prepare (PanelBackground *background)
 
 			gdk_window_set_background_pattern (background->window,
 						       background->default_pattern);
+			cairo_surface_destroy(surface);
 		} else
 			gdk_window_set_background_rgba (
 				background->window, &background->default_color);

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -113,19 +113,32 @@ panel_background_prepare (PanelBackground *background)
 			double width, height;
 
 			surface = NULL;
+			width = 1.0;
+			height = 1.0;
 			cairo_pattern_get_surface(background->default_pattern, &surface);
-			cairo_surface_reference(surface);
-			width = cairo_image_surface_get_width (surface);
-			height = cairo_image_surface_get_height (surface);
+			/* catch invalid images (e.g. -gtk-gradient) before scaling and rendering */
+			if (surface != NULL ){
+				cairo_surface_reference(surface);
+				width = cairo_image_surface_get_width (surface);
+				height = cairo_image_surface_get_height (surface);
+				cairo_matrix_init_translate (&m, 0, 0);
+				cairo_matrix_scale (&m,
+						width / background->region.width,
+						height / background->region.height);
+				cairo_pattern_set_matrix (background->default_pattern, &m);
 
-			cairo_matrix_init_translate (&m, 0, 0);
-			cairo_matrix_scale (&m,
-					width / background->region.width,
-					height / background->region.height);
-			cairo_pattern_set_matrix (background->default_pattern, &m);
-
-			gdk_window_set_background_pattern (background->window,
-						       background->default_pattern);
+				gdk_window_set_background_pattern (background->window,
+											background->default_pattern);
+			}
+			else {
+				g_printerr ("%s\n",
+						("unsupported panel image background such as -gtk-gradient"));
+				g_printerr ("%s\n",
+						("use an image file or a standard css gradient"));
+				/* use any background color that has been set if image is invalid */
+				gdk_window_set_background_rgba (
+				background->window, &background->default_color);
+			}
 			cairo_surface_destroy(surface);
 		} else
 			gdk_window_set_background_rgba (

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -109,11 +109,17 @@ panel_background_prepare (PanelBackground *background)
 			* (gdk_window_clear_backing_region), the correctly
 			* scaled pattern is used */
 			cairo_matrix_t m;
+			cairo_surface_t *surface;
+			double width, height;
+
+			cairo_pattern_get_surface(background->default_pattern, &surface);
+			width = cairo_image_surface_get_width (surface);
+			height = cairo_image_surface_get_height (surface);
 
 			cairo_matrix_init_translate (&m, 0, 0);
 			cairo_matrix_scale (&m,
-					    1.0 / background->region.width,
-					    1.0 / background->region.height);
+					width / background->region.width,
+					height / background->region.height);
 			cairo_pattern_set_matrix (background->default_pattern, &m);
 
 			gdk_window_set_background_pattern (background->window,

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -131,9 +131,9 @@ panel_background_prepare (PanelBackground *background)
 											background->default_pattern);
 			}
 			else {
-				g_printerr ("%s\n",
+				g_warning ("%s\n",
 						("unsupported panel image background such as -gtk-gradient"));
-				g_printerr ("%s\n",
+				g_warning ("%s\n",
 						("use an image file or a standard css gradient"));
 				/* use any background color that has been set if image is invalid */
 				gdk_window_set_background_rgba (


### PR DESCRIPTION
Make panel image backgrounds set in the GTK theme work, like they did in GTK2. Tested with all supported GTK3 major versions 4.14 through 3.22.  Both image and gradient backgrounds work, best rendering in recent GTK versions but all will work. Image file bg is stretched to fit, same as on a user-set image background.

Fixes https://github.com/mate-desktop/mate-panel/issues/595