### PR TITLE
panel-toplevel: Remove pointer boundary check in panel_toplevel_queue…

### DIFF
--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -3851,7 +3851,6 @@ panel_toplevel_queue_auto_hide (PanelToplevel *toplevel)
 	g_return_if_fail (PANEL_IS_TOPLEVEL (toplevel));
 
 	if (!toplevel->priv->auto_hide ||
-	    panel_toplevel_contains_pointer (toplevel) ||
 	    panel_toplevel_get_autohide_disabled (toplevel))
 	  return;
 


### PR DESCRIPTION
Attempt at fixing issue #620 . The pointer boundary check inside this function seems unnecessary so we remove it.