### PR TITLE
set the "document-properties" icon in "Edit Menus"

### DIFF
--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -361,7 +361,7 @@ static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int positio
 	/* Menu editors */
 	if (!panel_lockdown_get_locked_down () && (panel_is_program_in_path("mozo") || panel_is_program_in_path("menulibre")))
 	{
-		mate_panel_applet_add_callback (menubar->priv->info, "edit", NULL, _("_Edit Menus"), NULL);
+		mate_panel_applet_add_callback (menubar->priv->info, "edit", "document-properties", _("_Edit Menus"), NULL);
 	}
 
 	g_signal_connect_after(menubar, "focus-in-event", G_CALLBACK(gtk_widget_queue_draw), menubar);

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -671,7 +671,7 @@ panel_menu_button_load (const char  *menu_path,
         if (!panel_lockdown_get_locked_down () &&
             (panel_is_program_in_path ("mozo") ||
 	    panel_is_program_in_path ("menulibre")))
-		mate_panel_applet_add_callback (info, "edit", NULL,
+		mate_panel_applet_add_callback (info, "edit", "document-properties",
 					   _("_Edit Menus"), NULL);
 
 	panel_widget_set_applet_expandable (panel, GTK_WIDGET (button), FALSE, TRUE);


### PR DESCRIPTION
do you like this icon? other icon? or with no icon?

without the PR:

![before_panel](https://user-images.githubusercontent.com/7734191/35486448-7d10a3e0-046e-11e8-8335-d48392776a1c.png)

with the PR:

![after_panel](https://user-images.githubusercontent.com/7734191/35486449-8442e9a2-046e-11e8-8c6e-902c81dce0f7.png)