### PR TITLE
System tray: fix hidden icons on image/transparent color BG

### DIFF
--- a/applets/notification_area/system-tray/na-tray-child.c
+++ b/applets/notification_area/system-tray/na-tray-child.c
@@ -76,7 +76,7 @@ na_tray_child_realize (GtkWidget *widget)
       gdk_window_set_composited (window, TRUE);
       cairo_pattern_destroy (transparent);
 
-      child->parent_relative_bg = TRUE;
+      child->parent_relative_bg = FALSE;
     }
   else if (visual == gdk_window_get_visual(gdk_window_get_parent(window)))
     {
@@ -589,7 +589,7 @@ na_tray_child_force_redraw (NaTrayChild *child)
 {
   GtkWidget *widget = GTK_WIDGET (child);
 
-  if (gtk_widget_get_mapped (widget) && child->parent_relative_bg)
+  if (gtk_widget_get_mapped (widget))
     {
 #if 1
       /* Sending an ExposeEvent might cause redraw problems if the

--- a/applets/notification_area/system-tray/na-tray-child.c
+++ b/applets/notification_area/system-tray/na-tray-child.c
@@ -76,7 +76,7 @@ na_tray_child_realize (GtkWidget *widget)
       gdk_window_set_composited (window, TRUE);
       cairo_pattern_destroy (transparent);
 
-      child->parent_relative_bg = FALSE;
+      child->parent_relative_bg = TRUE;
     }
   else if (visual == gdk_window_get_visual(gdk_window_get_parent(window)))
     {


### PR DESCRIPTION
Includes https://github.com/mate-desktop/mate-panel/pull/606 to support rendering GTK theme backgrounds on vertical panels by attaching the .vertical and .horizontal style classes to PanelPlugs as it is based on that branch.

Also force a relative background on na-tray child objects to force the icons to appear on a custom image background or in the case of a noncompositing WM a transparent color bg (which acts like an image BG). Fix https://github.com/mate-desktop/mate-panel/issues/585