### PR TITLE
Wayland additions to build system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,9 +167,62 @@ AM_CONDITIONAL(WNCKLET_INPROCESS, test -n "$WNCKLET_COMPILE_INPROCESS")
 # For the run dialog
 gl_CHECK_TYPE_STRUCT_DIRENT_D_TYPE
 
-dnl X development libraries check
+must_enable_x11=no
+must_enable_wayland=no
+try_all_backends=yes
 
-PKG_CHECK_MODULES(X, x11 xau, :, AC_MSG_ERROR([X development libraries not found]))
+AC_ARG_ENABLE(x11,
+              [AC_HELP_STRING([--enable-x11],
+                              [Enable X11 support and disable Wayland (unless it's also enabled explicitly)
+                              @<:@default=yes@:>@])],
+              [must_enable_x11=yes
+               try_all_backends=no],)
+
+AC_ARG_ENABLE(wayland,
+              [AC_HELP_STRING([--enable-wayland],
+                              [Enable Wayland support and disable X11 (unless it's also enabled explicitly)
+                              @<:@default=yes@:>@])],
+              [must_enable_wayland=yes
+               try_all_backends=no],)
+
+# Check if we have wayland-client installed, and thus should build with Wayland support
+
+have_wayland=no
+
+if test "x$must_enable_wayland" = "xyes" -o "x$try_all_backends" = "xyes"; then
+  PKG_CHECK_MODULES(WAYLAND, wayland-client, have_wayland=yes,)
+fi
+
+AM_CONDITIONAL(ENABLE_WAYLAND, [test "x$have_wayland" = "xyes"])
+
+if test "x$have_wayland" = "xyes"; then
+  AC_DEFINE(HAVE_WAYLAND, 1, [Have the Wayland development library])
+fi
+
+# Error out if Wayland was required but not found
+if test "x$have_wayland" != "xyes" -a "x$must_enable_wayland" = "xyes"; then
+  # The user has explicitly told us to use Wayland, but we can't find the library :(
+  AC_MSG_ERROR([Wayland client library not found])
+fi
+
+# Check if we have the X development libraries
+# (we can compile with X and/or Wayland supported)
+
+have_x11=no
+
+if test "x$must_enable_x11" = "xyes" -o "x$try_all_backends" = "xyes"; then
+  PKG_CHECK_MODULES(X, x11 xau, have_x11=yes, AC_MSG_ERROR([X development libraries not found]))
+fi
+
+AM_CONDITIONAL(ENABLE_X11, [test "x$have_x11" = "xyes"])
+
+if test "x$have_x11" = "xyes"; then
+  AC_DEFINE(HAVE_X11, 1, [Have the X11 development library])
+fi
+
+if test "x$have_x11" != "xyes" -a "x$have_wayland" != "xyes"; then
+  AC_MSG_ERROR([No usable backend available, install X or Wayland development libraries])
+fi
 
 AC_SUBST(X_LIBS)
 
@@ -308,6 +361,8 @@ echo "
         Maintainer mode:               ${USE_MAINTAINER_MODE}
         Use *_DISABLE_DEPRECATED:      ${enable_deprecation_flags}
         Applets to build in-process:   ${PANEL_INPROCESS_APPLETS}
+        X11 support:                   ${have_x11}
+        Wayland support:               ${have_wayland}
         XRandr support:                ${have_randr}
         Build introspection support:   ${found_introspection}
         Build gtk-doc documentation:   ${enable_gtk_doc}

--- a/configure.ac
+++ b/configure.ac
@@ -301,6 +301,7 @@ mate-panel/Makefile
 mate-panel/libegg/Makefile
 mate-panel/libmate-panel-applet-private/Makefile
 mate-panel/libpanel-util/Makefile
+mate-panel/wayland-protocols/Makefile
 mate-panel/mate-panel.desktop.in
 libmate-panel-applet/libmatepanelapplet-4.0.pc
 libmate-panel-applet/libmatepanelapplet-4.0-uninstalled.pc

--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = libegg libmate-panel-applet-private libpanel-util
+SUBDIRS = wayland-protocols libegg libmate-panel-applet-private libpanel-util
 
 bin_PROGRAMS = \
 	mate-panel \

--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -65,6 +65,12 @@ panel_sources = \
 	panel-applet-info.c \
 	panel-reset.c
 
+if ENABLE_WAYLAND
+panel_sources += \
+	wayland-protocols/wlr-layer-shell-unstable-v1-protocol.c \
+	wayland-protocols/xdg-shell-protocol.c
+endif
+
 panel_headers = \
 	panel-types.h \
 	panel-widget.h \
@@ -117,12 +123,19 @@ panel_headers = \
 	panel-reset.h \
 	panel-schemas.h
 
+if ENABLE_WAYLAND
+panel_headers += \
+	wayland-protocols/wlr-layer-shell-unstable-v1-protocol.h \
+	wayland-protocols/xdg-shell-protocol.h
+endif
+
 mate_panel_SOURCES = \
 	$(panel_sources) \
 	$(panel_headers)
 
 mate_panel_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
+	$(WAYLAND_CFLAGS) \
 	$(XRANDR_CFLAGS) \
 	-DPANEL_MODULES_DIR=\"$(modulesdir)\" \
 	-DMATEMENU_I_KNOW_THIS_IS_UNSTABLE
@@ -133,6 +146,7 @@ mate_panel_LDADD = \
 	$(top_builddir)/mate-panel/libpanel-util/libpanel-util.la \
 	$(PANEL_LIBS) \
 	$(DCONF_LIBS) \
+	$(WAYLAND_LIBS) \
 	$(XRANDR_LIBS) \
 	$(X_LIBS) \
 	-lm

--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -275,7 +275,9 @@ EXTRA_DIST = \
 	panel-test-applets.gresource.xml	\
 	panel-marshal.list \
 	$(entries_DATA) \
-	$(desktop_in_files)
+	$(desktop_in_files) \
+	wayland-protocols/wlr-layer-shell-unstable-v1.xml \
+	wayland-protocols/xdg-shell.xml
 
 CLEANFILES = \
 	$(BUILT_SOURCES) \

--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -135,10 +135,15 @@ mate_panel_SOURCES = \
 
 mate_panel_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
-	$(WAYLAND_CFLAGS) \
 	$(XRANDR_CFLAGS) \
 	-DPANEL_MODULES_DIR=\"$(modulesdir)\" \
 	-DMATEMENU_I_KNOW_THIS_IS_UNSTABLE
+
+if ENABLE_WAYLAND
+mate_panel_CPPFLAGS += \
+	$(WAYLAND_CFLAGS)
+endif
+
 
 mate_panel_LDADD = \
 	$(top_builddir)/mate-panel/libegg/libegg.la \
@@ -146,10 +151,14 @@ mate_panel_LDADD = \
 	$(top_builddir)/mate-panel/libpanel-util/libpanel-util.la \
 	$(PANEL_LIBS) \
 	$(DCONF_LIBS) \
-	$(WAYLAND_LIBS) \
 	$(XRANDR_LIBS) \
 	$(X_LIBS) \
 	-lm
+
+if ENABLE_WAYLAND
+mate_panel_LDADD += \
+	$(WAYLAND_LIBS)
+endif
 
 mate_panel_LDFLAGS = -export-dynamic
 

--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -125,8 +125,8 @@ panel_headers = \
 
 if ENABLE_WAYLAND
 panel_headers += \
-	wayland-protocols/wlr-layer-shell-unstable-v1-protocol.h \
-	wayland-protocols/xdg-shell-protocol.h
+	wayland-protocols/wlr-layer-shell-unstable-v1-client-protocol.h \
+	wayland-protocols/xdg-shell-client-protocol.h
 endif
 
 mate_panel_SOURCES = \

--- a/mate-panel/wayland-protocols/Makefile.am
+++ b/mate-panel/wayland-protocols/Makefile.am
@@ -1,14 +1,14 @@
 if ENABLE_WAYLAND
-all: wlr-layer-shell-unstable-v1-protocol.h wlr-layer-shell-unstable-v1-protocol.c xdg-shell-protocol.h xdg-shell-protocol.c
+all: wlr-layer-shell-unstable-v1-client-protocol.h wlr-layer-shell-unstable-v1-protocol.c xdg-shell-client-protocol.h xdg-shell-protocol.c
 
-wlr-layer-shell-unstable-v1-protocol.h: wlr-layer-shell-unstable-v1.xml
-	wayland-scanner -c client-header wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-protocol.h
+wlr-layer-shell-unstable-v1-client-protocol.h: wlr-layer-shell-unstable-v1.xml
+	wayland-scanner -c client-header wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-client-protocol.h
 
 wlr-layer-shell-unstable-v1-protocol.c: wlr-layer-shell-unstable-v1.xml
 	wayland-scanner -c private-code wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-protocol.c
 
-xdg-shell-protocol.h: xdg-shell.xml
-	wayland-scanner -c client-header xdg-shell.xml xdg-shell-protocol.h
+xdg-shell-client-protocol.h: xdg-shell.xml
+	wayland-scanner -c client-header xdg-shell.xml xdg-shell-client-protocol.h
 
 xdg-shell-protocol.c: xdg-shell.xml
 	wayland-scanner -c private-code xdg-shell.xml xdg-shell-protocol.c

--- a/mate-panel/wayland-protocols/Makefile.am
+++ b/mate-panel/wayland-protocols/Makefile.am
@@ -1,10 +1,6 @@
 if ENABLE_WAYLAND
 all: wlr-layer-shell-unstable-v1-client-protocol.h wlr-layer-shell-unstable-v1-protocol.c xdg-shell-client-protocol.h xdg-shell-protocol.c
 
-EXTRA_DIST = \
-	wlr-layer-shell-unstable-v1.xml \
-	xdg-shell.xml
-
 wlr-layer-shell-unstable-v1-client-protocol.h: wlr-layer-shell-unstable-v1.xml
 	wayland-scanner -c client-header wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-client-protocol.h
 

--- a/mate-panel/wayland-protocols/Makefile.am
+++ b/mate-panel/wayland-protocols/Makefile.am
@@ -1,6 +1,10 @@
 if ENABLE_WAYLAND
 all: wlr-layer-shell-unstable-v1-client-protocol.h wlr-layer-shell-unstable-v1-protocol.c xdg-shell-client-protocol.h xdg-shell-protocol.c
 
+EXTRA_DIST = \
+	wlr-layer-shell-unstable-v1.xml \
+	xdg-shell.xml
+
 wlr-layer-shell-unstable-v1-client-protocol.h: wlr-layer-shell-unstable-v1.xml
 	wayland-scanner -c client-header wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-client-protocol.h
 

--- a/mate-panel/wayland-protocols/Makefile.am
+++ b/mate-panel/wayland-protocols/Makefile.am
@@ -1,0 +1,15 @@
+if ENABLE_WAYLAND
+all: wlr-layer-shell-unstable-v1-protocol.h wlr-layer-shell-unstable-v1-protocol.c xdg-shell-protocol.h xdg-shell-protocol.c
+
+wlr-layer-shell-unstable-v1-protocol.h: wlr-layer-shell-unstable-v1.xml
+	wayland-scanner -c client-header wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-protocol.h
+
+wlr-layer-shell-unstable-v1-protocol.c: wlr-layer-shell-unstable-v1.xml
+	wayland-scanner -c private-code wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-protocol.c
+
+xdg-shell-protocol.h: xdg-shell.xml
+	wayland-scanner -c client-header xdg-shell.xml xdg-shell-protocol.h
+
+xdg-shell-protocol.c: xdg-shell.xml
+	wayland-scanner -c private-code xdg-shell.xml xdg-shell-protocol.c
+endif


### PR DESCRIPTION
This adds most of the changes needed to our build system for #873 (Wayland Support).

It autodetects which backends (x11 or wayland) are available, or can be forced to build one or both with the `--enable-x11` and `--enable-wayland` options. As in the other PR, if a backend is specified specifically only that backend is built, and an error will occur if it is not available. Both backends may be specified, in which case both must be available for the build to succeed.

I also added the `mate-panel/wayland-protocols` subdirectory to the build system. The makefile in it generates the protocol files from the xml at build time.