### PR TITLE
menu.c: Fix: Keep spaces in the left if "menus-have-icons" is off

### DIFF
--- a/data/theme/mate-panel.css
+++ b/data/theme/mate-panel.css
@@ -8,3 +8,6 @@ MatePanelAppletFrameDBus > MatePanelAppletFrameDBus {
 	background-size: 12px 22px;
 }
 
+.mate-panel-menu-icon-box{
+	min-width: 16px;
+}

--- a/mate-panel/menu.c
+++ b/mate-panel/menu.c
@@ -164,7 +164,7 @@ panel_create_menu (void)
 
 	retval = gtk_menu_new ();
 
-	gtk_menu_set_reserve_toggle_size (GTK_MENU (retval), FALSE);
+	gtk_menu_set_reserve_toggle_size (GTK_MENU (retval), TRUE);
 
 	gtk_widget_set_name (retval, "mate-panel-main-menu");
 

--- a/mate-panel/panel-context-menu.c
+++ b/mate-panel/panel-context-menu.c
@@ -230,6 +230,8 @@ panel_context_menu_build_edition (PanelWidget *panel_widget,
 {
 	GtkWidget *menuitem;
 
+	gtk_menu_set_reserve_toggle_size (GTK_MENU (menu), FALSE);
+
 	menuitem = panel_image_menu_item_new_from_icon ("list-add", _("_Add to Panel…"));
 
 	gtk_widget_show (menuitem);


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/mate-panel/pull/820#issuecomment-399709389