### PR TITLE
Ensure alt-F1 can show the menu even if no menu applet on panel

### DIFF
--- a/mate-panel/panel-action-protocol.c
+++ b/mate-panel/panel-action-protocol.c
@@ -58,6 +58,8 @@ panel_action_protocol_main_menu (GdkScreen *screen,
 	GdkVisual *visual;
 	GtkWidget *toplevel;
 	GtkStyleContext *context;
+	GdkSeat *seat;
+	GdkDevice *device;
 
 	info = mate_panel_applet_get_by_type (PANEL_OBJECT_MENU_BAR, screen);
 	if (info) {
@@ -88,6 +90,11 @@ panel_action_protocol_main_menu (GdkScreen *screen,
 	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
 	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
 	gtk_style_context_add_class(context,"mate-panel-menu-bar");
+
+	seat = gdk_display_get_default_seat (gdk_display_get_default());
+	device = gdk_seat_get_pointer (seat);
+	gdk_event_set_device (event, device);
+
 	gtk_menu_popup_at_pointer (GTK_MENU (menu),event);
 }
 


### PR DESCRIPTION
Fix regression introduced by https://github.com/mate-desktop/mate-panel/commit/17ac8aab4d139cb917619a3a981300f51b750c17 and ensure that menu shown follows same theme as menu shown from panel menu button or panel menu bar.