### PR TITLE
Fix crashes on moving/removing applets with glib 2.53.4 or later

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -501,8 +501,6 @@ get_updated_timeformat (ClockData *cd)
 static void
 update_timeformat (ClockData *cd)
 {
-        if (cd->settings == NULL)
-                return;
         if (cd->timeformat)
                 g_free (cd->timeformat);
         cd->timeformat = get_updated_timeformat (cd);
@@ -703,8 +701,6 @@ update_tooltip (ClockData * cd)
 static void
 refresh_clock (ClockData *cd)
 {
-        if (cd->settings == NULL)
-                return;
         unfix_size (cd);
         update_clock (cd);
 }
@@ -712,9 +708,6 @@ refresh_clock (ClockData *cd)
 static void
 refresh_clock_timeout(ClockData *cd)
 {
-        if (cd->settings == NULL)
-                return;
-
         unfix_size (cd);
 
         update_timeformat (cd);
@@ -756,6 +749,9 @@ free_locations (ClockData *cd)
 static void
 destroy_clock (GtkWidget * widget, ClockData *cd)
 {
+        if (cd->settings)
+                g_signal_handlers_disconnect_by_data( cd->settings, cd);
+
         if (cd->settings)
                 g_object_unref (cd->settings);
         cd->settings = NULL;
@@ -2002,9 +1998,6 @@ static void
 update_weather_bool_value_and_toggle_from_gsettings (ClockData *cd, gchar *key,
                                                  gboolean *value_loc, const char *widget_name)
 {
-        if (cd->settings == NULL)
-                return;
-
         GtkWidget *widget;
         gboolean value;
 
@@ -2084,9 +2077,6 @@ location_set_current_cb (ClockLocation *loc,
 static void
 locations_changed (ClockData *cd)
 {
-        if (cd->settings == NULL)
-                return;
-
         GList *l;
         ClockLocation *loc;
         glong id;
@@ -2290,9 +2280,6 @@ temperature_unit_changed (GSettings    *settings,
                           gchar        *key,
                           ClockData    *cd)
 {
-        if (cd->settings == NULL)
-                return;
-
         cd->temperature_unit = g_settings_get_enum (settings, key);
         if (cd->temperature_unit > 0)
         {
@@ -2311,9 +2298,6 @@ speed_unit_changed (GSettings    *settings,
                     gchar        *key,
                     ClockData    *cd)
 {
-        if (cd->settings == NULL)
-                return;
-
         cd->speed_unit = g_settings_get_enum (settings, key);
         if (cd->speed_unit > 0)
         {
@@ -2332,9 +2316,6 @@ custom_format_changed (GSettings    *settings,
                        gchar        *key,
                        ClockData    *clock)
 {
-        if (clock->settings == NULL)
-                return;
-
         gchar *value;
         value = g_settings_get_string (settings, key);
 

--- a/applets/fish/fish.c
+++ b/applets/fish/fish.c
@@ -995,9 +995,6 @@ static void display_fortune_dialog(FishApplet* fish)
 
 static void name_changed_notify(GSettings* settings, gchar* key, FishApplet* fish)
 {
-	if (fish->source_id == 0)
-		return;
-
 	char *value;
 
 	value = g_settings_get_string (settings, key);
@@ -1023,9 +1020,6 @@ static void name_changed_notify(GSettings* settings, gchar* key, FishApplet* fis
 
 static void image_changed_notify(GSettings* settings, gchar* key, FishApplet* fish)
 {
-	if (fish->source_id == 0)
-		return;
-
 	char *value;
 
 	value = g_settings_get_string (settings, key);
@@ -1777,6 +1771,10 @@ static gboolean fishy_factory(MatePanelApplet* applet, const char* iid, gpointer
 static void fish_applet_dispose (GObject *object)
 {
 	FishApplet* fish = (FishApplet*) object;
+
+	if (fish->settings != NULL)
+		g_signal_handlers_disconnect_by_data (fish->settings,
+					  fish);
 
 	if (fish->timeout)
 	{

--- a/mate-panel/applet.c
+++ b/mate-panel/applet.c
@@ -796,6 +796,8 @@ mate_panel_applet_destroy (GtkWidget  *widget,
 {
 	g_return_if_fail (info != NULL);
 
+	g_signal_handlers_disconnect_by_data(info->settings,widget);
+
 	info->widget = NULL;
 
 	if (info->settings) {

--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -647,6 +647,9 @@ void
 panel_action_button_set_type (PanelActionButton     *button,
 			      PanelActionButtonType  type)
 {
+	if (!type)
+		return;
+
 	g_return_if_fail (type > PANEL_ACTION_NONE && type < PANEL_ACTION_LAST);
 
 	if (type == button->priv->type)


### PR DESCRIPTION
*On destroying applet disconnect signals for functions that otherwise segfaults with glib 2.53.4 or later.
*Fish: it's not always enough for a function to return immediately if applet destroyed anymore
*panel-action-button: suppress a warning