### PR TITLE
panel-stock-icons.c: fix failed assertation  from deprecated code

### DIFF
--- a/mate-panel/panel-stock-icons.c
+++ b/mate-panel/panel-stock-icons.c
@@ -53,82 +53,9 @@ GtkIconSize panel_add_to_icon_get_size(void)
 	return panel_add_to_icon_size;
 }
 
-typedef struct {
-	char *stock_id;
-	char *icon;
-} PanelStockIcon;
-
-static PanelStockIcon stock_icons [] = {
-	{ PANEL_STOCK_FORCE_QUIT, PANEL_ICON_FORCE_QUIT }
-};
-
-static void
-panel_init_stock_icons (GtkIconFactory *factory)
-{
-	GtkIconSource *source;
-	int            i;
-
-
-	source = gtk_icon_source_new ();
-
-	for (i = 0; i < G_N_ELEMENTS (stock_icons); i++) {
-		GtkIconSet *set;
-
-		gtk_icon_source_set_icon_name (source, stock_icons [i].icon);
-
-		set = gtk_icon_set_new ();
-		gtk_icon_set_add_source (set, source);
-
-		gtk_icon_factory_add (factory, stock_icons [i].stock_id, set);
-		gtk_icon_set_unref (set);
-	}
-
-	gtk_icon_source_free (source);
-
-}
-
-typedef struct {
-	char *stock_id;
-	char *stock_icon_id;
-	char *label;
-} PanelStockItem;
-
-static PanelStockItem stock_items [] = {
-	{ PANEL_STOCK_EXECUTE,     "system-run",            N_("_Run") },
-	{ PANEL_STOCK_FORCE_QUIT,  PANEL_STOCK_FORCE_QUIT,  N_("_Force quit") },
-	{ PANEL_STOCK_CLEAR,       "edit-clear",            N_("C_lear") },
-	{ PANEL_STOCK_DONT_DELETE, "process-stop",          N_("D_on't Delete") }
-};
-
-static void
-panel_init_stock_items (GtkIconFactory *factory)
-{
-	GtkStockItem *items;
-	int           i;
-
-	items = g_new (GtkStockItem, G_N_ELEMENTS (stock_items));
-
-	for (i = 0; i < G_N_ELEMENTS (stock_items); i++) {
-		GtkIconSet *icon_set;
-
-		items [i].stock_id           = g_strdup (stock_items [i].stock_id);
-		items [i].label              = g_strdup (stock_items [i].label);
-		items [i].modifier           = 0;
-		items [i].keyval             = 0;
-		items [i].translation_domain = g_strdup (GETTEXT_PACKAGE);
-
-		/* FIXME: does this take into account the theme? */
-		icon_set = gtk_icon_factory_lookup_default (stock_items [i].stock_icon_id);
-		gtk_icon_factory_add (factory, stock_items [i].stock_id, icon_set);
-	}
-
-	gtk_stock_add_static (items, G_N_ELEMENTS (stock_items));
-}
-
 void
 panel_init_stock_icons_and_items (void)
 {
-	GtkIconFactory *factory;
 	GSettings      *settings;
 	gint		icon_size;
 
@@ -161,12 +88,5 @@ panel_init_stock_icons_and_items (void)
 							 PANEL_ADD_TO_DEFAULT_ICON_SIZE,
 							 PANEL_ADD_TO_DEFAULT_ICON_SIZE);
 
-	factory = gtk_icon_factory_new ();
-	gtk_icon_factory_add_default (factory);
-
-	panel_init_stock_icons (factory);
-	panel_init_stock_items (factory);
-
-	g_object_unref (factory);
 	g_object_unref (settings);
 }


### PR DESCRIPTION
Fix three  "gtk_icon_factory_add: assertion 'icon_set != NULL' failed" warnings. Note that the gtk_icon_factory stuff is all deprecated:
https://developer.gnome.org/gtk3/stable/gtk3-Themeable-Stock-Images.html#gtk-icon-factory-add

