### PR TITLE
Backport #863 (Alt+F1 focus fix) to 1.20

### DIFF
--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -26,9 +26,12 @@
 
 #include "panel-menu-button.h"
 
+#include <X11/Xlib.h>
+
 #include <string.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
+#include <gdk/gdkx.h>
 
 #include <matemenu-tree.h>
 
@@ -91,6 +94,8 @@ struct _PanelMenuButtonPrivate {
 	char                  *menu_path;
 	char                  *custom_icon;
 	char                  *tooltip;
+
+	Window                 interrupted_window;
 
 	MenuPathRoot           path_root;
 	guint                  use_menu_path : 1;
@@ -424,12 +429,23 @@ panel_menu_button_recreate_menu (PanelMenuButton *button)
 	button->priv->menu = NULL;
 }
 
+static gboolean panel_menu_button_menu_deactivate (GtkWidget* widget, PanelMenuButton* button)
+{
+	GtkWidget *toplevel = gtk_widget_get_toplevel(widget);
+	panel_util_set_current_active_window(toplevel, button->priv->interrupted_window);
+	button->priv->interrupted_window = None;
+
+	return FALSE;
+}
+
 void
 panel_menu_button_popup_menu (PanelMenuButton *button,
 			      guint            n_button,
 			      guint32          activate_time)
 {
 	GdkScreen *screen;
+	GtkWidget *toplevel;
+	GdkWindow *window;
 
 	g_return_if_fail (PANEL_IS_MENU_BUTTON (button));
 
@@ -449,6 +465,12 @@ panel_menu_button_popup_menu (PanelMenuButton *button,
 			GTK_WIDGET (button),
 			n_button,
 			activate_time);
+
+	g_signal_connect(GTK_MENU_SHELL (button->priv->menu), "deactivate", G_CALLBACK (panel_menu_button_menu_deactivate), button);
+	toplevel = gtk_widget_get_toplevel(GTK_WIDGET(button->priv->toplevel));
+	button->priv->interrupted_window = panel_util_get_current_active_window (toplevel);
+	window = gtk_widget_get_window (toplevel);
+	panel_util_set_current_active_window (toplevel, GDK_WINDOW_XID(window));
 }
 
 static void

--- a/mate-panel/panel-util.h
+++ b/mate-panel/panel-util.h
@@ -3,6 +3,7 @@
 
 #include <gio/gio.h>
 #include <gtk/gtk.h>
+#include <X11/Xlib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +67,10 @@ void panel_util_set_tooltip_text (GtkWidget  *widget,
 
 GFile *panel_util_get_file_optional_homedir (const char *location);
 
+Window panel_util_get_current_active_window (GtkWidget *toplevel);
+
+void   panel_util_set_current_active_window (GtkWidget *toplevel,
+					     Window     window);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
menu-bar: transfer focus correctly on alt-F1

The background is in https://gitlab.gnome.org/GNOME/gtk/issues/85 . One of the conclusions, in https://gitlab.gnome.org/GNOME/gtk/issues/85#note_264804, is that mate-panel needs to properly transfer focus on alt-F1 keyboard shortcut.

It used to work only by luck before, only because gtk used to deactivate itself during a keyboard grab. But as discussed in https://gitlab.gnome.org/GNOME/gtk/issues/85 that behavior poses accessibility feedback issues, is not coherent, and keyboard grab feedback will not be available in wayland anyway. Thus @ebassi saying in https://gitlab.gnome.org/GNOME/gtk/issues/85#note_264804 that not transferring focus properly is the actual bug.

This change explictly switches to the menu bar after saving which X Window had the focus, and on menu bar deactivation restores focus to that X Window.

Fixes #851

See #851.  This commit is identical to f0f4c5e1217eefd46edf9f98633fb32967c67461 but for whitespace changes in `panel_menu_button_popup_menu()`.