### PR TITLE
don't use deprecated gtk_show_uri

### DIFF
--- a/applets/clock/clock-utils.c
+++ b/applets/clock/clock-utils.c
@@ -72,10 +72,13 @@ clock_utils_display_help (GtkWidget  *widget,
 		uri = g_strdup_printf ("help:%s/%s", doc_id, link_id);
 	else
 		uri = g_strdup_printf ("help:%s", doc_id);
-
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_show_uri_on_window (NULL, uri, 
+		gtk_get_current_event_time (), &error);
+#else
 	gtk_show_uri (gtk_widget_get_screen (widget), uri,
-		      gtk_get_current_event_time (), &error);
-
+		gtk_get_current_event_time (), &error);
+#endif
 	g_free (uri);
 
 	if (error &&

--- a/applets/fish/fish.c
+++ b/applets/fish/fish.c
@@ -151,10 +151,13 @@ static void show_help(FishApplet* fish, const char* link_id)
 		uri = g_strdup_printf ("help:%s/%s", FISH_HELP_DOC, link_id);
 	else
 		uri = g_strdup_printf ("help:%s", FISH_HELP_DOC);
-
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_show_uri_on_window (NULL, uri, 
+			  gtk_get_current_event_time (), &error);
+#else
 	gtk_show_uri (gtk_widget_get_screen (GTK_WIDGET (fish)), uri,
 		      gtk_get_current_event_time (), &error);
-
+#endif
 	g_free (uri);
 
 	if (error &&

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -104,9 +104,11 @@ static void help_cb(GtkAction* action, NaTrayApplet* applet)
 	#define NA_HELP_DOC "mate-user-guide"
 
 	uri = g_strdup_printf("help:%s/%s", NA_HELP_DOC, "panels-notification-area");
-
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_show_uri_on_window (NULL, uri, gtk_get_current_event_time (), &error);
+#else
 	gtk_show_uri(gtk_widget_get_screen(GTK_WIDGET(applet)), uri, gtk_get_current_event_time(), &error);
-
+#endif
 	g_free(uri);
 
 	if (error && g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))

--- a/applets/wncklet/wncklet.c
+++ b/applets/wncklet/wncklet.c
@@ -49,9 +49,11 @@ void wncklet_display_help(GtkWidget* widget, const char* doc_id, const char* lin
 		uri = g_strdup_printf("help:%s/%s", doc_id, link_id);
 	else
 		uri = g_strdup_printf("help:%s", doc_id);
-
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_show_uri_on_window (NULL, uri, gtk_get_current_event_time (), &error);
+#else
 	gtk_show_uri(gtk_widget_get_screen(widget), uri, gtk_get_current_event_time(), &error);
-
+#endif
 	g_free(uri);
 
 	if (error && g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED))

--- a/mate-panel/libpanel-util/panel-show.c
+++ b/mate-panel/libpanel-util/panel-show.c
@@ -177,9 +177,11 @@ gboolean panel_show_uri(GdkScreen* screen, const gchar* uri, guint32 timestamp, 
 	{
 		return panel_show_caja_search_uri(screen, uri, timestamp, error);
 	}
-
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_show_uri_on_window (NULL, uri,timestamp, &local_error);
+#else
 	gtk_show_uri(screen, uri, timestamp, &local_error);
-
+#endif
 	return _panel_show_handle_error(uri, screen, local_error, error);
 }
 
@@ -282,9 +284,11 @@ panel_show_help (GdkScreen    *screen,
 		uri = g_strdup_printf ("help:%s/%s", doc, link);
 	else
 		uri = g_strdup_printf ("help:%s", doc);
-
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_show_uri_on_window (NULL, uri, gtk_get_current_event_time (), &local_error);
+#else
 	gtk_show_uri (screen, uri, gtk_get_current_event_time (), &local_error);
-
+#endif
 	g_free (uri);
 
 	return _panel_show_help_handle_error (doc, screen, local_error, error);

--- a/mate-panel/libpanel-util/panel-show.h
+++ b/mate-panel/libpanel-util/panel-show.h
@@ -1,5 +1,6 @@
 /*
- * panel-show.h: a helper around gtk_show_uri
+ * panel-show.h: a helper around gtk_show_uri_on_window for gtk 3.22 
+ * or gtk_show_uri for gtk 3.20 and earlier
  *
  * Copyright (C) 2008 Novell, Inc.
  *


### PR DESCRIPTION
Tested on Debian Unstable. Uses NULL as the window, seems to work fine. Help tested from clock, window list, tray, fish, and panel context menu. Tested with applets both in and out of process and help always worked and never saw a redraw problem afterwards.