### PR TITLE
applet.c: avoid deprecated GtkImageMenuItem

### DIFF
--- a/mate-panel/libpanel-util/panel-gtk.c
+++ b/mate-panel/libpanel-util/panel-gtk.c
@@ -164,22 +164,68 @@ GtkWidget *
 panel_image_menu_item_new_from_icon (const gchar *icon_name,
 				     const gchar *label_name)
 {
-    GtkWidget *icon;
-    GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+	GtkWidget *icon;
+	GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
 
-    if (icon_name)
-        icon = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
-    else
-        icon = gtk_image_new ();
+	if (icon_name)
+		icon = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+	else
+		icon = gtk_image_new ();
 
-    GtkWidget *label_menu = gtk_label_new_with_mnemonic (g_strconcat (label_name, "     ", NULL));
-    GtkWidget *menuitem = gtk_menu_item_new ();
+	GtkWidget *label_menu = gtk_label_new_with_mnemonic (g_strconcat (label_name, "     ", NULL));
+	GtkWidget *menuitem = gtk_menu_item_new ();
  
-    gtk_container_add (GTK_CONTAINER (box), icon);
-    gtk_container_add (GTK_CONTAINER (box), label_menu);
+	gtk_container_add (GTK_CONTAINER (box), icon);
+	gtk_container_add (GTK_CONTAINER (box), label_menu);
  
-    gtk_container_add (GTK_CONTAINER (menuitem), box);
-    gtk_widget_show_all (menuitem);
+	gtk_container_add (GTK_CONTAINER (menuitem), box);
+	gtk_widget_show_all (menuitem);
 
-    return menuitem;
+	return menuitem;
+}
+
+GtkWidget *
+panel_image_menu_item_new_from_gicon (GIcon       *gicon,
+				      const gchar *label_name)
+{
+	GtkWidget *icon;
+	GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+
+	if (gicon)
+		icon = gtk_image_new_from_gicon (gicon, GTK_ICON_SIZE_MENU);
+	else
+		icon = gtk_image_new ();
+
+	GtkWidget *label_menu = gtk_label_new_with_mnemonic (g_strconcat (label_name, "     ", NULL));
+	GtkWidget *menuitem = gtk_menu_item_new ();
+ 
+	gtk_container_add (GTK_CONTAINER (box), icon);
+	gtk_container_add (GTK_CONTAINER (box), label_menu);
+ 
+	gtk_container_add (GTK_CONTAINER (menuitem), box);
+	gtk_widget_show_all (menuitem);
+
+	return menuitem;
+}
+
+GtkWidget *
+panel_check_menu_item_new (GtkWidget *widget_check)
+{
+	GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+	GtkWidget *menuitem = gtk_menu_item_new ();
+	GtkWidget *label_name = gtk_bin_get_child (GTK_BIN (widget_check));
+
+	gtk_label_set_text_with_mnemonic (GTK_LABEL (label_name),
+					  g_strconcat (gtk_label_get_label (GTK_LABEL (label_name)), "     ", NULL));
+
+	gtk_widget_set_margin_start (widget_check, 2);
+	gtk_widget_set_margin_start (gtk_bin_get_child (GTK_BIN (widget_check)), 11);
+	gtk_box_pack_start (GTK_BOX (box), widget_check, FALSE, FALSE, 5);
+
+	gtk_container_add (GTK_CONTAINER (menuitem), box);
+	gtk_widget_show_all (menuitem);
+
+	gtk_label_set_mnemonic_widget (GTK_LABEL (label_name), menuitem);
+
+	return menuitem;
 }

--- a/mate-panel/libpanel-util/panel-gtk.h
+++ b/mate-panel/libpanel-util/panel-gtk.h
@@ -49,6 +49,11 @@ GtkWidget* panel_file_chooser_dialog_new (const gchar          *title,
 GtkWidget* panel_image_menu_item_new_from_icon (const gchar *icon_name,
 						const gchar *label_name);
 
+GtkWidget* panel_image_menu_item_new_from_gicon (GIcon       *gicon,
+						 const gchar *label_name);
+
+GtkWidget* panel_check_menu_item_new (GtkWidget *widget_check);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
avoid deprecated:

gtk_image_menu_item_new_with_mnemonic
gtk_image_menu_item_set_image

![finalprapplet](https://user-images.githubusercontent.com/7734191/39100108-f38250a2-4684-11e8-8d2f-51d090364a3e.png)

**EDIT:** this PR needs to work with https://github.com/mate-desktop/mate-themes/pull/219