### PR TITLE
make file/folder launchers work again

### DIFF
--- a/mate-panel/launcher.h
+++ b/mate-panel/launcher.h
@@ -14,8 +14,6 @@
 #include "applet.h"
 #include "panel-widget.h"
 
-#include <gio/gdesktopappinfo.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -24,7 +22,8 @@ typedef struct {
 	AppletInfo        *info;
 	GtkWidget         *button;
 
-	GDesktopAppInfo   *app_info;
+	char              *location;
+	GKeyFile          *key_file;
 
 	GtkWidget         *prop_dialog;
 	GSList            *error_dialogs;

--- a/mate-panel/libpanel-util/panel-launch.c
+++ b/mate-panel/libpanel-util/panel-launch.c
@@ -163,23 +163,29 @@ panel_app_info_launch_uri (GDesktopAppInfo     *appinfo,
 }
 
 gboolean
-panel_app_info_launch (GDesktopAppInfo   *appinfo,
+panel_launch_key_file (GKeyFile   *keyfile,
 		       GList      *uri_list,
 		       GdkScreen  *screen,
 		       const gchar *action,
 		       GError    **error)
 {
+	GDesktopAppInfo *appinfo;
 	gboolean         retval;
 
-	g_return_val_if_fail (appinfo != NULL, FALSE);
+	g_return_val_if_fail (keyfile != NULL, FALSE);
 	g_return_val_if_fail (GDK_IS_SCREEN (screen), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	appinfo = g_desktop_app_info_new_from_keyfile (keyfile);
+	if (appinfo == NULL)
+		return FALSE;
 
 	retval = panel_app_info_launch_uris (appinfo,
 					     uri_list, screen, action,
 					     gtk_get_current_event_time (),
 					     error);
 
+	g_object_unref (appinfo);
 	return retval;
 }
 

--- a/mate-panel/libpanel-util/panel-launch.h
+++ b/mate-panel/libpanel-util/panel-launch.h
@@ -45,7 +45,7 @@ gboolean panel_app_info_launch_uri (GDesktopAppInfo     *appinfo,
 				    guint32       timestamp,
 				    GError      **error);
 
-gboolean panel_app_info_launch (GDesktopAppInfo   *appinfo,
+gboolean panel_launch_key_file (GKeyFile   *keyfile,
 				GList      *uri_list,
 				GdkScreen  *screen,
 				const gchar *action,

--- a/mate-panel/mate-desktop-item-edit.c
+++ b/mate-panel/mate-desktop-item-edit.c
@@ -140,7 +140,7 @@ main (int argc, char * argv[])
 
 			if (type == G_FILE_TYPE_DIRECTORY && create_new) {
 
-				dlg = panel_ditem_editor_new (NULL, NULL,
+				dlg = panel_ditem_editor_new (NULL, NULL, NULL,
 							     _("Create Launcher"));
 				g_object_set_data_full (G_OBJECT (dlg), "dir",
 							g_strdup (path),
@@ -164,13 +164,14 @@ main (int argc, char * argv[])
 					   		".directory")
 				   && !create_new) {
 				dlg = panel_ditem_editor_new_directory (NULL,
+									NULL,
 									uri,
 									_("Directory Properties"));
 			} else if (type == G_FILE_TYPE_REGULAR
 				   && g_str_has_suffix (desktops [i],
 					   		".desktop")
 				   && !create_new) {
-				dlg = panel_ditem_editor_new (NULL, uri,
+				dlg = panel_ditem_editor_new (NULL, NULL, uri,
 							      _("Launcher Properties"));
 			} else if (type == G_FILE_TYPE_REGULAR
 				   && create_new) {
@@ -187,13 +188,13 @@ main (int argc, char * argv[])
 		} else if (g_str_has_suffix (desktops [i], ".directory")) {
 			/* a non-existant file.  Well we can still edit that
 			 * sort of.  We will just create it new */
-			dlg = panel_ditem_editor_new_directory (NULL, uri,
+			dlg = panel_ditem_editor_new_directory (NULL, NULL, uri,
 								_("Directory Properties"));
 
 		} else if (g_str_has_suffix (desktops [i], ".desktop")) {
 			/* a non-existant file.  Well we can still edit that
 			 * sort of.  We will just create it new */
-			dlg = panel_ditem_editor_new (NULL, uri,
+			dlg = panel_ditem_editor_new (NULL, NULL, uri,
 						      _("Create Launcher"));
 
 		} else {

--- a/mate-panel/panel-ditem-editor.c
+++ b/mate-panel/panel-ditem-editor.c
@@ -1637,6 +1637,7 @@ panel_ditem_editor_load_uri (PanelDItemEditor  *dialog,
 
 static GtkWidget *
 panel_ditem_editor_new_full (GtkWindow   *parent,
+			     GKeyFile    *key_file,
 			     const char  *uri,
 			     const char  *title,
 			     gboolean     type_directory)
@@ -1645,6 +1646,7 @@ panel_ditem_editor_new_full (GtkWindow   *parent,
 
 	dialog = g_object_new (PANEL_TYPE_DITEM_EDITOR,
 			       "title", title,
+			       "keyfile", key_file,
 			       "uri", uri,
 			       "type-directory", type_directory,
 			       NULL);
@@ -1657,19 +1659,21 @@ panel_ditem_editor_new_full (GtkWindow   *parent,
 
 GtkWidget *
 panel_ditem_editor_new (GtkWindow   *parent,
+			GKeyFile    *key_file,
 			const char  *uri,
 			const char  *title)
 {
-	return panel_ditem_editor_new_full (parent, uri,
+	return panel_ditem_editor_new_full (parent, key_file, uri,
 					    title, FALSE);
 }
 
 GtkWidget *
 panel_ditem_editor_new_directory (GtkWindow   *parent,
+				  GKeyFile    *key_file,
 				  const char  *uri,
 				  const char  *title)
 {
-	return panel_ditem_editor_new_full (parent, uri,
+	return panel_ditem_editor_new_full (parent, key_file, uri,
 					    title, TRUE);
 }
 

--- a/mate-panel/panel-ditem-editor.h
+++ b/mate-panel/panel-ditem-editor.h
@@ -85,10 +85,12 @@ typedef char * (*PanelDitemSaveUri) (PanelDItemEditor *dialog, gpointer data);
 GType      panel_ditem_editor_get_type (void);
 
 GtkWidget *panel_ditem_editor_new (GtkWindow   *parent,
+				   GKeyFile    *key_file,
 				   const char  *uri,
 				   const char  *title);
 
 GtkWidget *panel_ditem_editor_new_directory (GtkWindow   *parent,
+					     GKeyFile    *key_file,
 					     const char  *uri,
 					     const char  *title);
 


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-panel/issues/590

reverts a part of 7ee450758e4f2bee13aa8ff967a5795a6dcdc91f

It's a big change, because https://github.com/mate-desktop/mate-panel/pull/511 was big.

Things that should work:
- creating new launcher by dragging a file/folder to panel
- editing the launcher (changing icon, URI, other properties)
- animation on launch
- desktop actions in right-click menu (can test with firefox, thunderbird, hexchat, libreoffice)
- translations of desktop actions names
- translations in launcher tooltip
- something else I could forget about

In the end, things should be the same as they were in 1.16.