### PR TITLE
status-notifier: fix crashes on wrong GVariant format

### DIFF
--- a/applets/notification_area/status-notifier/sn-dbus-menu.c
+++ b/applets/notification_area/status-notifier/sn-dbus-menu.c
@@ -126,6 +126,15 @@ layout_parse (SnDBusMenu *menu,
   GVariantIter iter;
   GVariant *child;
 
+  if (!g_variant_is_of_type (layout, G_VARIANT_TYPE ("(ia{sv}av)")))
+    {
+      g_warning ("Type of return value for 'layout' property in "
+                 "'GetLayout' call should be '(ia{sv}av)' but got '%s'",
+                 g_variant_get_type_string (layout));
+
+      return;
+    }
+
   g_variant_get (layout, "(i@a{sv}@av)", &id, &props, &items);
 
   submenu = layout_update_item (menu, gtk_menu, id, props);

--- a/applets/notification_area/status-notifier/sn-item-v0.c
+++ b/applets/notification_area/status-notifier/sn-item-v0.c
@@ -512,6 +512,14 @@ sn_tooltip_new (GVariant *variant)
   if (variant == NULL)
     return NULL;
 
+  if (!g_variant_is_of_type (variant, G_VARIANT_TYPE ("(sa(iiay)ss)")))
+    {
+      g_warning ("Type for 'ToolTip' property should be '(sa(iiay)ss)' "
+                 "but got '%s'", g_variant_get_type_string (variant));
+
+      return NULL;
+    }
+
   g_variant_get (variant, "(&s@a(iiay)&s&s)",
                  &icon_name, &icon_pixmap,
                  &title, &text);


### PR DESCRIPTION
Should address both crashes mentioned in https://github.com/mate-desktop/mate-panel/issues/686