### PR TITLE
Add missing include.

### DIFF
--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -13,6 +13,7 @@
 #include <sys/wait.h>
 
 #include <glib/gi18n.h>
+#include <gtk/gtkx.h>
 
 #include <libegg/eggdesktopfile.h>
 #include <libegg/eggsmclient.h>

--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -13,7 +13,7 @@
 #include <sys/wait.h>
 
 #include <glib/gi18n.h>
-#include <gtk/gtkx.h>
+#include <gdk/gtdx.h>
 
 #include <libegg/eggdesktopfile.h>
 #include <libegg/eggsmclient.h>

--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -13,7 +13,7 @@
 #include <sys/wait.h>
 
 #include <glib/gi18n.h>
-#include <gdk/gtdx.h>
+#include <gdk/gdkx.h>
 
 #include <libegg/eggdesktopfile.h>
 #include <libegg/eggsmclient.h>


### PR DESCRIPTION
Fixes the build warning discussed here: 

  * https://github.com/mate-desktop/mate-panel/pull/624#issuecomment-321738661