### PR TITLE
status-notifier: properly handle the NULL case for items

### DIFF
--- a/applets/notification_area/status-notifier/sn-host-v0.c
+++ b/applets/notification_area/status-notifier/sn-host-v0.c
@@ -223,8 +223,10 @@ register_host_cb (GObject      *source_object,
 
   items = sn_watcher_v0_gen_dup_registered_items (v0->watcher);
 
-  for (i = 0; items[i] != NULL; i++)
-    add_registered_item (v0, items[i]);
+  if (items) {
+    for (i = 0; items[i] != NULL; i++)
+      add_registered_item (v0, items[i]);
+  }
 
   g_strfreev (items);
 }


### PR DESCRIPTION
patch by https://github.com/supermaz to catch the no-items/NULL case returned by  sn_watcher_v0_gen_dup_registered_items (v0->watcher);