### PR TITLE
tx:Add some Chinese translations in help/mate-clock

### DIFF
--- a/help/mate-clock/zh_CN/zh_CN.po
+++ b/help/mate-clock/zh_CN/zh_CN.po
@@ -433,12 +433,12 @@ msgstr ""
 #. (itstool) path: listitem/para
 #: C/index.docbook:297
 msgid "<guimenuitem>Copy Time</guimenuitem>"
-msgstr ""
+msgstr "复制时间"
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:302
 msgid "<guimenuitem>Copy Date</guimenuitem>"
-msgstr ""
+msgstr "复制日期"
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:309
@@ -452,6 +452,8 @@ msgid ""
 "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Paste</guimenuitem> "
 "</menuchoice> or middle-click to insert the item."
 msgstr ""
+"选择 <menuchoice><guimenu>编辑</guimenu><guimenuitem>粘贴</guimenuitem> "
+"</menuchoice> 或者点击鼠标中键插入拷贝内容"
 
 #. (itstool) path: sect1/title
 #: C/index.docbook:326
@@ -476,7 +478,7 @@ msgstr ""
 #. (itstool) path: varlistentry/term
 #: C/index.docbook:335
 msgid "<guilabel>Clock Format</guilabel>"
-msgstr ""
+msgstr "时间格式"
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:337
@@ -513,7 +515,7 @@ msgstr ""
 #. (itstool) path: varlistentry/term
 #: C/index.docbook:353
 msgid "<guilabel>Show the date</guilabel>"
-msgstr ""
+msgstr "显示日期"
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:355
@@ -523,7 +525,7 @@ msgstr ""
 #. (itstool) path: varlistentry/term
 #: C/index.docbook:359
 msgid "<guilabel>Show seconds</guilabel>"
-msgstr ""
+msgstr "显示秒"
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:361
@@ -543,7 +545,7 @@ msgstr ""
 #. (itstool) path: varlistentry/term
 #: C/index.docbook:371
 msgid "<guilabel>Show the weather</guilabel>"
-msgstr ""
+msgstr "显示天气"
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:373
@@ -556,7 +558,7 @@ msgstr ""
 #. (itstool) path: varlistentry/term
 #: C/index.docbook:378
 msgid "<guilabel>Show temperature</guilabel>"
-msgstr ""
+msgstr "显示温度"
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:380
@@ -602,7 +604,7 @@ msgstr "天气首选项"
 #. (itstool) path: varlistentry/term
 #: C/index.docbook:420
 msgid "<guilabel>Weather</guilabel>"
-msgstr ""
+msgstr "温度单位"
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:422
@@ -634,7 +636,7 @@ msgstr ""
 #. (itstool) path: varlistentry/term
 #: C/index.docbook:441
 msgid "<guilabel>Wind speed unit</guilabel>"
-msgstr ""
+msgstr "风速单位"
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:443


### PR DESCRIPTION
OS system language is Chinese, but when open Clock Manual-> Usage with right-click on the bottom-right clock icon,  some step descriptions is still displayed with English.