### PR TITLE
workspace-switcher: restore border width and spacing in prefs dialog

### DIFF
--- a/applets/wncklet/workspace-switcher.ui
+++ b/applets/wncklet/workspace-switcher.ui
@@ -73,9 +73,10 @@
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
+            <property name="border_width">5</property>
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
-            <property name="spacing">6</property>
+            <property name="spacing">12</property>
             <child>
               <object class="GtkFrame" id="frame1">
                 <property name="visible">True</property>


### PR DESCRIPTION
Dialog after https://github.com/mate-desktop/mate-panel/pull/702:

![wps-cluttered](https://user-images.githubusercontent.com/5138986/35572698-39f8f9d0-05e6-11e8-9c05-f3f729424ddb.png)

Dialog before https://github.com/mate-desktop/mate-panel/pull/702 (and after this PR):

![wps-uncluttered](https://user-images.githubusercontent.com/5138986/35572709-3fba4770-05e6-11e8-8609-dd9013f48aa2.png)
