### PR TITLE
libmate-panel-applet: Fix another potential source of applet crashes

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1329,6 +1329,8 @@ mate_panel_applet_get_pattern_from_pixmap (MatePanelApplet *applet,
 	cairo_t         *cr;
 	cairo_pattern_t *pattern;
 
+	pattern = NULL; /*Properly initialize this, otherwise crashes can occur*/
+
 	g_return_val_if_fail (PANEL_IS_APPLET (applet), NULL);
 
 	if (!gtk_widget_get_realized (GTK_WIDGET (applet)))


### PR DESCRIPTION
Properly initialize pattern, GNOME found this stopped applet crashes on bg change(though not the same crashes we just fixed)

https://github.com/GNOME/gnome-panel/commit/88b9beeb8ab69072fe6912af33c620143d17b0a3
We could return a random value from
panel_applet_get_pattern_from_pixmap(), and that was very nasty.
based on