### PR TITLE
Convert launcher icons to cairo surfaces

### DIFF
--- a/applets/clock/clock-location-tile.c
+++ b/applets/clock/clock-location-tile.c
@@ -584,11 +584,14 @@ weather_info_setup_tooltip (WeatherInfo *info, ClockLocation *location, GtkToolt
         const gchar *sys_timezone;
         time_t sunrise_time, sunset_time;
         gchar *sunrise_str, *sunset_str;
+        gint icon_scale;
 
-        icon_name = weather_info_get_icon_name (info);
         theme = gtk_icon_theme_get_default ();
-        pixbuf = gtk_icon_theme_load_icon (theme, icon_name, 48,
-                                           GTK_ICON_LOOKUP_GENERIC_FALLBACK, NULL);
+        icon_name = weather_info_get_icon_name (info);
+        icon_scale = gdk_window_get_scale_factor (gdk_get_default_root_window ());
+
+        pixbuf = gtk_icon_theme_load_icon_for_scale (theme, icon_name, 48, icon_scale,
+                                                     GTK_ICON_LOOKUP_GENERIC_FALLBACK, NULL);
         if (pixbuf)
                 gtk_tooltip_set_icon (tooltip, pixbuf);
 
@@ -654,7 +657,7 @@ weather_info_setup_tooltip (WeatherInfo *info, ClockLocation *location, GtkToolt
 static gboolean
 weather_tooltip (GtkWidget  *widget,
                  gint        x,
-                 gint             y,
+                 gint        y,
                  gboolean    keyboard_mode,
                  GtkTooltip *tooltip,
                  gpointer    data)
@@ -681,20 +684,23 @@ update_weather_icon (ClockLocation *loc, WeatherInfo *info, gpointer data)
 {
         ClockLocationTile *tile = data;
         ClockLocationTilePrivate *priv = PRIVATE (tile);
-        GdkPixbuf *pixbuf = NULL;
+        cairo_surface_t *surface = NULL;
         GtkIconTheme *theme = NULL;
         const gchar *icon_name;
+        gint icon_scale;
 
         if (!info || !weather_info_is_valid (info))
                 return;
 
+        theme = gtk_icon_theme_get_for_screen (gtk_widget_get_screen (GTK_WIDGET (priv->weather_icon)));
         icon_name = weather_info_get_icon_name (info);
-        theme = gtk_icon_theme_get_default ();
-        pixbuf = gtk_icon_theme_load_icon (theme, icon_name, 16,
-                                           GTK_ICON_LOOKUP_GENERIC_FALLBACK, NULL);
+        icon_scale = gtk_widget_get_scale_factor (GTK_WIDGET (priv->weather_icon));
 
-        if (pixbuf) {
-                gtk_image_set_from_pixbuf (GTK_IMAGE (priv->weather_icon), pixbuf);
+        surface = gtk_icon_theme_load_surface (theme, icon_name, 16, icon_scale,
+                                               NULL, GTK_ICON_LOOKUP_GENERIC_FALLBACK, NULL);
+
+        if (surface) {
+                gtk_image_set_from_surface (GTK_IMAGE (priv->weather_icon), surface);
                 gtk_widget_set_margin_end (priv->weather_icon, 6);
         }
 }

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1975,7 +1975,8 @@ location_weather_updated_cb (ClockLocation *location,
         const gchar *icon_name;
         const gchar *temp;
         GtkIconTheme *theme;
-        GdkPixbuf *pixbuf;
+        cairo_surface_t *surface;
+        gint icon_size, icon_scale;
 
         if (!info || !weather_info_is_valid (info))
                 return;
@@ -1984,15 +1985,23 @@ location_weather_updated_cb (ClockLocation *location,
                 return;
 
         icon_name = weather_info_get_icon_name (info);
-        /* FIXME: mmh, screen please? Also, don't hardcode to 16 */
-        theme = gtk_icon_theme_get_default ();
-        pixbuf = gtk_icon_theme_load_icon (theme, icon_name, 16,
-                                           GTK_ICON_LOOKUP_GENERIC_FALLBACK, NULL);
+        if (icon_name == NULL)
+                return;
+
+        theme = gtk_icon_theme_get_for_screen (gtk_widget_get_screen (GTK_WIDGET (cd->applet)));
+
+        icon_size = mate_panel_applet_get_size (MATE_PANEL_APPLET (cd->applet));
+        icon_scale = gtk_widget_get_scale_factor (GTK_WIDGET (cd->applet));
+
+        surface = gtk_icon_theme_load_surface (theme, icon_name, icon_size, icon_scale,
+                                               NULL, GTK_ICON_LOOKUP_GENERIC_FALLBACK, NULL);
 
         temp = weather_info_get_temp_summary (info);
 
-        gtk_image_set_from_pixbuf (GTK_IMAGE (cd->panel_weather_icon), pixbuf);
+        gtk_image_set_from_surface (GTK_IMAGE (cd->panel_weather_icon), surface);
         gtk_label_set_text (GTK_LABEL (cd->panel_temperature_label), temp);
+
+        cairo_surface_destroy (surface);
 }
 
 static void

--- a/mate-panel/button-widget.h
+++ b/mate-panel/button-widget.h
@@ -51,7 +51,7 @@ void             button_widget_set_ignore_leave  (ButtonWidget     *button,
 						  gboolean          ignore_leave);
 gboolean         button_widget_get_ignore_leave  (ButtonWidget     *button);
 GtkIconTheme    *button_widget_get_icon_theme    (ButtonWidget     *button);
-GdkPixbuf       *button_widget_get_pixbuf        (ButtonWidget     *button);
+cairo_surface_t *button_widget_get_surface       (ButtonWidget     *button);
 
 #ifdef __cplusplus
 }

--- a/mate-panel/panel-util.c
+++ b/mate-panel/panel-util.c
@@ -327,7 +327,7 @@ panel_find_icon (GtkIconTheme  *icon_theme,
 	return retval;
 }
 
-GdkPixbuf *
+cairo_surface_t *
 panel_load_icon (GtkIconTheme  *icon_theme,
 		 const char    *icon_name,
 		 int            size,
@@ -335,7 +335,8 @@ panel_load_icon (GtkIconTheme  *icon_theme,
 		 int            desired_height,
 		 char         **error_msg)
 {
-	GdkPixbuf *retval;
+	GdkPixbuf *pixbuf;
+	cairo_surface_t *surface;
 	char      *file;
 	GError    *error;
 
@@ -351,19 +352,25 @@ panel_load_icon (GtkIconTheme  *icon_theme,
 	}
 
 	error = NULL;
-	retval = gdk_pixbuf_new_from_file_at_size (file,
+	pixbuf = gdk_pixbuf_new_from_file_at_scale (file,
 						   desired_width,
 						   desired_height,
+						   TRUE,
 						   &error);
 	if (error) {
 		if (error_msg)
 			*error_msg = g_strdup (error->message);
 		g_error_free (error);
+		surface = NULL;
+	}
+	else {
+		surface = gdk_cairo_surface_create_from_pixbuf (pixbuf, 0, NULL);
 	}
 
 	g_free (file);
+	g_object_unref (pixbuf);
 
-	return retval;
+	return surface;
 }
 
 static char* panel_lock_screen_action_get_command(const char* action)

--- a/mate-panel/panel-util.h
+++ b/mate-panel/panel-util.h
@@ -31,7 +31,7 @@ GIcon *         panel_gicon_from_icon_name (const char *icon_name);
 char *          panel_find_icon         (GtkIconTheme  *icon_theme,
 					 const char    *icon_name,
 					 int            size);
-GdkPixbuf *     panel_load_icon         (GtkIconTheme  *icon_theme,
+cairo_surface_t *panel_load_icon        (GtkIconTheme  *icon_theme,
 					 const char    *icon_name,
 					 int            size,
 					 int            desired_width,

--- a/mate-panel/xstuff.c
+++ b/mate-panel/xstuff.c
@@ -328,7 +328,7 @@ draw_zoom_animation (GdkScreen *gscreen,
 
 void
 xstuff_zoom_animate (GtkWidget *widget,
-		     GdkPixbuf *pixbuf,
+		     cairo_surface_t *surface,
 		     PanelOrientation orientation,
 		     GdkRectangle *opt_rect)
 {
@@ -353,12 +353,17 @@ xstuff_zoom_animate (GtkWidget *widget,
 
 	gscreen = gtk_widget_get_screen (widget);
 
-	if (gdk_screen_is_composited (gscreen) && pixbuf)
+	if (gdk_screen_is_composited (gscreen) && surface) {
+		GdkPixbuf *pixbuf = gdk_pixbuf_get_from_surface (surface,
+				0, 0,
+				cairo_image_surface_get_width (surface),
+				cairo_image_surface_get_height (surface));
 		draw_zoom_animation_composited (gscreen,
-						rect.x, rect.y,
-						rect.width, rect.height,
-						pixbuf, orientation);
-	else {
+				rect.x, rect.y,
+				rect.width, rect.height,
+				pixbuf, orientation);
+		g_object_unref (pixbuf);
+	} else {
 		display = gdk_screen_get_display (gscreen);
 		monitor = gdk_display_get_monitor_at_window (display,
 							     gtk_widget_get_window (widget));

--- a/mate-panel/xstuff.h
+++ b/mate-panel/xstuff.h
@@ -5,7 +5,7 @@
 #include <gtk/gtk.h>
 
 void xstuff_zoom_animate                (GtkWidget        *widget,
-					 GdkPixbuf        *pixbuf,
+					 cairo_surface_t  *surface,
 					 PanelOrientation  orientation,
 					 GdkRectangle     *opt_src_rect);
 


### PR DESCRIPTION
This improves support for HiDPI by loading properly scaled surfaces for
launcher and drawer icons.

It also fixes the Show Desktop wncklet to show a surface icon. Other
wncklets have their icons determined by libwnck, so they remain as
pixbufs.

Fixes mate-desktop/mate-desktop/issues/314