### PR TITLE
status-notifier: hide mate-polkit icon if passive

### DIFF
--- a/applets/notification_area/status-notifier/sn-item-v0.c
+++ b/applets/notification_area/status-notifier/sn-item-v0.c
@@ -239,7 +239,7 @@ update (SnItemV0 *v0)
   GtkImage *image;
   SnTooltip *tip;
   gint icon_size;
-
+  gboolean visible;
   g_return_if_fail (SN_IS_ITEM_V0 (v0));
 
   image = GTK_IMAGE (v0->image);
@@ -314,6 +314,12 @@ update (SnItemV0 *v0)
     atk_object_set_name (accessible, v0->id);
 
   /* TODO: hide "Passive" items with a setting? */
+  /*Special case mate-polkit*/
+  if (g_strcmp0 (v0->status, "password-dialog") != 0){
+    visible = g_strcmp0 (v0->status, "Passive") != 0;
+    gtk_widget_set_visible (GTK_WIDGET (v0), visible);
+    }
+  else
   gtk_widget_set_visible (GTK_WIDGET (v0), TRUE);
 }
 


### PR DESCRIPTION
Hide the mate-polkit statusnotifier icon (and only that icon) if it is set passive.  Works with https://github.com/mate-desktop/mate-polkit/pull/38 in mate-polkit to fix https://github.com/mate-desktop/mate-polkit/issues/35 (status notifier icon keeps showing after dropping elevated privileges). Keep the other passive indicators showing as they are too often needed.