### PR TITLE
context menu: add separator before Reset Panel menu item

### DIFF
--- a/mate-panel/panel-context-menu.c
+++ b/mate-panel/panel-context-menu.c
@@ -251,6 +251,8 @@ panel_context_menu_build_edition (PanelWidget *panel_widget,
 				  G_CALLBACK (panel_properties_dialog_present), 
 				  panel_widget->toplevel);
 
+	add_menu_separator (menu);
+
 	menuitem = gtk_image_menu_item_new_with_mnemonic (_("_Reset Panel"));
 	image = gtk_image_new_from_icon_name ("document-revert", GTK_ICON_SIZE_MENU);
 	gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (menuitem), image);


### PR DESCRIPTION
I've decided to separate this menu item from the previous ones, even though it invokes a confirmation dialog now. Just thought that the radical actions should be in a separate section.

This is a follow-up to discussions in https://github.com/mate-desktop/mate-panel/pull/655, https://github.com/mate-desktop/mate-panel/pull/664, https://github.com/mate-desktop/mate-panel/pull/665.