### PR TITLE
Fix on wide panels (vert/horz)

### DIFF
--- a/applets/notification_area/Makefile.am
+++ b/applets/notification_area/Makefile.am
@@ -20,8 +20,8 @@ AM_CPPFLAGS =							\
 AM_CFLAGS = $(WARN_CFLAGS)
 
 libtray_la_SOURCES =				\
-	na-box.c				\
-	na-box.h				\
+	na-grid.c				\
+	na-grid.h				\
 	na-host.c				\
 	na-host.h				\
 	na-item.c				\

--- a/applets/notification_area/Makefile.am
+++ b/applets/notification_area/Makefile.am
@@ -93,6 +93,9 @@ org.mate.panel.applet.NotificationAreaAppletFactory.service: $(service_in_files)
 		$< > $@
 endif
 
+notification_area_gschemas_in = org.mate.panel.applet.notification-area.gschema.xml.in
+gsettings_SCHEMAS = $(notification_area_gschemas_in:.xml.in=.xml)
+
 ui_FILES = \
 	notification-area-menu.xml
 
@@ -106,8 +109,12 @@ BUILT_SOURCES = 		\
 	na-resources.c	\
 	na-resources.h
 
+@INTLTOOL_XML_NOMERGE_RULE@
+@GSETTINGS_RULES@
+
 EXTRA_DIST =								\
 	org.mate.panel.NotificationAreaApplet.mate-panel-applet.in.in	\
+	$(notification_area_gschemas_in)				\
 	$(ui_FILES)	\
 	na.gresource.xml \
 	$(service_in_files)
@@ -115,6 +122,7 @@ EXTRA_DIST =								\
 CLEANFILES =			\
 	$(applet_DATA) 		\
 	$(applet_DATA).in	\
-	$(service_DATA)
+	$(service_DATA)		\
+	$(gsettings_SCHEMAS)
 
 -include $(top_srcdir)/git.mk

--- a/applets/notification_area/Makefile.am
+++ b/applets/notification_area/Makefile.am
@@ -97,6 +97,7 @@ notification_area_gschemas_in = org.mate.panel.applet.notification-area.gschema.
 gsettings_SCHEMAS = $(notification_area_gschemas_in:.xml.in=.xml)
 
 ui_FILES = \
+	notification-area-preferences-dialog.ui	\
 	notification-area-menu.xml
 
 na-resources.c: na.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/na.gresource.xml)

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -30,7 +30,7 @@
 #include <gtk/gtk.h>
 
 #include "main.h"
-#include "na-box.h"
+#include "na-grid.h"
 
 #ifdef PROVIDE_WATCHER_SERVICE
 # include "libstatus-notifier-watcher/gf-status-notifier-watcher.h"
@@ -40,7 +40,7 @@
 
 struct _NaTrayAppletPrivate
 {
-  GtkWidget *box;
+  GtkWidget *grid;
 
 #ifdef PROVIDE_WATCHER_SERVICE
   GfStatusNotifierWatcher *sn_watcher;
@@ -225,14 +225,14 @@ na_tray_applet_style_updated (GtkWidget *widget)
   if (parent_class_style_updated)
     parent_class_style_updated (widget);
 
-  if (!applet->priv->box)
+  if (!applet->priv->grid)
     return;
 
   gtk_widget_style_get (widget,
                         "icon-padding", &padding,
                         "icon-size", &icon_size,
                         NULL);
-  g_object_set (applet->priv->box,
+  g_object_set (applet->priv->grid,
                 "icon-padding", padding,
                 "icon-size", icon_size,
                 NULL);
@@ -247,8 +247,8 @@ na_tray_applet_change_background(MatePanelApplet* panel_applet, MatePanelAppletB
     parent_class_change_background (panel_applet, type, color, pattern);
   }
 
-  if (applet->priv->box)
-    na_box_force_redraw (NA_BOX (applet->priv->box));
+  if (applet->priv->grid)
+    na_grid_force_redraw (NA_GRID (applet->priv->grid));
 }
 
 static void
@@ -260,10 +260,10 @@ na_tray_applet_change_orient (MatePanelApplet       *panel_applet,
   if (parent_class_change_orient)
     parent_class_change_orient (panel_applet, orient);
 
-  if (!applet->priv->box)
+  if (!applet->priv->grid)
     return;
 
-  gtk_orientable_set_orientation (GTK_ORIENTABLE (applet->priv->box),
+  gtk_orientable_set_orientation (GTK_ORIENTABLE (applet->priv->grid),
                                   get_gtk_orientation_from_applet_orient (orient));
 }
 
@@ -286,10 +286,10 @@ na_tray_applet_focus (GtkWidget        *widget,
 {
   NaTrayApplet *applet = NA_TRAY_APPLET (widget);
 
-  /* We let the box handle the focus movement because we behave more like a
+  /* We let the grid handle the focus movement because we behave more like a
    * container than a single applet.  But if focus didn't move, we let the
    * applet do its thing. */
-  if (gtk_widget_child_focus (applet->priv->box, direction))
+  if (gtk_widget_child_focus (applet->priv->grid, direction))
     return TRUE;
 
   return GTK_WIDGET_CLASS (na_tray_applet_parent_class)->focus (widget, direction);
@@ -353,10 +353,10 @@ na_tray_applet_init (NaTrayApplet *applet)
 #endif
 
   orient = mate_panel_applet_get_orient (MATE_PANEL_APPLET (applet));
-  applet->priv->box = na_box_new (get_gtk_orientation_from_applet_orient (orient));
+  applet->priv->grid = na_grid_new (get_gtk_orientation_from_applet_orient (orient));
 
-  gtk_container_add (GTK_CONTAINER (applet), GTK_WIDGET (applet->priv->box));
-  gtk_widget_show (GTK_WIDGET (applet->priv->box));
+  gtk_container_add (GTK_CONTAINER (applet), GTK_WIDGET (applet->priv->grid));
+  gtk_widget_show (GTK_WIDGET (applet->priv->grid));
 
   atko = gtk_widget_get_accessible (GTK_WIDGET (applet));
   atk_object_set_name (atko, _("Panel Notification Area"));

--- a/applets/notification_area/main.h
+++ b/applets/notification_area/main.h
@@ -26,6 +26,9 @@
 
 #define NA_RESOURCE_PATH "/org/mate/panel/applet/na/"
 
+#define NA_TRAY_SCHEMA                  "org.mate.panel.applet.notification-area"
+#define KEY_MIN_ICON_SIZE               "min-icon-size"
+
 G_BEGIN_DECLS
 
 #define NA_TYPE_TRAY_APPLET             (na_tray_applet_get_type ())

--- a/applets/notification_area/na-grid.h
+++ b/applets/notification_area/na-grid.h
@@ -22,8 +22,8 @@
  * Used to be: eggtraytray.h
  */
 
-#ifndef NA_BOX_H
-#define NA_BOX_H
+#ifndef NA_GRID_H
+#define NA_GRID_H
 
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
@@ -32,25 +32,12 @@
 
 G_BEGIN_DECLS
 
-#define NA_TYPE_BOX			(na_box_get_type ())
-#define NA_BOX(obj)			(G_TYPE_CHECK_INSTANCE_CAST ((obj), NA_TYPE_BOX, NaBox))
-#define NA_BOX_CLASS(klass)		(G_TYPE_CHECK_CLASS_CAST ((klass), NA_TYPE_BOX, NaBoxClass))
-#define NA_IS_BOX(obj)			(G_TYPE_CHECK_INSTANCE_TYPE ((obj), NA_TYPE_BOX))
-#define NA_IS_BOX_CLASS(klass)		(G_TYPE_CHECK_CLASS_TYPE ((klass), NA_TYPE_BOX))
-#define NA_BOX_GET_CLASS(obj)		(G_TYPE_INSTANCE_GET_CLASS ((obj), NA_TYPE_BOX, NaBoxClass))
+#define NA_TYPE_GRID (na_grid_get_type ())
+G_DECLARE_FINAL_TYPE (NaGrid, na_grid, NA, GRID, GtkBox)
 
-typedef struct _NaBox		NaBox;
-typedef struct _NaBoxClass	NaBoxClass;
-
-struct _NaBoxClass
-{
-  GtkBoxClass parent_class;
-};
-
-GType           na_box_get_type         (void);
-GtkWidget      *na_box_new              (GtkOrientation orientation);
-void            na_box_force_redraw     (NaBox *box);
+GtkWidget      *na_grid_new                     (GtkOrientation orientation);
+void            na_grid_force_redraw            (NaGrid *grid);
 
 G_END_DECLS
 
-#endif /* __NA_TRAY_H__ */
+#endif /* __NA_GRID_H__ */

--- a/applets/notification_area/na-grid.h
+++ b/applets/notification_area/na-grid.h
@@ -33,8 +33,10 @@
 G_BEGIN_DECLS
 
 #define NA_TYPE_GRID (na_grid_get_type ())
-G_DECLARE_FINAL_TYPE (NaGrid, na_grid, NA, GRID, GtkBox)
+G_DECLARE_FINAL_TYPE (NaGrid, na_grid, NA, GRID, GtkGrid)
 
+void            na_grid_set_min_icon_size       (NaGrid *grid,
+                                                 gint    min_icon_size);
 GtkWidget      *na_grid_new                     (GtkOrientation orientation);
 void            na_grid_force_redraw            (NaGrid *grid);
 

--- a/applets/notification_area/na.gresource.xml
+++ b/applets/notification_area/na.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/org/mate/panel/applet/na">
+    <file compressed="true">notification-area-preferences-dialog.ui</file>
     <file compressed="true">notification-area-menu.xml</file>
   </gresource>
 </gresources>

--- a/applets/notification_area/notification-area-menu.xml
+++ b/applets/notification_area/notification-area-menu.xml
@@ -1,3 +1,4 @@
+<menuitem name="Notification Area Preferences Item" action="SystemTrayPreferences" />
 <menuitem name="Notification Area Help Item" action="SystemTrayHelp" />
 <menuitem name="Notification Area About Item" action="SystemTrayAbout" />
 

--- a/applets/notification_area/notification-area-preferences-dialog.ui
+++ b/applets/notification_area/notification-area-preferences-dialog.ui
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 
+
+mate-panel - panel-properties-dialog
+Copyright (C) Mate Developer
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+Author: Wolfgang Ulbrich
+
+-->
+<interface>
+  <requires lib="gtk+" version="3.14"/>
+  <!-- interface-license-type gplv2 -->
+  <!-- interface-name mate-panel -->
+  <!-- interface-description panel-properties-dialog -->
+  <!-- interface-copyright Mate Developer -->
+  <!-- interface-authors Wolfgang Ulbrich -->
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="lower">7</property>
+    <property name="upper">100</property>
+    <property name="value">26</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
+  </object>
+  <object class="GtkDialog" id="notification_area_preferences_dialog">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Notification Area Preferences</property>
+    <property name="resizable">False</property>
+    <property name="window_position">center</property>
+    <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkButton" id="closebutton">
+                <property name="label">gtk-close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="has_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkNotebook" id="notebook">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="border_width">5</property>
+            <property name="show_tabs">False</property>
+            <property name="show_border">False</property>
+            <child>
+              <object class="GtkGrid" id="general_grid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">6</property>
+                <property name="margin_right">6</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">6</property>
+                <property name="row_spacing">6</property>
+                <property name="column_spacing">12</property>
+                <child>
+                  <object class="GtkLabel" id="min_icon_size_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">_Minimum Icon Size:</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">min_icon_size_spin</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="min_icon_size_spin">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="text" translatable="yes">26</property>
+                    <property name="adjustment">adjustment1</property>
+                    <property name="climb_rate">1</property>
+                    <property name="numeric">True</property>
+                    <property name="value">26</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="min_icon_size_label_pixels">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">pixels</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">2</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="tab">
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child type="tab">
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-7">closebutton</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/applets/notification_area/org.mate.panel.applet.notification-area.gschema.xml.in
+++ b/applets/notification_area/org.mate.panel.applet.notification-area.gschema.xml.in
@@ -1,0 +1,9 @@
+<schemalist gettext-domain="@GETTEXT_PACKAGE@">
+  <schema id="org.mate.panel.applet.notification-area">
+    <key name="min-icon-size" type="i">
+      <default>24</default>
+      <summary>Minimum icon size</summary>
+      <description>The minimum size an icon can have.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/applets/notification_area/testtray.c
+++ b/applets/notification_area/testtray.c
@@ -30,7 +30,7 @@
 #ifdef PROVIDE_WATCHER_SERVICE
 # include "libstatus-notifier-watcher/gf-status-notifier-watcher.h"
 #endif
-#include "na-box.h"
+#include "na-grid.h"
 
 #define NOTIFICATION_AREA_ICON "mate-panel-notification-area"
 
@@ -181,7 +181,7 @@ create_tray_on_screen (GdkScreen *screen,
   gtk_label_set_yalign (GTK_LABEL (label), 0.5);
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
 
-  data->traybox = na_box_new (GTK_ORIENTATION_HORIZONTAL);
+  data->traybox = na_grid_new (GTK_ORIENTATION_HORIZONTAL);
   gtk_box_pack_start (GTK_BOX (vbox), GTK_WIDGET (data->traybox), TRUE, TRUE, 0);
 
   g_signal_connect_after (data->traybox, "add", G_CALLBACK (tray_added_cb), data);

--- a/configure.ac
+++ b/configure.ac
@@ -282,6 +282,7 @@ applets/clock/pixmaps/Makefile
 applets/fish/Makefile
 applets/fish/org.mate.panel.applet.fish.gschema.xml
 applets/notification_area/Makefile
+applets/notification_area/org.mate.panel.applet.notification-area.gschema.xml
 applets/notification_area/libstatus-notifier-watcher/Makefile
 applets/notification_area/status-notifier/Makefile
 applets/notification_area/system-tray/Makefile

--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -303,35 +303,40 @@ calc_arrow (PanelOrientation  orientation,
 	    gdouble          *size)
 {
 	GtkArrowType retval = GTK_ARROW_UP;
-	double scale;
 
-	scale = (orientation & PANEL_HORIZONTAL_MASK ? button_height : button_width) / 48.0;
-
-	*size = 12 * scale;
+	if (orientation & PANEL_HORIZONTAL_MASK) {
+		if (button_width > 50)
+			button_width = 50;
+	} else {
+		if (button_height > 50)
+			button_height = 50;
+	}
+	
+	*size = (orientation & PANEL_HORIZONTAL_MASK ? button_width : button_height) / 2;
 	*angle = 0;
 
 	switch (orientation) {
 	case PANEL_ORIENTATION_TOP:
-		*x     = scale * 3;
-		*y     = scale * (48 - 13);
+		*x     = (button_width - (*size)) / 2;
+		*y     = button_height * .99 - (*size) / (3/2);	// 3/2 is the approximate ratio of GTK arrows
 		*angle = G_PI;
 		retval = GTK_ARROW_DOWN;
 		break;
 	case PANEL_ORIENTATION_BOTTOM:
-		*x     = scale * (48 - 13);
-		*y     = scale * 1;
+		*x     = (button_width - (*size)) / 2;
+		*y     = button_height * .01;
 		*angle = 0;
 		retval = GTK_ARROW_UP;
 		break;
 	case PANEL_ORIENTATION_LEFT:
-		*x     = scale * (48 - 13);
-		*y     = scale * 3;
+		*x     = button_width * .99 - (*size) / (3/2);	// 3/2 is the approximate ratio of GTK arrows
+		*y     = (button_height - (*size)) / 2;
 		*angle = G_PI / 2;
 		retval = GTK_ARROW_RIGHT;
 		break;
 	case PANEL_ORIENTATION_RIGHT:
-		*x     = scale * 1;
-		*y     = scale * 3;
+		*x     = button_width * .01;
+		*y     = (button_height - (*size)) / 2;
 		*angle = 3 * (G_PI / 2);
 		retval = GTK_ARROW_LEFT;
 		break;
@@ -446,9 +451,14 @@ button_widget_get_preferred_width (GtkWidget *widget,
 
 	parent = gtk_widget_get_parent (widget);
 
-	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK)
+	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK){
 		size = gtk_widget_get_allocated_height (parent);
-	else
+
+		/* should get this value (50) from gsettings, user defined value in properties of the panel (max_icon_size) OR use 48*/
+		if ( size > 50 )
+			size = 50;	
+
+	} else
 		size = gtk_widget_get_allocated_width (parent);
 
 	*minimal_width = *natural_width = size;
@@ -467,8 +477,14 @@ button_widget_get_preferred_height (GtkWidget *widget,
 
 	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK)
 		size = gtk_widget_get_allocated_height (parent);
-	else
+	else {
 		size = gtk_widget_get_allocated_width (parent);
+		
+		/* should get this value (50) from gsettings, user defined value in properties of the panel (max_icon_size) OR use 48*/
+		if ( size > 50 )
+			size = 50;	
+	
+	}
 
 	*minimal_height = *natural_height = size;
 }
@@ -480,6 +496,17 @@ button_widget_size_allocate (GtkWidget     *widget,
 	ButtonWidget *button_widget = BUTTON_WIDGET (widget);
 	int           size;
 
+	/* should get this value (50) from gsettings, user defined value in properties of the panel (max_icon_size) OR use 48?*/
+	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK) {
+		if ( allocation->height > 50 ) {
+			allocation->width = 50;	
+		}
+	} else {
+		if ( allocation->width > 50 ) {
+			allocation->height = 50;	
+		}
+	}
+	
 	GTK_WIDGET_CLASS (button_widget_parent_class)->size_allocate (widget, allocation);
 
 	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK)

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -14,6 +14,7 @@ applets/fish/fish.c
 [type: gettext/gsettings]applets/fish/org.mate.panel.applet.fish.gschema.xml.in
 [type: gettext/ini]applets/fish/org.mate.panel.FishApplet.mate-panel-applet.in.in
 applets/notification_area/main.c
+[type: gettext/gsettings]applets/notification_area/org.mate.panel.applet.notification-area.gschema.xml.in
 [type: gettext/ini]applets/notification_area/org.mate.panel.NotificationAreaApplet.mate-panel-applet.in.in
 [type: gettext/gsettings]applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in
 [type: gettext/gsettings]applets/wncklet/org.mate.panel.applet.workspace-switcher.gschema.xml.in

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -14,6 +14,7 @@ applets/fish/fish.c
 [type: gettext/gsettings]applets/fish/org.mate.panel.applet.fish.gschema.xml.in
 [type: gettext/ini]applets/fish/org.mate.panel.FishApplet.mate-panel-applet.in.in
 applets/notification_area/main.c
+[type: gettext/glade]applets/notification_area/notification-area-preferences-dialog.ui
 [type: gettext/gsettings]applets/notification_area/org.mate.panel.applet.notification-area.gschema.xml.in
 [type: gettext/ini]applets/notification_area/org.mate.panel.NotificationAreaApplet.mate-panel-applet.in.in
 [type: gettext/gsettings]applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in


### PR DESCRIPTION
This takes care of some issues from https://github.com/mate-desktop/mate-panel/issues/157
And it's a final remake of the own issue I had created: https://github.com/mate-desktop/mate-panel/pull/325 (at the time mate-panel was being ported to Gtk3 so it was messy, now that it's finally only Gtk3, I've made the proper changes)

This change limits the size taken by all BUTTON_WIDGETs when the panel is wide, because for the moment when for example the panel is horizontal 200 pixels wide/high, the widgets take up 200x200 for an icon of max size 48.
I've set it to take now (for this example) 50x200 or 200x50 (if it's a vertical panel 200px wide)
If users want to leave the same space as before around the icons they just have to move them on the panel anyway and leave empty space around and it can be as before.. (but it might affect other applets I don't know of)
The GTK_ARROW is also resized properly on BUTTON_WIDGETs with property "has_arrow"

I've setup 50 as a limit, because I found by my own surprise 48 was hardcoded as the limit for the icon size.
For further discussion:
Couldn't it be a panel wide user set option, so that the user sets the maximum icon size somewhere and we can get the value in any applet needing it?
I though about changing the panel properties dialog and add a new option like 'max_icon_size' or something like that, so that the user decides on the maximum icon size him/herself. Then that would be saved in the gsettings of the panel.
But getting that value as a gsettings from "org.mate.panel.." in any applet that needs it doesn't seem to be the right way to do it? I haven't seen a single applet accessing the main panel gsettings it is attached to..?

![changes](https://user-images.githubusercontent.com/13189097/44319716-d4813d00-a43d-11e8-9ca5-7817ba276244.png)

Then it also finally sets the way for a notification area that should make everyone happy.
I replaced the GtkBox that has been there since forever by a GtkGrid.

![screenshot at 2018-08-21 14-05-58](https://user-images.githubusercontent.com/13189097/44400446-780c4380-a54b-11e8-80b0-1c47bc426be9.png)
As you can see I added a Preferences dialog, with two options, a tick box to keep them aligned on one line as it was before, they automatically resize to the width of the panel, up to 48px (icon size) centered (the change I made in BUTTON_WIDGETs applies now on the notification area items too, they don't take up 200x200 on a wide panel anymore).
And if the "Display icons only on one line" is unticked, one can choose the size of the icons directly and they'll re-arrange nicely in a gird.
As you can see the two examples where I set 28 size for one and 43 for the other. They don't adapt to all sizes though, once the size is big enough or small enough to fill the width/height, it resizes..
And as you can see the settings are set in a GSchema. I'll just need help to figure out how to change the Makefile to automatically compile it, I've spent hours on it without figuring it out. I installed the GSchema manually..
![screenshot at 2018-08-21 14-14-01](https://user-images.githubusercontent.com/13189097/44400829-ed2c4880-a54c-11e8-8aa3-139ac783931e.png)

PROBLEMS left:
The makefile is buggy, I couldn't figure out how to get the gschema file to compile and be included in the mape-panel package, somehow it is left out, in the build process dpkg doesn't validate it?
So to test it, you need to install the new notification_area gschema manually for the moment
If someone could help, I'm not a pro of makefiles ;)
Else the main problems left are in finishing the event handlers, the grid doesn't redraw when the panel loads for the first time. I don't know which event to target? realize? size-allocate?
The grid doesn't redraw properly when the panel size is modified, same, I don't know which event to target for that change.
And the grid sorting code of the icons is a bit messy `reorder_items_with_data, refresh_grid` in `na-grid.c`. I'm sure it can be made much more neatly, but since I'm leaving for 3 weeks to a place with no internet in 3 days, I'm already publishing it so that anyone else who wants can work on it. I'll get back to it when I come back

One small thing is that the GtkDialog for preferences is not attached to a parent hence it produces:
"GtkDialog mapped without a transient parent. This is discouraged." in the syslog
I took parts of the code from the clock applet, hence the clock applet has the same issue.

I also had to coment out the na-resource.c/na-resource.h stuff in the actual Makefile, because these files don't exist as of yet?
