### PR TITLE
get focus when displaying "applet broken" dialog

### DIFF
--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -827,6 +827,10 @@ _mate_panel_applet_frame_applet_broken (MatePanelAppletFrame *frame)
 	gtk_window_set_title (GTK_WINDOW (dialog), _("Error"));
 
 	gtk_widget_show (dialog);
+
+	gtk_window_present_with_time (GTK_WINDOW (dialog),
+				      gdk_x11_get_server_time (gtk_widget_get_window (GTK_WIDGET (dialog))));
+
 	g_free (dialog_txt);
 }
 


### PR DESCRIPTION
how to test:

for example: `killall mate-sensors-applet` and see the focus without/with the PR

![applet_broken](https://user-images.githubusercontent.com/7734191/34922286-39d1d544-f98e-11e7-95cc-15df909d761f.png)