### PR TITLE
GTK 3.22/status-notifer Fix menu position if size changed since last shown

### DIFF
--- a/applets/notification_area/status-notifier/sn-dbus-menu.c
+++ b/applets/notification_area/status-notifier/sn-dbus-menu.c
@@ -111,7 +111,6 @@ layout_update_item (SnDBusMenu *menu,
     {
       sn_dbus_menu_item_update_props (item, props);
     }
-
   return item->submenu;
 }
 
@@ -179,8 +178,11 @@ get_layout_cb (GObject      *source_object,
 
   g_hash_table_remove_all (menu->items);
   layout_parse (menu, layout, GTK_MENU (menu));
-  /*Reposition to accomodate size change if necessary*/
+#if GTK_CHECK_VERSION (3, 22, 0)
+  /* Reposition menu to accomodate any size changes   */
+  /* Menu size never changes with GTK 3.20 or earlier */
   gtk_menu_reposition(GTK_MENU(menu));
+#endif
   g_variant_unref (layout);
 }
 

--- a/applets/notification_area/status-notifier/sn-dbus-menu.c
+++ b/applets/notification_area/status-notifier/sn-dbus-menu.c
@@ -179,6 +179,8 @@ get_layout_cb (GObject      *source_object,
 
   g_hash_table_remove_all (menu->items);
   layout_parse (menu, layout, GTK_MENU (menu));
+  /*Reposition to accomodate size change if necessary*/
+  gtk_menu_reposition(GTK_MENU(menu));
   g_variant_unref (layout);
 }
 

--- a/applets/notification_area/status-notifier/sn-item.c
+++ b/applets/notification_area/status-notifier/sn-item.c
@@ -277,6 +277,8 @@ sn_item_button_press_event (GtkWidget      *widget,
           gtk_menu_popup (priv->menu, NULL, NULL,
                           sn_item_popup_menu_position_func, widget,
                           event->button, event->time);
+          /*Fix positioning if size changed since last shown*/
+          gtk_menu_reposition(priv->menu);
 #endif
         }
       else
@@ -329,6 +331,8 @@ sn_item_popup_menu (GtkWidget *widget)
       gtk_menu_popup (priv->menu, NULL, NULL,
                       sn_item_popup_menu_position_func, widget,
                       button, active_time);
+      /*Fix positioning if size changed since last shown*/
+      gtk_menu_reposition(priv->menu);
 #endif
     }
   else

--- a/applets/notification_area/status-notifier/sn-item.c
+++ b/applets/notification_area/status-notifier/sn-item.c
@@ -271,6 +271,8 @@ sn_item_button_press_event (GtkWidget      *widget,
                                     GDK_GRAVITY_SOUTH_WEST,
                                     GDK_GRAVITY_NORTH_WEST,
                                     (GdkEvent *) event);
+          /*Fix positioning if size changed since last shown*/
+          gtk_menu_reposition(priv->menu);
 #else
           gtk_menu_popup (priv->menu, NULL, NULL,
                           sn_item_popup_menu_position_func, widget,

--- a/applets/notification_area/status-notifier/sn-item.c
+++ b/applets/notification_area/status-notifier/sn-item.c
@@ -313,6 +313,8 @@ sn_item_popup_menu (GtkWidget *widget)
                                 GDK_GRAVITY_SOUTH_WEST,
                                 GDK_GRAVITY_NORTH_WEST,
                                 NULL);
+      /*Fix positioning if size changed since last shown*/
+      gtk_menu_reposition(priv->menu);
 #else
       guint button = 0;
       guint32 active_time = GDK_CURRENT_TIME;


### PR DESCRIPTION
Mostly fixes serious mispositioning (on popup) of network-manager applet (indicator mode) menus when connections were changed on last showing of menu and applet is on bottom panel and especially on the bottom right. A slight low positioning on a bottom panel can remain when a connection is activated and a few menu items are added, thus expanding the menu while it is still showing. 