### PR TITLE
Add option to context menu to reset the panel

### DIFF
--- a/mate-panel/panel-context-menu.c
+++ b/mate-panel/panel-context-menu.c
@@ -47,6 +47,7 @@
 #include "panel-lockdown.h"
 #include "panel-addto.h"
 #include "panel-icon-names.h"
+#include "panel-reset.h"
 
 static void
 panel_context_menu_show_help (GtkWidget *w,
@@ -202,6 +203,14 @@ panel_context_menu_build_edition (PanelWidget *panel_widget,
 	g_signal_connect_swapped (menuitem, "activate",
 				  G_CALLBACK (panel_properties_dialog_present), 
 				  panel_widget->toplevel);
+
+	menuitem = gtk_image_menu_item_new_with_mnemonic (_("_Reset Panel"));
+	image = gtk_image_new_from_stock (GTK_STOCK_REVERT_TO_SAVED, GTK_ICON_SIZE_MENU);
+	gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (menuitem), image);
+	gtk_widget_show (menuitem);
+	gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
+	g_signal_connect (menuitem, "activate",
+			  G_CALLBACK (panel_reset), NULL);
 
 	menuitem = gtk_image_menu_item_new_with_mnemonic (_("_Delete This Panel"));
 	image = gtk_image_new_from_icon_name ("edit-delete",


### PR DESCRIPTION
It can happen that a panel configuration is so messed up, that only a reset helps.

Only a few users know how to do that.

This patch adds a context menu entry "Reset Panel", which enables a user to do that.

Internally the function behind "mate-panel --reset" is called.