### PR TITLE
Remove legacy X11 package detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -169,26 +169,7 @@ gl_CHECK_TYPE_STRUCT_DIRENT_D_TYPE
 
 dnl X development libraries check
 
-PKG_CHECK_MODULES(X, x11 xau, :, [
-  # pkg-config modules not found (only present since X11R7 aka Xorg); use
-  # old-style detection
-  AC_PATH_XTRA()
-  # X not found
-  if test x$no_x = xyes ; then
-    AC_MSG_ERROR([X development libraries not found])
-  fi
-
-  gp_save_cflags="$CFLAGS"
-  gp_save_libs="$LIBS"
-  CFLAGS="$X_CFLAGS"
-  LIBS="$X_PRE_LIBS $X_LIBS $X_EXTRA_LIBS"
-  AC_CHECK_LIB(X11, XFree,, AC_MSG_ERROR([libX11 not found]))
-  AC_CHECK_LIB(Xau, XauFileName,, AC_MSG_ERROR([libXau not found]))
-  CFLAGS="$gp_save_cflags"
-  LIBS="$gp_save_libs"
-
-  X_LIBS="$X_PRE_LIBS $X_LIBS -lX11 -lXau $X_EXTRA_LIBS"
-])
+PKG_CHECK_MODULES(X, x11 xau, :, AC_MSG_ERROR([X development libraries not found]))
 
 AC_SUBST(X_LIBS)
 


### PR DESCRIPTION
This was a suggested change to my Wayland PR, but since I just got it from prexisting code, I thought it would be best to propose it separately.

Original comment by @muktupavels:
> Well it is 2018... I would just require pkg-config file and would remove old-style detection...
https://gitlab.freedesktop.org/xorg/lib/libx11
https://gitlab.freedesktop.org/xorg/lib/libxau
This tells that x11.pc and xau.pc is available as minimum for 9 years.