### PR TITLE
fix menubar behaviour when using auto-hide

### DIFF
--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -3805,6 +3805,7 @@ panel_toplevel_queue_auto_hide (PanelToplevel *toplevel)
 	g_return_if_fail (PANEL_IS_TOPLEVEL (toplevel));
 
 	if (!toplevel->priv->auto_hide ||
+	    panel_toplevel_contains_pointer (toplevel) ||
 	    panel_toplevel_get_autohide_disabled (toplevel))
 	  return;
 


### PR DESCRIPTION
Revert "panel-toplevel: Remove pointer boundary check in panel_toplevel queue_auto_hide()"

This reverts commit 0d29acf6a70090ee771de2793b1af8e1388a430f.

Which causes a regression.
Fixes https://github.com/mate-desktop/mate-panel/issues/773