### PR TITLE
Keep the right icons on bottom still displaying right when the resolution change larger. #682

### DIFF
--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -2915,6 +2915,11 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 {
 	GtkWidget *widget;
 
+	GList *list;
+	const char *id;
+	int position;
+	gboolean stick;
+
 	widget = GTK_WIDGET (toplevel);
 
 	g_assert (gtk_widget_get_realized (widget));
@@ -2933,6 +2938,29 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 		gdk_window_resize (gtk_widget_get_window (widget),
 				   toplevel->priv->geometry.width,
 				   toplevel->priv->geometry.height);
+
+	if(resize || move)
+	{
+		for(list = toplevel->priv->panel_widget->applet_list;list!=NULL;list = g_list_next(list)) 
+		{
+			AppletData *ad = list->data;
+			id = mate_panel_applet_get_id_by_widget (ad->applet);
+
+			if (!id)
+				return;
+
+			AppletInfo *info;
+			info = mate_panel_applet_get_by_id (id);
+
+			stick = g_settings_get_boolean (info->settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY);
+
+			if(stick)
+			{
+				position = g_settings_get_int (info->settings, PANEL_OBJECT_POSITION_KEY);
+				ad->pos = toplevel->priv->geometry.width - position;
+			}
+		}
+	}
 }
 
 static void


### PR DESCRIPTION
this commit fixes #682

When the resolution changes, at the same time refresh the location of the icon on the right.