### PR TITLE
clock: set  horizontal padding for clock-button

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1284,8 +1284,8 @@ force_no_button_vertical_padding (GtkWidget *widget)
                                          "#clock-applet-button {\n"
                                          "padding-top: 0px;\n"
                                          "padding-bottom: 0px;\n"
-                                         "margin-top: 0px;\n"
-                                         "margin-bottom: 0px;\n"
+                                         "padding-left: 4px;\n"
+                                         "padding-right: 4px;\n"
                                          "}",
                                          -1, NULL);
         gtk_style_context_add_provider (gtk_widget_get_style_context (widget),


### PR DESCRIPTION
For some reasons padding settings for `button` widget in gtk+  themes are still ignored if clock-applet is build-in-process.
Forcing a horizontal padding is to make sure we have space left and right from the button.
I think it looks better to have a space there.
`padding-left/right: 4 px;` is used by our and gtk+ default themes. So this is a good value.