### PR TITLE
rework the process of cancelling the background change operation

### DIFF
--- a/mate-panel/libmate-panel-applet-private/panel-applet-container.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-container.c
@@ -594,7 +594,7 @@ set_applet_property_cb (GObject      *source_object,
 	g_object_unref (container);
 }
 
-void
+gconstpointer
 mate_panel_applet_container_child_set (MatePanelAppletContainer *container,
 				  const gchar          *property_name,
 				  const GVariant       *value,
@@ -607,7 +607,7 @@ mate_panel_applet_container_child_set (MatePanelAppletContainer *container,
 	GSimpleAsyncResult       *result;
 
 	if (!proxy)
-		return;
+		return NULL;
 
 	info = mate_panel_applet_container_child_property_get_info (property_name);
 	if (!info) {
@@ -617,7 +617,7 @@ mate_panel_applet_container_child_set (MatePanelAppletContainer *container,
 						     MATE_PANEL_APPLET_CONTAINER_INVALID_CHILD_PROPERTY,
 						     "%s: Applet has no child property named `%s'",
 						     G_STRLOC, property_name);
-		return;
+		return NULL;
 	}
 
 	result = g_simple_async_result_new (G_OBJECT (container),
@@ -645,6 +645,8 @@ mate_panel_applet_container_child_set (MatePanelAppletContainer *container,
 				-1, cancellable,
 				set_applet_property_cb,
 				result);
+
+	return result;
 }
 
 gboolean
@@ -696,7 +698,7 @@ get_applet_property_cb (GObject      *source_object,
 	g_object_unref (container);
 }
 
-void
+gconstpointer
 mate_panel_applet_container_child_get (MatePanelAppletContainer *container,
 				  const gchar          *property_name,
 				  GCancellable         *cancellable,
@@ -708,7 +710,7 @@ mate_panel_applet_container_child_get (MatePanelAppletContainer *container,
 	GSimpleAsyncResult       *result;
 
 	if (!proxy)
-		return;
+		return NULL;
 
 	info = mate_panel_applet_container_child_property_get_info (property_name);
 	if (!info) {
@@ -718,7 +720,7 @@ mate_panel_applet_container_child_get (MatePanelAppletContainer *container,
 						     MATE_PANEL_APPLET_CONTAINER_INVALID_CHILD_PROPERTY,
 						     "%s: Applet has no child property named `%s'",
 						     G_STRLOC, property_name);
-		return;
+		return NULL;
 	}
 
 	result = g_simple_async_result_new (G_OBJECT (container),
@@ -744,6 +746,8 @@ mate_panel_applet_container_child_get (MatePanelAppletContainer *container,
 				-1, cancellable,
 				get_applet_property_cb,
 				result);
+
+	return result;
 }
 
 GVariant *
@@ -825,4 +829,15 @@ mate_panel_applet_container_child_popup_menu_finish (MatePanelAppletContainer *c
 	g_warn_if_fail (g_simple_async_result_get_source_tag (simple) == mate_panel_applet_container_child_popup_menu);
 
 	return !g_simple_async_result_propagate_error (simple, error);
+}
+
+void
+mate_panel_applet_container_cancel_operation (MatePanelAppletContainer *container,
+                                              gconstpointer             operation)
+{
+	gpointer value = g_hash_table_lookup (container->priv->pending_ops, operation);
+	if (value == NULL)
+		return;
+
+	g_cancellable_cancel (G_CANCELLABLE (value));
 }

--- a/mate-panel/libmate-panel-applet-private/panel-applet-container.h
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-container.h
@@ -94,7 +94,7 @@ gboolean   mate_panel_applet_container_child_popup_menu_finish (MatePanelAppletC
 							   GAsyncResult         *result,
 							   GError              **error);
 
-void       mate_panel_applet_container_child_set               (MatePanelAppletContainer *container,
+gconstpointer  mate_panel_applet_container_child_set           (MatePanelAppletContainer *container,
 							   const gchar          *property_name,
 							   const GVariant       *value,
 							   GCancellable         *cancellable,
@@ -103,7 +103,7 @@ void       mate_panel_applet_container_child_set               (MatePanelAppletC
 gboolean   mate_panel_applet_container_child_set_finish        (MatePanelAppletContainer *container,
 							   GAsyncResult         *result,
 							   GError              **error);
-void       mate_panel_applet_container_child_get               (MatePanelAppletContainer *container,
+gconstpointer  mate_panel_applet_container_child_get           (MatePanelAppletContainer *container,
 							   const gchar          *property_name,
 							   GCancellable         *cancellable,
 							   GAsyncReadyCallback   callback,
@@ -111,6 +111,9 @@ void       mate_panel_applet_container_child_get               (MatePanelAppletC
 GVariant  *mate_panel_applet_container_child_get_finish        (MatePanelAppletContainer *container,
 							   GAsyncResult         *result,
 							   GError              **error);
+
+void       mate_panel_applet_container_cancel_operation (MatePanelAppletContainer *container,
+                                                         gconstpointer             operation);
 
 #ifdef __cplusplus
 }

--- a/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
@@ -235,8 +235,7 @@ container_child_background_set (GObject      *source_object,
 
 	mate_panel_applet_container_child_set_finish (container, res, NULL);
 
-	if (frame->priv->bg_operation)
-		frame->priv->bg_operation = NULL;
+	frame->priv->bg_operation = NULL;
 }
 
 static void
@@ -327,8 +326,7 @@ mate_panel_applet_frame_dbus_finalize (GObject *object)
 {
 	MatePanelAppletFrameDBus *frame = MATE_PANEL_APPLET_FRAME_DBUS (object);
 
-	if (frame->priv->bg_operation)
-		frame->priv->bg_operation = NULL;
+	frame->priv->bg_operation = NULL;
 
 	G_OBJECT_CLASS (mate_panel_applet_frame_dbus_parent_class)->finalize (object);
 }

--- a/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
@@ -42,7 +42,7 @@ G_DEFINE_TYPE (MatePanelAppletFrameDBus,
 struct _MatePanelAppletFrameDBusPrivate
 {
 	MatePanelAppletContainer *container;
-	GCancellable         *bg_cancellable;
+	gconstpointer             bg_operation;
 };
 
 /* Keep in sync with mate-panel-applet.h. Uggh. */
@@ -235,10 +235,8 @@ container_child_background_set (GObject      *source_object,
 
 	mate_panel_applet_container_child_set_finish (container, res, NULL);
 
-	if (frame->priv->bg_cancellable)
-		g_object_unref (frame->priv->bg_cancellable);
-
-	frame->priv->bg_cancellable = NULL;
+	if (frame->priv->bg_operation)
+		frame->priv->bg_operation = NULL;
 }
 
 static void
@@ -246,22 +244,23 @@ mate_panel_applet_frame_dbus_change_background (MatePanelAppletFrame    *frame,
 					   PanelBackgroundType  type)
 {
 	MatePanelAppletFrameDBus *dbus_frame = MATE_PANEL_APPLET_FRAME_DBUS (frame);
+	MatePanelAppletFrameDBusPrivate *priv = dbus_frame->priv;
 	char *bg_str;
 
 	bg_str = _mate_panel_applet_frame_get_background_string (
 			frame, PANEL_WIDGET (gtk_widget_get_parent (GTK_WIDGET (frame))), type);
 
 	if (bg_str != NULL) {
-		if (dbus_frame->priv->bg_cancellable)
-			g_cancellable_cancel (dbus_frame->priv->bg_cancellable);
-		dbus_frame->priv->bg_cancellable = g_cancellable_new ();
+		if (priv->bg_operation)
+			mate_panel_applet_container_cancel_operation (priv->container, priv->bg_operation);
 
-		mate_panel_applet_container_child_set (dbus_frame->priv->container,
+		priv->bg_operation = mate_panel_applet_container_child_set (priv->container,
 						  "background",
 						  g_variant_new_string (bg_str),
-						  dbus_frame->priv->bg_cancellable,
+						  NULL,
 						  container_child_background_set,
 						  dbus_frame);
+
 		g_free (bg_str);
 	}
 }
@@ -328,9 +327,8 @@ mate_panel_applet_frame_dbus_finalize (GObject *object)
 {
 	MatePanelAppletFrameDBus *frame = MATE_PANEL_APPLET_FRAME_DBUS (object);
 
-	if (frame->priv->bg_cancellable)
-		g_object_unref (frame->priv->bg_cancellable);
-	frame->priv->bg_cancellable = NULL;
+	if (frame->priv->bg_operation)
+		frame->priv->bg_operation = NULL;
 
 	G_OBJECT_CLASS (mate_panel_applet_frame_dbus_parent_class)->finalize (object);
 }
@@ -348,7 +346,7 @@ mate_panel_applet_frame_dbus_init (MatePanelAppletFrameDBus *frame)
 	gtk_widget_show (container);
 	gtk_container_add (GTK_CONTAINER (frame), container);
 	frame->priv->container = MATE_PANEL_APPLET_CONTAINER (container);
-	frame->priv->bg_cancellable = NULL;
+	frame->priv->bg_operation = NULL;
 
 	g_signal_connect (container, "child-property-changed::flags",
 			  G_CALLBACK (mate_panel_applet_frame_dbus_flags_changed),


### PR DESCRIPTION
don't mess with additional references to a GCancellable, instead
keep just a const pointer to the internal operation data and use
it as a key when it's needed to cancel the operation.

fixes https://github.com/mate-desktop/mate-panel/issues/214
fixes https://github.com/mate-desktop/mate-panel/issues/431