### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -925,9 +925,8 @@ position_calendar_popup (ClockData *cd)
                    monitors */
                 monitor.x = 0;
                 monitor.y = 0;
-
-                gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                                         &monitor.width, &monitor.height);
+                monitor.width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+                monitor.height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
         }
 
         /* Based on panel orientation, position the popup.

--- a/applets/fish/fish.c
+++ b/applets/fish/fish.c
@@ -37,6 +37,7 @@
 #include <glib/gi18n.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include <gio/gio.h>
 
@@ -856,8 +857,8 @@ static void display_fortune_dialog(FishApplet* fish)
 
 		screen = gtk_widget_get_screen (GTK_WIDGET (fish));
 
-		gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-					 &screen_width, &screen_height);
+		screen_width  = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+		screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
 		gtk_window_set_default_size (GTK_WINDOW (fish->fortune_dialog),
 					     MIN (600, screen_width  * 0.9),

--- a/applets/notification_area/system-tray/fixedtip.c
+++ b/applets/notification_area/system-tray/fixedtip.c
@@ -20,6 +20,7 @@
  * 02110-1301, USA.
  */
 
+#include <gdk/gdkx.h>
 #include "fixedtip.h"
 
 /* Signals */
@@ -158,8 +159,8 @@ na_fixed_tip_position (NaFixedTip *fixedtip)
   parent_width = gdk_window_get_width(parent_window);
   parent_height = gdk_window_get_height(parent_window);
 
-  gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                           &screen_width, &screen_height);
+  screen_width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+  screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
   /* pad between panel and message window */
 #define PAD 5

--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -796,8 +796,6 @@ mate_panel_applet_position_menu (GtkMenu   *menu,
 	int             menu_y = 0;
 	int             pointer_x;
 	int             pointer_y;
-	int             screen_width;
-	int             screen_height;
 
 	g_return_if_fail (PANEL_IS_APPLET (widget));
 
@@ -821,9 +819,6 @@ mate_panel_applet_position_menu (GtkMenu   *menu,
 	menu_x += allocation.x;
 	menu_y += allocation.y;
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &screen_width, &screen_height);
-
 	if (applet->priv->orient == MATE_PANEL_APPLET_ORIENT_UP ||
 	    applet->priv->orient == MATE_PANEL_APPLET_ORIENT_DOWN) {
 		if (gtk_widget_get_direction (GTK_WIDGET (menu)) != GTK_TEXT_DIR_RTL) {
@@ -839,9 +834,9 @@ mate_panel_applet_position_menu (GtkMenu   *menu,
 					       allocation.width - requisition.width);
 			}
 		}
-		menu_x = MIN (menu_x, screen_width - requisition.width);
+		menu_x = MIN (menu_x, WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) - requisition.width);
 
-		if (menu_y > screen_height / 2)
+		if (menu_y > HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) / 2)
 			menu_y -= requisition.height;
 		else
 			menu_y += allocation.height;
@@ -849,9 +844,9 @@ mate_panel_applet_position_menu (GtkMenu   *menu,
 		if (pointer_y < allocation.height &&
 		    requisition.height < pointer_y)
 			menu_y += MIN (pointer_y, allocation.height - requisition.height);
-		menu_y = MIN (menu_y, screen_height - requisition.height);
+		menu_y = MIN (menu_y, HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) - requisition.height);
 
-		if (menu_x > screen_width / 2)
+		if (menu_x > WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) / 2)
 			menu_x -= requisition.width;
 		else
 			menu_x += allocation.width;

--- a/mate-panel/applet.c
+++ b/mate-panel/applet.c
@@ -641,8 +641,6 @@ mate_panel_applet_position_menu (GtkMenu   *menu,
 	int             menu_y = 0;
 	int             pointer_x;
 	int             pointer_y;
-	int             screen_width;
-	int             screen_height;
 
 	parent = gtk_widget_get_parent (applet);
 
@@ -667,9 +665,6 @@ mate_panel_applet_position_menu (GtkMenu   *menu,
 		menu_y += allocation.y;
 	}
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &screen_width, &screen_height);
-
 	if (PANEL_WIDGET (parent)->orient == GTK_ORIENTATION_HORIZONTAL) {
 		if (gtk_widget_get_direction (GTK_WIDGET (menu)) != GTK_TEXT_DIR_RTL) {
 			if (pointer_x < allocation.width &&
@@ -684,9 +679,9 @@ mate_panel_applet_position_menu (GtkMenu   *menu,
 					       allocation.width - requisition.width);
 			}
 		}
-		menu_x = MIN (menu_x, screen_width - requisition.width);
+		menu_x = MIN (menu_x, WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) - requisition.width);
 
-		if (menu_y > screen_height / 2)
+		if (menu_y > HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) / 2)
 			menu_y -= requisition.height;
 		else
 			menu_y += allocation.height;
@@ -694,9 +689,9 @@ mate_panel_applet_position_menu (GtkMenu   *menu,
 		if (pointer_y < allocation.height &&
 		    requisition.height < pointer_y)
 			menu_y += MIN (pointer_y, allocation.height - requisition.height);
-		menu_y = MIN (menu_y, screen_height - requisition.height);
+		menu_y = MIN (menu_y, HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) - requisition.height);
 
-		if (menu_x > screen_width / 2)
+		if (menu_x > WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) / 2)
 			menu_x -= requisition.width;
 		else
 			menu_x += allocation.width;

--- a/mate-panel/panel-addto.c
+++ b/mate-panel/panel-addto.c
@@ -27,6 +27,7 @@
 
 #include <glib/gi18n.h>
 #include <gio/gio.h>
+#include <gdk/gdkx.h>
 
 #include <matemenu-tree.h>
 
@@ -1373,10 +1374,7 @@ panel_addto_present (GtkMenuItem *item,
 				     panel_addto_dialog_quark);
 
 	screen = gtk_window_get_screen (GTK_WINDOW (toplevel));
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 NULL, &screen_height);
-
+	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 	height = MIN (MAX_ADDTOPANEL_HEIGHT, 3 * (screen_height / 4));
 
 	if (!dialog) {

--- a/mate-panel/panel-force-quit.c
+++ b/mate-panel/panel-force-quit.c
@@ -86,8 +86,8 @@ display_popup_window (GdkScreen *screen)
 
 	gtk_widget_realize (retval);
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &screen_width, &screen_height);
+	screen_width  = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
 	gtk_widget_get_allocation (retval, &allocation);
 

--- a/mate-panel/panel-struts.c
+++ b/mate-panel/panel-struts.c
@@ -22,6 +22,7 @@
  */
 
 #include <config.h>
+#include <gdk/gdkx.h>
 
 #include "panel-struts.h"
 
@@ -268,8 +269,8 @@ panel_struts_set_window_hint (PanelToplevel *toplevel)
 
 	strut_size = strut->allocated_strut_size;
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (strut->screen), NULL, NULL,
-				 &screen_width, &screen_height);
+	screen_width  = WidthOfScreen (gdk_x11_screen_get_xscreen (strut->screen));
+	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (strut->screen));
 
 	panel_struts_get_monitor_geometry (strut->screen,
 					   strut->monitor,

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -32,6 +32,7 @@
 #include <string.h>
 
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include <glib/gi18n.h>
 
@@ -277,19 +278,14 @@ gboolean panel_toplevel_is_last_unattached(PanelToplevel* toplevel)
 static GdkScreen* panel_toplevel_get_screen_geometry(PanelToplevel* toplevel, int* width, int* height)
 {
 	GdkScreen* screen;
-	gint       screen_width;
-	gint       screen_height;
 
 	g_return_val_if_fail(PANEL_IS_TOPLEVEL (toplevel), NULL);
 	g_return_val_if_fail(width != NULL && height != NULL, NULL);
 
 	screen = gtk_window_get_screen(GTK_WINDOW(toplevel));
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &screen_width, &screen_height);
-
-	*width  = screen_width;
-	*height = screen_height;
+	*width  = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+	*height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
 	return screen;
 }


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/mate-panel/commit/7b2bc7d9f98c6ba8c2c31bdf9605faadb42a7e0e

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height