### PR TITLE
clock: force_no_button_vertical_padding

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1273,15 +1273,17 @@ clock_update_text_gravity (GtkWidget *label)
 }
 
 static inline void
-force_button_negative_margin (GtkWidget *widget)
+force_no_button_vertical_padding (GtkWidget *widget)
 {
         GtkCssProvider  *provider;
 
         provider = gtk_css_provider_new ();
         gtk_css_provider_load_from_data (provider,
-                                         "#clock-applet-button.flat.toggle > box.horizontal > box.horizontal > image {\n"
-                                         "margin-top: -4px;\n"
-                                         "margin-bottom: -4px;\n"
+                                         "#clock-applet-button {\n"
+                                         "padding-top: 0px;\n"
+                                         "padding-bottom: 0px;\n"
+                                         "margin-top: 0px;\n"
+                                         "margin-bottom: 0px;\n"
                                          "}",
                                          -1, NULL);
         gtk_style_context_add_provider (gtk_widget_get_style_context (widget),
@@ -1301,7 +1303,7 @@ create_main_clock_button (void)
         button = gtk_toggle_button_new ();
         gtk_button_set_relief (GTK_BUTTON (button), GTK_RELIEF_NONE);
 
-        force_button_negative_margin (button);
+        force_no_button_vertical_padding (button);
 
         return button;
 }


### PR DESCRIPTION
fixes weather-icon problems with some themes

with TOK theme:
![clock-applet-tok-theme](https://user-images.githubusercontent.com/961604/50404692-0703c380-07ab-11e9-8ec6-d2e8f9f18101.jpg)
with adwaita:
![clock-applet-adwaita](https://user-images.githubusercontent.com/961604/50404697-12ef8580-07ab-11e9-9a1d-4c2eb284576e.jpg)

Sorry, i can't test linuxmint themes, because it isn't allowed to spam my mate-appearance-properties with tons of similar themes.

@monsta @lukefromdc 
Does this work for you?