### PR TITLE
GTK 3.22: Avoid deprecated gtk_menu_popup

### DIFF
--- a/mate-panel/applet.c
+++ b/mate-panel/applet.c
@@ -732,7 +732,12 @@ applet_show_menu (AppletInfo     *info,
 
 	if (!gtk_widget_get_realized (info->menu))
 		gtk_widget_show (info->menu);
-
+#if GTK_CHECK_VERSION (3, 22, 0)
+	/* Trying to get the widget from the calling function here */
+	/* puts main menu (menubar) context menu in wrong place    */
+	gtk_menu_popup_at_pointer (GTK_MENU (info->menu),
+	                          NULL);
+#else
 	gtk_menu_popup (GTK_MENU (info->menu),
 			NULL,
 			NULL,
@@ -740,6 +745,7 @@ applet_show_menu (AppletInfo     *info,
 			info->widget,
 			event->button,
 			event->time);
+#endif
 }
 
 static gboolean
@@ -752,7 +758,6 @@ applet_do_popup_menu (GtkWidget      *widget,
 
 	if (info->type == PANEL_OBJECT_APPLET)
 		return FALSE;
-
 	applet_show_menu (info, event);
 
 	return TRUE;

--- a/mate-panel/menu.c
+++ b/mate-panel/menu.c
@@ -588,12 +588,18 @@ show_item_menu (GtkWidget      *item,
 
 	gtk_menu_set_screen (GTK_MENU (menu),
 			     gtk_window_get_screen (GTK_WINDOW (panel_widget->toplevel)));
-
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_menu_popup_at_widget (GTK_MENU (menu),
+	                          GTK_WIDGET (item),
+	                          GDK_GRAVITY_SOUTH_WEST,
+	                          GDK_GRAVITY_NORTH_WEST,
+	                          NULL);
+#else
 	gtk_menu_popup (GTK_MENU (menu),
 			NULL, NULL, NULL, NULL,
 			bevent->button,
 			bevent->time);
-
+#endif
 	return TRUE;
 }
 

--- a/mate-panel/panel-action-protocol.c
+++ b/mate-panel/panel-action-protocol.c
@@ -76,8 +76,16 @@ panel_action_protocol_main_menu (GdkScreen *screen,
 	panel_toplevel_push_autohide_disabler (panel_widget->toplevel);
 
 	gtk_menu_set_screen (GTK_MENU (menu), screen);
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_menu_popup_at_widget (GTK_MENU (menu),
+	                          GTK_WIDGET (info->widget),
+	                          GDK_GRAVITY_SOUTH_WEST,
+	                          GDK_GRAVITY_NORTH_WEST,
+                              NULL);
+#else
 	gtk_menu_popup (GTK_MENU (menu), NULL, NULL,
 			NULL, NULL, 0, activate_time);
+#endif
 }
 
 static void

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -442,6 +442,13 @@ panel_menu_button_popup_menu (PanelMenuButton *button,
 	screen = gtk_window_get_screen (GTK_WINDOW (button->priv->toplevel));
 	gtk_menu_set_screen (GTK_MENU (button->priv->menu), screen);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_menu_popup_at_widget (GTK_MENU (button->priv->menu),
+	                          GTK_WIDGET (button),
+	                          GDK_GRAVITY_SOUTH_WEST,
+	                          GDK_GRAVITY_NORTH_WEST,
+	                          NULL);
+#else
 	gtk_menu_popup (GTK_MENU (button->priv->menu),
 			NULL,
 			NULL,
@@ -449,6 +456,7 @@ panel_menu_button_popup_menu (PanelMenuButton *button,
 			GTK_WIDGET (button),
 			n_button,
 			activate_time);
+#endif
 }
 
 static void

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -357,19 +357,24 @@ panel_popup_menu (PanelToplevel *toplevel,
 		panel_data->insertion_pos = panel_widget_get_cursorloc (panel_widget);
 	else
 		panel_data->insertion_pos = -1;
-
+#if !GTK_CHECK_VERSION (3, 22, 0)
 	if (current_event)
 		gdk_event_free (current_event);
-
+#endif
 	menu = make_popup_panel_menu (panel_widget);
 	if (!menu)
 		return FALSE;
 
 	gtk_menu_set_screen (GTK_MENU (menu),
 			     gtk_window_get_screen (GTK_WINDOW (toplevel)));
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_menu_popup_at_pointer (GTK_MENU (menu),current_event);
 
+	if (current_event)
+		gdk_event_free (current_event);
+#else
 	gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, NULL, button, activate_time);
-
+#endif
 	return TRUE;
 }
 


### PR DESCRIPTION
Port to gtk_menu_popup_at_widget and when that cannot be used gtk_menu_popup_at_pointer.