### PR TITLE
Stop panel collapse left on adding certain out-of-process applets

### DIFF
--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1584,6 +1584,7 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 #if !GTK_CHECK_VERSION(3, 18, 0)
 	panel_widget_set_background_region (panel);
 #endif
+	gtk_widget_queue_resize(widget);
 }
 
 gboolean


### PR DESCRIPTION
Stop panel from collapsing left on adding fish, moving window-list(or other wncklet applet) on otherwise empty panel. Stop collapse left of panel with one applet from wncklet(and no other applets) on adding 2nd applet from wncklet. 
Fixes https://github.com/mate-desktop/mate-panel/issues/661