### PR TITLE
status-notifier: fix failure to show icon for missing icon

### DIFF
--- a/applets/notification_area/status-notifier/sn-item-v0.c
+++ b/applets/notification_area/status-notifier/sn-item-v0.c
@@ -252,8 +252,11 @@ update (SnItemV0 *v0)
   if (v0->icon_name != NULL && v0->icon_name[0] != '\0')
     {
       GdkPixbuf *pixbuf;
-
       pixbuf = get_icon_by_name (v0->icon_name, icon_size);
+      if (!pixbuf){
+          /*deal with missing icon or failure to load icon*/
+          pixbuf = get_icon_by_name ("image-missing", icon_size);
+      }
       gtk_image_set_from_pixbuf (image, pixbuf);
       g_object_unref (pixbuf);
     }


### PR DESCRIPTION
Fix 1px wide invisible icon in cases such as
https://github.com/mate-desktop/mate-panel/issues/695
Show the "image-missing" icon if the named icon cannot be found or loaded