### PR TITLE
Scale monitor geometries down to device pixels

### DIFF
--- a/mate-panel/panel-multiscreen.c
+++ b/mate-panel/panel-multiscreen.c
@@ -219,21 +219,8 @@ panel_multiscreen_get_gdk_monitors_for_screen (GdkScreen     *screen,
 	num_monitors = gdk_display_get_n_monitors (display);
 	geometries = g_new (GdkRectangle, num_monitors);
 
-	for (i = 0; i < num_monitors; i++) {
-		GdkMonitor *monitor;
-		int         scale;
-
-		monitor = gdk_display_get_monitor (display, i);
-		scale = gdk_monitor_get_scale_factor (monitor);
-
-		gdk_monitor_get_geometry (monitor, &(geometries[i]));
-
-		/* Scale geometries down to device pixels to support HiDPI displays */
-		geometries[i].x /= scale;
-		geometries[i].y /= scale;
-		geometries[i].width /= scale;
-		geometries[i].height /= scale;
-	}
+	for (i = 0; i < num_monitors; i++)
+		gdk_monitor_get_geometry (gdk_display_get_monitor (display, i), &(geometries[i]));
 
 	*monitors_ret = num_monitors;
 	*geometries_ret = geometries;

--- a/mate-panel/panel-run-dialog.c
+++ b/mate-panel/panel-run-dialog.c
@@ -1708,7 +1708,6 @@ panel_run_dialog_setup_entry (PanelRunDialog *dialog,
 	GdkScreen             *screen;
 	int                    width_request;
 	GtkWidget             *entry;
-	gint                   scale;
 
 	dialog->combobox = PANEL_GTK_BUILDER_GET (gui, "comboboxentry");
 
@@ -1721,10 +1720,9 @@ panel_run_dialog_setup_entry (PanelRunDialog *dialog,
 		(GTK_COMBO_BOX (dialog->combobox), 0);
 
 	screen = gtk_window_get_screen (GTK_WINDOW (dialog->run_dialog));
-	scale = gtk_widget_get_scale_factor (GTK_WIDGET (dialog->run_dialog));
 
         /* 1/4 the width of the first monitor should be a good value */
-	width_request = panel_multiscreen_width (screen, 0) / (4 * scale);
+	width_request = panel_multiscreen_width (screen, 0) / 4;
 	g_object_set (G_OBJECT (dialog->combobox),
 		      "width_request", width_request,
 		      NULL);

--- a/mate-panel/panel-struts.c
+++ b/mate-panel/panel-struts.c
@@ -75,17 +75,10 @@ panel_struts_get_monitor_geometry (GdkScreen *screen,
 				   int       *width,
 				   int       *height)
 {
-        GdkDisplay *display;
-        int scale;
-
-        /* Use scale factor to bring strut dimensions up to application pixels to support HiDPI displays */
-        display = gdk_screen_get_display (screen);
-        scale = gdk_monitor_get_scale_factor (gdk_display_get_monitor (display, monitor));
-
-        *x      = panel_multiscreen_x      (screen, monitor) * scale;
-        *y      = panel_multiscreen_y      (screen, monitor) * scale;
-        *width  = panel_multiscreen_width  (screen, monitor) * scale;
-        *height = panel_multiscreen_height (screen, monitor) * scale;
+        *x      = panel_multiscreen_x      (screen, monitor);
+        *y      = panel_multiscreen_y      (screen, monitor);
+        *width  = panel_multiscreen_width  (screen, monitor);
+        *height = panel_multiscreen_height (screen, monitor);
 }
 
 static PanelStrut *
@@ -263,6 +256,7 @@ panel_struts_set_window_hint (PanelToplevel *toplevel)
 	int         monitor_x, monitor_y, monitor_width, monitor_height;
 	int         screen_width, screen_height;
 	int         leftmost, rightmost, topmost, bottommost;
+	int         scale;
 
 	widget = GTK_WIDGET (toplevel);
 
@@ -274,10 +268,11 @@ panel_struts_set_window_hint (PanelToplevel *toplevel)
 		return;
 	}
 
+	scale = gtk_widget_get_scale_factor (widget);
 	strut_size = strut->allocated_strut_size;
 
-	screen_width  = WidthOfScreen (gdk_x11_screen_get_xscreen (strut->screen));
-	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (strut->screen));
+	screen_width  = WidthOfScreen (gdk_x11_screen_get_xscreen (strut->screen)) / scale;
+	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (strut->screen)) / scale;
 
 	panel_struts_get_monitor_geometry (strut->screen,
 					   strut->monitor,
@@ -322,8 +317,8 @@ panel_struts_set_window_hint (PanelToplevel *toplevel)
 	panel_xutils_set_strut (gtk_widget_get_window (widget),
 				strut->orientation,
 				strut_size,
-				strut->allocated_strut_start,
-				strut->allocated_strut_end);
+				strut->allocated_strut_start * scale,
+				strut->allocated_strut_end * scale);
 }
 
 void
@@ -449,24 +444,32 @@ panel_struts_register_strut (PanelToplevel    *toplevel,
 		strut->geometry.y      = monitor_y;
 		strut->geometry.width  = strut->strut_end - strut->strut_start + 1;
 		strut->geometry.height = strut->strut_size / scale;
+		if (scale > 1)
+			strut->geometry.width -= (strut->strut_size / scale);
 		break;
 	case PANEL_ORIENTATION_BOTTOM:
 		strut->geometry.x      = strut->strut_start;
 		strut->geometry.y      = monitor_y + monitor_height - strut->strut_size;
 		strut->geometry.width  = strut->strut_end - strut->strut_start + 1;
 		strut->geometry.height = strut->strut_size / scale;
+		if (scale > 1)
+			strut->geometry.width -= (strut->strut_size / scale);
 		break;
 	case PANEL_ORIENTATION_LEFT:
 		strut->geometry.x      = monitor_x;
 		strut->geometry.y      = strut->strut_start;
 		strut->geometry.width  = strut->strut_size / scale;
 		strut->geometry.height = strut->strut_end - strut->strut_start + 1;
+		if (scale > 1)
+			strut->geometry.height -= (strut->strut_size / scale);
 		break;
 	case PANEL_ORIENTATION_RIGHT:
 		strut->geometry.x      = monitor_x + monitor_width - strut->strut_size;
 		strut->geometry.y      = strut->strut_start;
 		strut->geometry.width  = strut->strut_size / scale;
 		strut->geometry.height = strut->strut_end - strut->strut_start + 1;
+		if (scale > 1)
+			strut->geometry.height -= (strut->strut_size / scale);
 		break;
 	}
 

--- a/mate-panel/panel-struts.c
+++ b/mate-panel/panel-struts.c
@@ -75,10 +75,17 @@ panel_struts_get_monitor_geometry (GdkScreen *screen,
 				   int       *width,
 				   int       *height)
 {
-        *x      = panel_multiscreen_x      (screen, monitor);
-        *y      = panel_multiscreen_y      (screen, monitor);
-        *width  = panel_multiscreen_width  (screen, monitor);
-        *height = panel_multiscreen_height (screen, monitor);
+        GdkDisplay *display;
+        int scale;
+
+        /* Use scale factor to bring strut dimensions up to application pixels to support HiDPI displays */
+        display = gdk_screen_get_display (screen);
+        scale = gdk_monitor_get_scale_factor (gdk_display_get_monitor (display, monitor));
+
+        *x      = panel_multiscreen_x      (screen, monitor) * scale;
+        *y      = panel_multiscreen_y      (screen, monitor) * scale;
+        *width  = panel_multiscreen_width  (screen, monitor) * scale;
+        *height = panel_multiscreen_height (screen, monitor) * scale;
 }
 
 static PanelStrut *

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -290,8 +290,7 @@ static GdkScreen* panel_toplevel_get_screen_geometry(PanelToplevel* toplevel, in
 	 * sorts of awful misalignments and pretend it's all good. Or we can just
 	 * make this thing think that the screen is scaled down, and because GTK+
 	 * already scaled everything up without the panel knowing about it, the whole
-	 * thing somehow works well... sigh.
-	 * @see panel_toplevel_get_monitor_geometry() */
+	 * thing somehow works well... sigh. */
 	*width  = WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) / toplevel->priv->scale;
 	*height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) / toplevel->priv->scale;
 
@@ -307,24 +306,17 @@ static GdkScreen* panel_toplevel_get_monitor_geometry(PanelToplevel* toplevel, i
 
 	screen = gtk_window_get_screen(GTK_WINDOW(toplevel));
 
-	if (x) *x = panel_multiscreen_x(screen, toplevel->priv->monitor) / toplevel->priv->scale;
-	if (y) *y = panel_multiscreen_y(screen, toplevel->priv->monitor) / toplevel->priv->scale;
+	if (x) *x = panel_multiscreen_x(screen, toplevel->priv->monitor);
+	if (y) *y = panel_multiscreen_y(screen, toplevel->priv->monitor);
 
-	/* To scale the panels up for HiDPI displays, we can either multiply a lot of
-	 * toplevel geometry attributes by the scale factor, then correct for all
-	 * sorts of awful misalignments and pretend it's all good. Or we can just
-	 * make this thing think that the screen is scaled down, and because GTK+
-	 * already scaled everything up without the panel knowing about it, the whole
-	 * thing somehow works well... sigh.
-	 * @see panel_toplevel_get_screen_geometry() */
 	if (width)
 	{
-		*width  = panel_multiscreen_width(screen, toplevel->priv->monitor) / toplevel->priv->scale;
+		*width  = panel_multiscreen_width(screen, toplevel->priv->monitor);
 	}
 
 	if (height)
 	{
-		*height = panel_multiscreen_height(screen, toplevel->priv->monitor) / toplevel->priv->scale;
+		*height = panel_multiscreen_height(screen, toplevel->priv->monitor);
 	}
 
 	return screen;


### PR DESCRIPTION
This allows for supporting multiple monitors in HiDPI.

_Caveat_: I do _not_ own an external HiDPI monitor, so I use `xrandr` in the command line to set the scale and positioning of the second monitor.

@flexiondotorg - I think you're the only one here with both a HiDPI laptop _and_ a HiDPI external monitor. Could you test this, please?