### PR TITLE
notification-area-preferences-dialog.ui: avoid GtkButton:use-stock

### DIFF
--- a/applets/notification_area/notification-area-preferences-dialog.ui
+++ b/applets/notification_area/notification-area-preferences-dialog.ui
@@ -22,7 +22,7 @@ Author: Wolfgang Ulbrich
 
 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name mate-panel -->
   <!-- interface-description panel-properties-dialog -->
@@ -34,6 +34,11 @@ Author: Wolfgang Ulbrich
     <property name="value">26</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
+  </object>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
   </object>
   <object class="GtkDialog" id="notification_area_preferences_dialog">
     <property name="can_focus">False</property>
@@ -57,13 +62,14 @@ Author: Wolfgang Ulbrich
             <property name="can_focus">False</property>
             <child>
               <object class="GtkButton" id="closebutton">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="has_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="image">image1</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
We have the deprecated property in that ui file since the PR https://github.com/mate-desktop/mate-panel/pull/856