### PR TITLE
window-list: fix rendering when in-process and panel not expanded

### DIFF
--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -392,7 +392,7 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 										GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 	g_object_unref (provider);
 
-	mate_panel_applet_set_flags(MATE_PANEL_APPLET(tasklist->applet), MATE_PANEL_APPLET_EXPAND_MAJOR | MATE_PANEL_APPLET_EXPAND_MINOR | MATE_PANEL_APPLET_HAS_HANDLE);
+	mate_panel_applet_set_flags(MATE_PANEL_APPLET(tasklist->applet),  MATE_PANEL_APPLET_EXPAND_MINOR | MATE_PANEL_APPLET_HAS_HANDLE);
 
 	setup_gsettings(tasklist);
 


### PR DESCRIPTION
Fix https://github.com/mate-desktop/mate-panel/issues/797
Note that another issue (present in master) prevents removal of the clock, workspace-switcher, or window-list from an unexpanded panel, the offending panel (only that panel and not all panels) becoming unresponsive until restarted. 