### PR TITLE
status-notifier: load icons specified by path

### DIFF
--- a/applets/notification_area/status-notifier/sn-item-v0.c
+++ b/applets/notification_area/status-notifier/sn-item-v0.c
@@ -256,6 +256,10 @@ update (SnItemV0 *v0)
       if (!pixbuf){
           /*try to find icons specified by path and filename*/
           pixbuf = gdk_pixbuf_new_from_file(v0->icon_name, NULL);
+          if (pixbuf){
+              /*An icon specified by path and filename may be the wrong size for the tray */
+              pixbuf=gdk_pixbuf_scale_simple(pixbuf, icon_size-2, icon_size-2,GDK_INTERP_BILINEAR);
+          }
       }
       if (!pixbuf){
           /*deal with missing icon or failure to load icon*/

--- a/applets/notification_area/status-notifier/sn-item-v0.c
+++ b/applets/notification_area/status-notifier/sn-item-v0.c
@@ -254,6 +254,10 @@ update (SnItemV0 *v0)
       GdkPixbuf *pixbuf;
       pixbuf = get_icon_by_name (v0->icon_name, icon_size);
       if (!pixbuf){
+          /*try to find icons specified by path and filename*/
+          pixbuf = gdk_pixbuf_new_from_file(v0->icon_name, NULL);
+      }
+      if (!pixbuf){
           /*deal with missing icon or failure to load icon*/
           pixbuf = get_icon_by_name ("image-missing", icon_size);
       }


### PR DESCRIPTION
Fix  https://github.com/mate-desktop/mate-panel/issues/695 and similar failures to load icons when the application calls for a path and not an icon name