### PR TITLE
Theme: consistant theming for applet drag handles in all themes

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -7,6 +7,11 @@ layout_DATA = \
 	opensuse.layout \
 	ubuntu.layout
 
+matepaneldir   = $(datadir)/mate-panel
+matepanel_DATA = \
+    mate-panel.css  \
+    panel-grid-symbolic.svg
+
 @INTLTOOL_XML_NOMERGE_RULE@
 
 gsettings_ENUM_NAMESPACE = org.mate.panel

--- a/data/mate-panel.css
+++ b/data/mate-panel.css
@@ -1,0 +1,10 @@
+
+MatePanelAppletFrameDBus > MatePanelAppletFrameDBus {
+	border-style: none;
+	background-repeat: no-repeat;
+	background-position: left;
+	color: @theme_fg_color;
+	background-image: -gtk-recolor(url("panel-grid-symbolic.svg"));
+	background-size: 12px 22px;
+}
+

--- a/data/panel-grid-symbolic.svg
+++ b/data/panel-grid-symbolic.svg
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="view-more-symbolic.svg"
+   height="22"
+   id="svg7384"
+   inkscape:version="0.91 r13725"
+   version="1.1"
+   width="12">
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:bbox-nodes="false"
+     inkscape:bbox-paths="true"
+     bordercolor="#666666"
+     borderopacity="1"
+     inkscape:current-layer="layer12"
+     inkscape:cx="37.386562"
+     inkscape:cy="10"
+     gridtolerance="10"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     id="namedview88"
+     inkscape:object-nodes="false"
+     inkscape:object-paths="false"
+     objecttolerance="10"
+     pagecolor="#3a3b39"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     showborder="true"
+     showgrid="false"
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-others="false"
+     inkscape:snap-to-guides="true"
+     inkscape:window-height="444"
+     inkscape:window-maximized="0"
+     inkscape:window-width="534"
+     inkscape:window-x="788"
+     inkscape:window-y="500"
+     inkscape:zoom="2.8284271">
+    <inkscape:grid
+       empspacing="2"
+       enabled="true"
+       id="grid4866"
+       originx="119.9998px"
+       originy="650px"
+       snapvisiblegridlinesonly="true"
+       spacingx="1px"
+       spacingy="1px"
+       type="xygrid"
+       visible="true" />
+    <inkscape:grid
+       color="#000000"
+       empcolor="#000000"
+       empopacity="0"
+       empspacing="4"
+       enabled="true"
+       id="grid5968"
+       opacity="0.1254902"
+       originx="119.9998px"
+       originy="650px"
+       snapvisiblegridlinesonly="true"
+       spacingx="0.5px"
+       spacingy="0.5px"
+       type="xygrid"
+       visible="true" />
+  </sodipodi:namedview>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="status"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer10"
+     inkscape:label="devices"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer11"
+     inkscape:label="apps"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer13"
+     inkscape:label="places"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer14"
+     inkscape:label="mimetypes"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer15"
+     inkscape:label="emblems"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="g71291"
+     inkscape:label="emotes"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="g4953"
+     inkscape:label="categories"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer12"
+     inkscape:label="actions"
+     style="display:inline"
+     transform="translate(-121.0004,-861)">
+    <rect
+       height="4"
+       id="rect20592"
+       rx="0.38461545"
+       ry="0.50229359"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#555555;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4"
+       x="125.23243"
+       y="864.17157" />
+    <rect
+       height="4"
+       id="rect16730"
+       rx="0.38461545"
+       ry="0.50229359"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#555555;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4"
+       x="125.23243"
+       y="870.17157" />
+    <rect
+       height="4"
+       id="rect16732"
+       rx="0.38461545"
+       ry="0.50229359"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#555555;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4"
+       x="125.23243"
+       y="876.17157" />
+  </g>
+</svg>

--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -15,6 +15,7 @@ AM_CPPFLAGS = \
 	-DMATELOCALEDIR=\""$(prefix)/$(DATADIRNAME)/locale"\" \
 	-DBUILDERDIR=\""$(uidir)"\" \
 	-DPANELDATADIR=\""$(datadir)/mate-panel"\" \
+	-DDATADIR=\""$(datadir)"\"
 	-DICONDIR=\""$(datadir)/mate-panel/pixmaps"\" \
 	$(DISABLE_DEPRECATED_CFLAGS)
 

--- a/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
@@ -245,8 +245,6 @@ mate_panel_applet_frame_dbus_change_background (MatePanelAppletFrame    *frame,
 	MatePanelAppletFrameDBus *dbus_frame = MATE_PANEL_APPLET_FRAME_DBUS (frame);
 	MatePanelAppletFrameDBusPrivate *priv = dbus_frame->priv;
 	char *bg_str;
-    gchar *theme_name;
-    GtkSettings *settings;
 
 	bg_str = _mate_panel_applet_frame_get_background_string (
 			frame, PANEL_WIDGET (gtk_widget_get_parent (GTK_WIDGET (frame))), type);
@@ -264,67 +262,6 @@ mate_panel_applet_frame_dbus_change_background (MatePanelAppletFrame    *frame,
 
 		g_free (bg_str);
 	}
-    GtkCssProvider *provider;
-    provider = gtk_css_provider_new ();
-
-    settings = gtk_settings_get_default();
-    g_object_get (settings, "gtk-theme-name", &theme_name, NULL);
-
-    /*Special case the GNOME high contrast themes*/
-    if (g_strcmp0 (theme_name, "HighContrast") == 0 ||
-                   g_strcmp0 (theme_name, "HighContrastInverse") == 0){
-        gtk_css_provider_load_from_data (provider,
-            "MatePanelAppletFrameDBus > MatePanelAppletFrameDBus { \n"
-            "border-style: solid; \n"
-            "border-width: 3px; \n"
-            "border-color: @theme_bg_color; \n"
-            "background-repeat: no-repeat; \n"
-            "background-position: left; \n"
-            "background-image: linear-gradient(to bottom, \n"
-            "@theme_fg_color, \n"
-            "@theme_fg_color 25%, \n"
-            "@theme_bg_color 28%, \n"
-            "@theme_bg_color 33%, \n"
-            "@theme_fg_color 34%, \n"
-            "@theme_fg_color 65%, \n"
-            "@theme_bg_color 66%, \n"
-            "@theme_bg_color 72%, \n"
-            "@theme_fg_color 75%, \n"
-            "@theme_fg_color); \n"
-            "}",
-            -1, NULL);
-    }
-    else{
-	    gtk_css_provider_load_from_data (provider,
-            "MatePanelAppletFrameDBus > MatePanelAppletFrameDBus { \n"
-            "border-style: solid; \n"
-            "border-width: 3px; \n"
-            "border-color: transparent; \n"
-            "background-repeat: no-repeat; \n"
-            "background-position: left; \n"
-            "background-image: linear-gradient(to bottom, \n"
-            "transparent, \n"
-            "transparent 20%, \n"
-            "alpha (#999999, 0.6) 21%, \n"
-            "alpha (#999999, 0.6) 29%, \n"
-            "transparent 30%, \n"
-            "transparent 45%, \n"
-            "alpha (#999999, 0.6) 46%, \n"
-            "alpha (#999999, 0.6) 54%, \n"
-            "transparent 55%, \n"
-            "transparent 70%, \n"
-            "alpha (#999999, 0.6) 71%, \n"
-            "alpha (#999999, 0.6) 79%, \n"
-            "transparent 80%, \n"
-            "transparent); \n"
-            "}",
-            -1, NULL);
-        }
-	gtk_style_context_add_provider (gtk_widget_get_style_context(GTK_WIDGET(frame)),
-                                    GTK_STYLE_PROVIDER (provider),
-                                    GTK_STYLE_PROVIDER_PRIORITY_FALLBACK);
-    g_object_unref (provider);
-    g_free (theme_name);
 }
 
 static void

--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -60,7 +60,8 @@ main (int argc, char **argv)
 {
 	char           *desktopfile;
 	GOptionContext *context;
-	GError         *error;
+	GError         *error, *error2;
+	GtkCssProvider *provider;
 
 	bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
@@ -165,6 +166,23 @@ main (int argc, char **argv)
 	/* Do this at the end, to be sure that we're really ready when
 	 * connecting to the session manager */
 	panel_session_init ();
+
+    /*Load a css file from a path so the drag handle image can be loaded*/
+    error2 = NULL;
+    provider = gtk_css_provider_new ();
+	        gtk_css_provider_load_from_path (provider,
+				DATADIR "/mate-panel/" "mate-panel.css", &error2);
+
+    if (error2 != NULL) {
+        g_warning ("Can't parse mate-panel CSS custom description: %s\n", error2->message);
+        g_error_free (error2);
+    }
+    else {
+	    gtk_style_context_add_provider_for_screen (gdk_screen_get_default(),
+                                    GTK_STYLE_PROVIDER (provider),
+                                    GTK_STYLE_PROVIDER_PRIORITY_FALLBACK);
+    }
+     g_object_unref (provider);
 
 	gtk_main ();
 


### PR DESCRIPTION
*Do NOT use border, as it is not overridden in MATE themes and pushes the image out of place
*Use two gradient images to make a 3x3 grid resembling MATE theme 3 holes image that works in both vertical and horizontal panels
*Note that while drag handle now shows in vertical panel, it only scales in horizontal panel as px and not % must be used in horizontal direction