### PR TITLE
avoid deprecated gdk_screen_get_monitor... functions:

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -909,7 +909,11 @@ position_calendar_popup (ClockData *cd)
         n = gdk_screen_get_n_monitors (screen);
 #endif
         for (i = 0; i < n; i++) {
+#if GTK_CHECK_VERSION (3, 22, 0)
+                gdk_monitor_get_geometry (gdk_display_get_monitor (display, i), &monitor);
+#else
                 gdk_screen_get_monitor_geometry (screen, i, &monitor);
+#endif
                 if (x >= monitor.x && x <= monitor.x + monitor.width &&
                     y >= monitor.y && y <= monitor.y + monitor.height) {
                         found_monitor = TRUE;

--- a/applets/notification_area/status-notifier/sn-item.c
+++ b/applets/notification_area/status-notifier/sn-item.c
@@ -194,7 +194,12 @@ sn_item_popup_menu_position_func (GtkMenu  *menu,
   GtkRequisition menu_req;
   GdkWindow     *window;
   GdkScreen     *screen;
+#if GTK_CHECK_VERSION (3, 22, 0)
+  GdkMonitor    *monitor_num;
+  GdkDisplay    *display;
+#else
   gint           monitor_num;
+#endif
   GdkRectangle   monitor;
 
   gtk_widget_get_allocation (widget, &widget_alloc);
@@ -207,8 +212,14 @@ sn_item_popup_menu_position_func (GtkMenu  *menu,
   *y += widget_alloc.y;
 
   screen = gtk_widget_get_screen (widget);
+#if GTK_CHECK_VERSION (3, 22, 0)
+  display = gdk_screen_get_display (screen);
+  monitor_num = gdk_display_get_monitor_at_point (display, *x, *y);
+  gdk_monitor_get_geometry (monitor_num, &monitor);
+#else
   monitor_num = gdk_screen_get_monitor_at_point (screen, *x, *y);
   gdk_screen_get_monitor_geometry (screen, monitor_num, &monitor);
+#endif
 
   /* put the menu on the left if we can't put it on the right */
   if (*x + menu_req.width > monitor.x + monitor.width)

--- a/mate-panel/panel-multiscreen.c
+++ b/mate-panel/panel-multiscreen.c
@@ -218,7 +218,11 @@ panel_multiscreen_get_gdk_monitors_for_screen (GdkScreen     *screen,
 	geometries = g_new (GdkRectangle, num_monitors);
 
 	for (i = 0; i < num_monitors; i++)
+#if GTK_CHECK_VERSION (3, 22, 0)
+		gdk_monitor_get_geometry (gdk_display_get_monitor (display, i), &(geometries[i]));
+#else
 		gdk_screen_get_monitor_geometry (screen, i, &(geometries[i]));
+#endif
 
 	*monitors_ret = num_monitors;
 	*geometries_ret = geometries;

--- a/mate-panel/xstuff.c
+++ b/mate-panel/xstuff.c
@@ -335,7 +335,12 @@ xstuff_zoom_animate (GtkWidget *widget,
 	GdkScreen *gscreen;
 	GdkRectangle rect, dest;
 	GtkAllocation allocation;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor *monitor;
+	GdkDisplay *display;
+#else
 	int monitor;
+#endif
 
 	if (opt_rect)
 		rect = *opt_rect;
@@ -358,9 +363,16 @@ xstuff_zoom_animate (GtkWidget *widget,
 						rect.width, rect.height,
 						pixbuf, orientation);
 	else {
+#if GTK_CHECK_VERSION (3, 22, 0)
+		display = gdk_screen_get_display (gscreen);
+		monitor = gdk_display_get_monitor_at_window (display,
+							     gtk_widget_get_window (widget));
+		gdk_monitor_get_geometry (monitor, &dest);
+#else
 		monitor = gdk_screen_get_monitor_at_window (gscreen,
 							    gtk_widget_get_window (widget));
 		gdk_screen_get_monitor_geometry (gscreen, monitor, &dest);
+#endif
 
 		draw_zoom_animation (gscreen,
 				     rect.x, rect.y, rect.width, rect.height,


### PR DESCRIPTION
avoid deprecated:

gdk_screen_get_monitor_geometry
gdk_screen_get_monitor_at_window
gdk_screen_get_monitor_at_point