### PR TITLE
Accessibility: white/black applet handles in GNOME high contrast themes

### DIFF
--- a/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
@@ -245,6 +245,8 @@ mate_panel_applet_frame_dbus_change_background (MatePanelAppletFrame    *frame,
 	MatePanelAppletFrameDBus *dbus_frame = MATE_PANEL_APPLET_FRAME_DBUS (frame);
 	MatePanelAppletFrameDBusPrivate *priv = dbus_frame->priv;
 	char *bg_str;
+    gchar *theme_name;
+    GtkSettings *settings;
 
 	bg_str = _mate_panel_applet_frame_get_background_string (
 			frame, PANEL_WIDGET (gtk_widget_get_parent (GTK_WIDGET (frame))), type);
@@ -264,34 +266,65 @@ mate_panel_applet_frame_dbus_change_background (MatePanelAppletFrame    *frame,
 	}
     GtkCssProvider *provider;
     provider = gtk_css_provider_new ();
-	gtk_css_provider_load_from_data (provider,
-		"MatePanelAppletFrameDBus > MatePanelAppletFrameDBus { \n"
-        "border-style: solid; \n"
-        "border-width: 3px; \n"
-        "border-color: transparent; \n"
-        "background-repeat: no-repeat; \n"
-        "background-position: left; \n"
-        "background-image: linear-gradient(to bottom, \n"
-        "transparent, \n"
-        "transparent 20%, \n"
-        "alpha (#999999, 0.6) 21%, \n"
-        "alpha (#999999, 0.6) 29%, \n"
-        "transparent 30%, \n"
-        "transparent 45%, \n"
-        "alpha (#999999, 0.6) 46%, \n"
-        "alpha (#999999, 0.6) 54%, \n"
-        "transparent 55%, \n"
-        "transparent 70%, \n"
-        "alpha (#999999, 0.6) 71%, \n"
-        "alpha (#999999, 0.6) 79%, \n"
-        "transparent 80%, \n"
-        "transparent); \n"
-        "}",
-        -1, NULL);
+
+    settings = gtk_settings_get_default();
+    g_object_get (settings, "gtk-theme-name", &theme_name, NULL);
+
+    /*Special case the GNOME high contrast themes*/
+    if (g_strcmp0 (theme_name, "HighContrast") == 0 ||
+                   g_strcmp0 (theme_name, "HighContrastInverse") == 0){
+        gtk_css_provider_load_from_data (provider,
+            "MatePanelAppletFrameDBus > MatePanelAppletFrameDBus { \n"
+            "border-style: solid; \n"
+            "border-width: 3px; \n"
+            "border-color: @theme_bg_color; \n"
+            "background-repeat: no-repeat; \n"
+            "background-position: left; \n"
+            "background-image: linear-gradient(to bottom, \n"
+            "@theme_fg_color, \n"
+            "@theme_fg_color 25%, \n"
+            "@theme_bg_color 28%, \n"
+            "@theme_bg_color 33%, \n"
+            "@theme_fg_color 34%, \n"
+            "@theme_fg_color 65%, \n"
+            "@theme_bg_color 66%, \n"
+            "@theme_bg_color 72%, \n"
+            "@theme_fg_color 75%, \n"
+            "@theme_fg_color); \n"
+            "}",
+            -1, NULL);
+    }
+    else{
+	    gtk_css_provider_load_from_data (provider,
+            "MatePanelAppletFrameDBus > MatePanelAppletFrameDBus { \n"
+            "border-style: solid; \n"
+            "border-width: 3px; \n"
+            "border-color: transparent; \n"
+            "background-repeat: no-repeat; \n"
+            "background-position: left; \n"
+            "background-image: linear-gradient(to bottom, \n"
+            "transparent, \n"
+            "transparent 20%, \n"
+            "alpha (#999999, 0.6) 21%, \n"
+            "alpha (#999999, 0.6) 29%, \n"
+            "transparent 30%, \n"
+            "transparent 45%, \n"
+            "alpha (#999999, 0.6) 46%, \n"
+            "alpha (#999999, 0.6) 54%, \n"
+            "transparent 55%, \n"
+            "transparent 70%, \n"
+            "alpha (#999999, 0.6) 71%, \n"
+            "alpha (#999999, 0.6) 79%, \n"
+            "transparent 80%, \n"
+            "transparent); \n"
+            "}",
+            -1, NULL);
+        }
 	gtk_style_context_add_provider (gtk_widget_get_style_context(GTK_WIDGET(frame)),
-		GTK_STYLE_PROVIDER (provider),
-		GTK_STYLE_PROVIDER_PRIORITY_FALLBACK);
-	g_object_unref (provider);
+                                    GTK_STYLE_PROVIDER (provider),
+                                    GTK_STYLE_PROVIDER_PRIORITY_FALLBACK);
+    g_object_unref (provider);
+    g_free (theme_name);
 }
 
 static void


### PR DESCRIPTION
Special case the GNOME HighContrast and HighContrastInverse themes to give max contrast on tray and window list applet handles. Follow-on to https://github.com/mate-desktop/mate-panel/commit/2e0a74d9458480966f2a87d1d66a58552a873300