### PR TITLE
Forces a window scale of 1 for the panel. Closes #621

### DIFF
--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -84,6 +84,9 @@ main (int argc, char **argv)
 
 	gtk_init (&argc, &argv);
 
+    /* FIXME: High dpi scaling does not work... */
+    gdk_x11_display_set_window_scale (gdk_display_get_default (), 1);
+
 	error = NULL;
 	if (!g_option_context_parse (context, &argc, &argv, &error)) {
 		g_printerr ("%s\n", error->message);


### PR DESCRIPTION
This pull request forces a specific window scale for `mate-panel`, instead of using the default or user configured scale.

Tested on a Dell XPS 15 with 3840 x 2160 and `GDK_SCALE=2` and `GDK_DPI_SCALE=0.5` exported to the Xsession. mate-panel dimensions are now correct.