### PR TITLE
Applet-handle: remove border as themes don't override it

### DIFF
--- a/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
@@ -297,9 +297,7 @@ mate_panel_applet_frame_dbus_change_background (MatePanelAppletFrame    *frame,
     else{
 	    gtk_css_provider_load_from_data (provider,
             "MatePanelAppletFrameDBus > MatePanelAppletFrameDBus { \n"
-            "border-style: solid; \n"
-            "border-width: 3px; \n"
-            "border-color: transparent; \n"
+            "border-style: none; \n"
             "background-repeat: no-repeat; \n"
             "background-position: left; \n"
             "background-image: linear-gradient(to bottom, \n"


### PR DESCRIPTION
Remove border from default applet drag handle, it clips image used in mate-themes Simpler alternate to https://github.com/mate-desktop/mate-panel/pull/782 but not as pretty in GNOME themes