### PR TITLE
GTK 3.23: fix applet size allocation

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1055,21 +1055,23 @@ mate_panel_applet_get_preferred_width (GtkWidget *widget,
 				       int       *minimum_width,
 				       int       *natural_width)
 {
-	MatePanelApplet *applet = MATE_PANEL_APPLET (widget);
-	gint scale;
-
 	GTK_WIDGET_CLASS (mate_panel_applet_parent_class)->get_preferred_width (widget,
 										minimum_width,
 										natural_width);
 
+#if !GTK_CHECK_VERSION (3, 23, 0)
+	MatePanelApplet *applet = MATE_PANEL_APPLET (widget);
 	if (applet->priv->out_of_process) {
-		/* Out-of-process applets end up scaled up doubly. We divide by the scale factor to ensure
+		/* Out-of-process applets end up scaled up doubly with GTK 3.22.
+         * For these builds divide by the scale factor to ensure
 		 * they are back at their own intended size.
 		 */
+		gint scale;
 		scale = gtk_widget_get_scale_factor (widget);
 		*minimum_width /= scale;
 		*natural_width /= scale;
 	}
+#endif
 }
 
 static void
@@ -1077,21 +1079,22 @@ mate_panel_applet_get_preferred_height (GtkWidget *widget,
 					int       *minimum_height,
 					int       *natural_height)
 {
-	MatePanelApplet *applet = MATE_PANEL_APPLET (widget);
-	gint scale;
-
 	GTK_WIDGET_CLASS (mate_panel_applet_parent_class)->get_preferred_height (widget,
 										minimum_height,
 										natural_height);
-
+#if !GTK_CHECK_VERSION (3, 23, 0)
+	MatePanelApplet *applet = MATE_PANEL_APPLET (widget);
 	if (applet->priv->out_of_process) {
-		/* Out-of-process applets end up scaled up doubly. We divide by the scale factor to ensure
+		gint scale;
+		/* Out-of-process applets end up scaled up doubly with GTK 3.22.
+         * For these builds divide by the scale factor to ensure
 		 * they are back at their own intended size.
 		 */
 		scale = gtk_widget_get_scale_factor (widget);
 		*minimum_height /= scale;
 		*natural_height /= scale;
 	}
+#endif
 }
 
 static GtkSizeRequestMode


### PR DESCRIPTION
Limit workaround for GTK 3.22 double width/height allocation to GTK 3.22 builds only. Fix https://github.com/mate-desktop/mate-panel/issues/843 in which out-of-process applets get only half their needed width with window-scaling=2. This issue is caused by
https://github.com/mate-desktop/mate-panel/commit/ff04f332136272a14c588da3f2d582ba0ff01be1
which is a fix for for out-of-process applets getting double their needed width. A bug in GTK 3.22 caused that and is fixed in GTK 3.23