### PR TITLE
Load menu icons only when "menus-have-icons" is set

### DIFF
--- a/data/theme/mate-panel.css
+++ b/data/theme/mate-panel.css
@@ -8,3 +8,6 @@ MatePanelAppletFrameDBus > MatePanelAppletFrameDBus {
 	background-size: 12px 22px;
 }
 
+.mate-panel-menu-icon-box{
+	min-width: 16px;
+}


### PR DESCRIPTION
Most panel menus excluding main menus. Duplicate behavior of now-deprecated code replaced by github.com/mate-desktop/mate-panel/commit/86701517e7d7cb3d2c08a40d76af97308f18902c