### PR TITLE
hidpi: fix tray icon spacing with window-scaling > 1

### DIFF
--- a/applets/notification_area/system-tray/na-tray-child.c
+++ b/applets/notification_area/system-tray/na-tray-child.c
@@ -120,6 +120,8 @@ na_tray_child_get_preferred_width (GtkWidget *widget,
                                    gint      *minimal_width,
                                   gint      *natural_width)
 {
+  gint scale;
+  scale = gtk_widget_get_scale_factor (widget);
   GTK_WIDGET_CLASS (na_tray_child_parent_class)->get_preferred_width (widget,
                                                                       minimal_width,
                                                                       natural_width);
@@ -129,6 +131,9 @@ na_tray_child_get_preferred_width (GtkWidget *widget,
 
   if (*natural_width < 16)
     *natural_width = 16;
+
+  *minimal_width = *minimal_width / scale;
+  *natural_width = *natural_width / scale;
 }
 
 static void
@@ -136,6 +141,8 @@ na_tray_child_get_preferred_height (GtkWidget *widget,
                                     gint      *minimal_height,
                                     gint      *natural_height)
 {
+  gint scale;
+  scale = gtk_widget_get_scale_factor (widget);
   GTK_WIDGET_CLASS (na_tray_child_parent_class)->get_preferred_height (widget,
                                                                        minimal_height,
                                                                        natural_height);
@@ -145,6 +152,9 @@ na_tray_child_get_preferred_height (GtkWidget *widget,
 
   if (*natural_height < 16)
     *natural_height = 16;
+
+  *minimal_height = *minimal_height / scale;
+  *natural_height = *natural_height / scale;
 }
 
 static void

--- a/applets/notification_area/system-tray/na-tray.c
+++ b/applets/notification_area/system-tray/na-tray.c
@@ -127,7 +127,8 @@ tray_added (NaTrayManager *manager,
 
   na_host_emit_item_added (NA_HOST (tray), NA_ITEM (icon));
 
-  gtk_widget_show (GTK_WIDGET (icon));
+  /*Does not seem to be needed anymore and can cause a render issue with hidpi*/
+  /*gtk_widget_show (GTK_WIDGET (icon));*/
 }
 
 static void


### PR DESCRIPTION
Fix too wide spacing of tray icons when window-scaling-factor = 2 or more. Tested both in and out of process, and in both vertical and horizontal panels.