### PR TITLE
replace deprecated gtk_menu_popup

### DIFF
--- a/mate-panel/applet.c
+++ b/mate-panel/applet.c
@@ -736,13 +736,7 @@ applet_show_menu (AppletInfo     *info,
 	if (!gtk_widget_get_realized (info->menu))
 		gtk_widget_show (info->menu);
 
-	gtk_menu_popup (GTK_MENU (info->menu),
-			NULL,
-			NULL,
-			(GtkMenuPositionFunc) mate_panel_applet_position_menu,
-			info->widget,
-			event->button,
-			event->time);
+	gtk_menu_popup_at_pointer (GTK_MENU (info->menu), NULL);
 }
 
 static gboolean

--- a/mate-panel/panel-action-protocol.c
+++ b/mate-panel/panel-action-protocol.c
@@ -76,8 +76,7 @@ panel_action_protocol_main_menu (GdkScreen *screen,
 	panel_toplevel_push_autohide_disabler (panel_widget->toplevel);
 
 	gtk_menu_set_screen (GTK_MENU (menu), screen);
-	gtk_menu_popup (GTK_MENU (menu), NULL, NULL,
-			NULL, NULL, 0, activate_time);
+	gtk_menu_popup_at_pointer (GTK_MENU (menu), NULL);
 }
 
 static void

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -364,7 +364,7 @@ panel_popup_menu (PanelToplevel *toplevel,
 	gtk_menu_set_screen (GTK_MENU (menu),
 			     gtk_window_get_screen (GTK_WINDOW (toplevel)));
 
-	gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, NULL, button, activate_time);
+	gtk_menu_popup_at_pointer (GTK_MENU (menu), NULL);
 
 	return TRUE;
 }


### PR DESCRIPTION
There is one occurrence of `gtk_menu_popup` left in menu.c, but replacing it make problems with that context-menu inside the the menu of menubar and main-menu.
Please test.