### PR TITLE
fixes/improvements for signals disconnecting

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -752,6 +752,9 @@ destroy_clock (GtkWidget * widget, ClockData *cd)
         if (cd->settings)
                 g_signal_handlers_disconnect_by_data( cd->settings, cd);
 
+        if (cd->systz)
+                g_signal_handlers_disconnect_by_data( cd->systz, cd);
+
         if (cd->settings)
                 g_object_unref (cd->settings);
         cd->settings = NULL;

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -688,22 +688,9 @@ static void display_properties_dialog(GtkAction* action, TasklistData* tasklist)
 
 static void destroy_tasklist(GtkWidget* widget, TasklistData* tasklist)
 {
+	g_signal_handlers_disconnect_by_data (G_OBJECT (tasklist->applet), tasklist);
 
-	g_signal_handlers_disconnect_by_func(G_OBJECT(tasklist->applet),
-						G_CALLBACK(applet_change_orient), tasklist);
-	g_signal_handlers_disconnect_by_func(G_OBJECT(tasklist->applet),
-						G_CALLBACK(applet_change_pixel_size), tasklist);
-	g_signal_handlers_disconnect_by_func(G_OBJECT(tasklist->applet),
-						G_CALLBACK(applet_change_background), tasklist);
-	g_signal_handlers_disconnect_by_func (tasklist->settings,
-					  G_CALLBACK (display_all_workspaces_changed),
-					  tasklist);
-	g_signal_handlers_disconnect_by_func (tasklist->settings,
-					  G_CALLBACK (group_windows_changed),
-					  tasklist);
-	g_signal_handlers_disconnect_by_func (tasklist->settings,
-					  G_CALLBACK (move_unminimized_windows_changed),
-					  tasklist);
+	g_signal_handlers_disconnect_by_data (tasklist->settings, tasklist);
 
 	g_object_unref(tasklist->settings);
 

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -961,18 +961,8 @@ static void display_properties_dialog(GtkAction* action, PagerData* pager)
 
 static void destroy_pager(GtkWidget* widget, PagerData* pager)
 {
-	g_signal_handlers_disconnect_by_func (pager->settings,
-					  G_CALLBACK (num_rows_changed),
-					  pager);
-	g_signal_handlers_disconnect_by_func (pager->settings,
-					  G_CALLBACK (display_workspace_names_changed),
-					  pager);
-	g_signal_handlers_disconnect_by_func (pager->settings,
-					  G_CALLBACK (all_workspaces_changed),
-					  pager);
-	g_signal_handlers_disconnect_by_func (pager->settings,
-					  G_CALLBACK (wrap_workspaces_changed),
-					  pager);
+	g_signal_handlers_disconnect_by_data (pager->settings, pager);
+
 	g_object_unref (pager->settings);
 
 	if (pager->properties_dialog)


### PR DESCRIPTION
New clock fix should address these crashes:
https://bugs.launchpad.net/bugs/1609581
https://bugs.launchpad.net/bugs/1676734

Other commit just optimizes https://github.com/mate-desktop/mate-panel/commit/9f43dd5c7c37b84960d06a98a4738ee40d8bfd50.
For the record, here's downstream report:
https://bugs.launchpad.net/bugs/1555993