### PR TITLE
Fix some simple warnings found by Cppcheck

### DIFF
--- a/applets/clock/clock-location-tile.c
+++ b/applets/clock/clock-location-tile.c
@@ -473,7 +473,7 @@ format_time (struct tm   *now,
                 }
         }
 
-        if (strftime (buf, sizeof (buf), format, now) <= 0) {
+        if (strftime (buf, sizeof (buf), format, now) == 0) {
                 strcpy (buf, "???");
         }
 

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -569,13 +569,13 @@ format_time (ClockData *cd)
                                                        NULL, NULL, NULL);
                 if (!timeformat)
                         strcpy (hour, "???");
-                else if (strftime (hour, sizeof (hour), timeformat, tm) <= 0)
+                else if (strftime (hour, sizeof (hour), timeformat, tm)== 0)
                         strcpy (hour, "???");
                 g_free (timeformat);
 
                 utf8 = g_locale_to_utf8 (hour, -1, NULL, NULL, NULL);
         } else {
-                if (strftime (hour, sizeof (hour), cd->timeformat, tm) <= 0)
+                if (strftime (hour, sizeof (hour), cd->timeformat, tm) == 0)
                         strcpy (hour, "???");
 
                 utf8 = g_locale_to_utf8 (hour, -1, NULL, NULL, NULL);
@@ -659,7 +659,7 @@ update_tooltip (ClockData * cd)
                 loc = g_locale_from_utf8 (_("%A %B %d (%%s)"), -1, NULL, NULL, NULL);
                 if (!loc)
                         strcpy (date, "???");
-                else if (strftime (date, sizeof (date), loc, tm) <= 0)
+                else if (strftime (date, sizeof (date), loc, tm) == 0)
                         strcpy (date, "???");
                 g_free (loc);
 
@@ -1639,7 +1639,7 @@ copy_time (GtkAction *action,
 
                 if (!format)
                         strcpy (string, "???");
-                else if (strftime (string, sizeof (string), format, tm) <= 0)
+                else if (strftime (string, sizeof (string), format, tm) == 0)
                         strcpy (string, "???");
                 g_free (format);
         }
@@ -1668,7 +1668,7 @@ copy_date (GtkAction *action,
         loc = g_locale_from_utf8 (_("%A, %B %d %Y"), -1, NULL, NULL, NULL);
         if (!loc)
                 strcpy (string, "???");
-        else if (strftime (string, sizeof (string), loc, tm) <= 0)
+        else if (strftime (string, sizeof (string), loc, tm) == 0)
                 strcpy (string, "???");
         g_free (loc);
 

--- a/applets/notification_area/status-notifier/sn-item.c
+++ b/applets/notification_area/status-notifier/sn-item.c
@@ -440,8 +440,6 @@ sn_item_ready (SnItem *item)
   SnItemPrivate *priv;
 
   menu = SN_ITEM_GET_CLASS (item)->get_menu (item);
-  if (menu == NULL)
-    return;
 
   if (menu == NULL || *menu == '\0' || g_strcmp0 (menu, "/") == 0)
     return;

--- a/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
@@ -455,11 +455,13 @@ mate_panel_applet_frame_dbus_load (const gchar                 *iid,
 	g_variant_builder_add (&builder, "{sv}",
 			       "locked-down",
 			       g_variant_new_boolean (mate_panel_applet_frame_activating_get_locked_down (frame_act)));
+	/*since background has just been set to NULL, this block never executes
 	if (background) {
 		g_variant_builder_add (&builder, "{sv}",
 				       "background",
 				       g_variant_new_string (background));
 	}
+	*/
 
 	g_object_set_data (G_OBJECT (frame), "mate-panel-applet-frame-activating", frame_act);
 

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -331,7 +331,6 @@ static GdkCursorType panel_toplevel_grab_op_cursor(PanelToplevel* toplevel, Pane
 		else
 			retval = GDK_FLEUR;
 		break;
-		break;
 	case PANEL_GRAB_OP_RESIZE_UP:
 		retval = GDK_TOP_SIDE;
 		break;


### PR DESCRIPTION
Static code analysis using Cppcheck found these simple warnings (considered style warning) as well as a huge number of variables that could be reduced in scope and have been left alone as that would be a major job.