### PR TITLE
Na-tray-applet high cpu load fix for 1.20

### DIFF
--- a/applets/notification_area/Makefile.am
+++ b/applets/notification_area/Makefile.am
@@ -20,8 +20,8 @@ AM_CPPFLAGS =							\
 AM_CFLAGS = $(WARN_CFLAGS)
 
 libtray_la_SOURCES =				\
-	na-box.c				\
-	na-box.h				\
+	na-grid.c				\
+	na-grid.h				\
 	na-host.c				\
 	na-host.h				\
 	na-item.c				\

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -30,7 +30,7 @@
 #include <gtk/gtk.h>
 
 #include "main.h"
-#include "na-box.h"
+#include "na-grid.h"
 
 #ifdef PROVIDE_WATCHER_SERVICE
 # include "libstatus-notifier-watcher/gf-status-notifier-watcher.h"
@@ -40,7 +40,7 @@
 
 struct _NaTrayAppletPrivate
 {
-  GtkWidget *box;
+  GtkWidget *grid;
 
 #ifdef PROVIDE_WATCHER_SERVICE
   GfStatusNotifierWatcher *sn_watcher;
@@ -225,14 +225,14 @@ na_tray_applet_style_updated (GtkWidget *widget)
   if (parent_class_style_updated)
     parent_class_style_updated (widget);
 
-  if (!applet->priv->box)
+  if (!applet->priv->grid)
     return;
 
   gtk_widget_style_get (widget,
                         "icon-padding", &padding,
                         "icon-size", &icon_size,
                         NULL);
-  g_object_set (applet->priv->box,
+  g_object_set (applet->priv->grid,
                 "icon-padding", padding,
                 "icon-size", icon_size,
                 NULL);
@@ -247,8 +247,8 @@ na_tray_applet_change_background(MatePanelApplet* panel_applet, MatePanelAppletB
     parent_class_change_background (panel_applet, type, color, pattern);
   }
 
-  if (applet->priv->box)
-    na_box_force_redraw (NA_BOX (applet->priv->box));
+  if (applet->priv->grid)
+    na_grid_force_redraw (NA_GRID (applet->priv->grid));
 }
 
 static void
@@ -260,10 +260,10 @@ na_tray_applet_change_orient (MatePanelApplet       *panel_applet,
   if (parent_class_change_orient)
     parent_class_change_orient (panel_applet, orient);
 
-  if (!applet->priv->box)
+  if (!applet->priv->grid)
     return;
 
-  gtk_orientable_set_orientation (GTK_ORIENTABLE (applet->priv->box),
+  gtk_orientable_set_orientation (GTK_ORIENTABLE (applet->priv->grid),
                                   get_gtk_orientation_from_applet_orient (orient));
 }
 
@@ -286,10 +286,10 @@ na_tray_applet_focus (GtkWidget        *widget,
 {
   NaTrayApplet *applet = NA_TRAY_APPLET (widget);
 
-  /* We let the box handle the focus movement because we behave more like a
+  /* We let the grid handle the focus movement because we behave more like a
    * container than a single applet.  But if focus didn't move, we let the
    * applet do its thing. */
-  if (gtk_widget_child_focus (applet->priv->box, direction))
+  if (gtk_widget_child_focus (applet->priv->grid, direction))
     return TRUE;
 
   return GTK_WIDGET_CLASS (na_tray_applet_parent_class)->focus (widget, direction);
@@ -353,10 +353,10 @@ na_tray_applet_init (NaTrayApplet *applet)
 #endif
 
   orient = mate_panel_applet_get_orient (MATE_PANEL_APPLET (applet));
-  applet->priv->box = na_box_new (get_gtk_orientation_from_applet_orient (orient));
+  applet->priv->grid = na_grid_new (get_gtk_orientation_from_applet_orient (orient));
 
-  gtk_container_add (GTK_CONTAINER (applet), GTK_WIDGET (applet->priv->box));
-  gtk_widget_show (GTK_WIDGET (applet->priv->box));
+  gtk_container_add (GTK_CONTAINER (applet), GTK_WIDGET (applet->priv->grid));
+  gtk_widget_show (GTK_WIDGET (applet->priv->grid));
 
   atko = gtk_widget_get_accessible (GTK_WIDGET (applet));
   atk_object_set_name (atko, _("Panel Notification Area"));

--- a/applets/notification_area/na-grid.c
+++ b/applets/notification_area/na-grid.c
@@ -145,6 +145,8 @@ refresh_grid (NaGrid *self)
 
   if (orientation == GTK_ORIENTATION_HORIZONTAL)
     {
+      gtk_grid_set_row_homogeneous (GTK_GRID (self), TRUE);
+      gtk_grid_set_column_homogeneous (GTK_GRID (self), FALSE);
       rows = MAX (1, allocation.height / self->min_icon_size);
       cols = MAX (1, length / rows);
       if (length % rows)
@@ -152,6 +154,8 @@ refresh_grid (NaGrid *self)
     }
   else
     {
+      gtk_grid_set_row_homogeneous (GTK_GRID (self), FALSE);
+      gtk_grid_set_column_homogeneous (GTK_GRID (self), TRUE);
       cols = MAX (1, allocation.width / self->min_icon_size);
       rows = MAX (1, length / cols);
       if (length % cols)
@@ -243,6 +247,7 @@ na_grid_init (NaGrid *self)
   
   gtk_grid_set_row_homogeneous (GTK_GRID (self), TRUE);
   gtk_grid_set_column_homogeneous (GTK_GRID (self), TRUE);
+
 }
 
 static void

--- a/applets/notification_area/na-grid.h
+++ b/applets/notification_area/na-grid.h
@@ -22,8 +22,8 @@
  * Used to be: eggtraytray.h
  */
 
-#ifndef NA_BOX_H
-#define NA_BOX_H
+#ifndef NA_GRID_H
+#define NA_GRID_H
 
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
@@ -32,25 +32,12 @@
 
 G_BEGIN_DECLS
 
-#define NA_TYPE_BOX			(na_box_get_type ())
-#define NA_BOX(obj)			(G_TYPE_CHECK_INSTANCE_CAST ((obj), NA_TYPE_BOX, NaBox))
-#define NA_BOX_CLASS(klass)		(G_TYPE_CHECK_CLASS_CAST ((klass), NA_TYPE_BOX, NaBoxClass))
-#define NA_IS_BOX(obj)			(G_TYPE_CHECK_INSTANCE_TYPE ((obj), NA_TYPE_BOX))
-#define NA_IS_BOX_CLASS(klass)		(G_TYPE_CHECK_CLASS_TYPE ((klass), NA_TYPE_BOX))
-#define NA_BOX_GET_CLASS(obj)		(G_TYPE_INSTANCE_GET_CLASS ((obj), NA_TYPE_BOX, NaBoxClass))
+#define NA_TYPE_GRID (na_grid_get_type ())
+G_DECLARE_FINAL_TYPE (NaGrid, na_grid, NA, GRID, GtkBox)
 
-typedef struct _NaBox		NaBox;
-typedef struct _NaBoxClass	NaBoxClass;
-
-struct _NaBoxClass
-{
-  GtkBoxClass parent_class;
-};
-
-GType           na_box_get_type         (void);
-GtkWidget      *na_box_new              (GtkOrientation orientation);
-void            na_box_force_redraw     (NaBox *box);
+GtkWidget      *na_grid_new                     (GtkOrientation orientation);
+void            na_grid_force_redraw            (NaGrid *grid);
 
 G_END_DECLS
 
-#endif /* __NA_TRAY_H__ */
+#endif /* __NA_GRID_H__ */

--- a/applets/notification_area/na-grid.h
+++ b/applets/notification_area/na-grid.h
@@ -33,8 +33,10 @@
 G_BEGIN_DECLS
 
 #define NA_TYPE_GRID (na_grid_get_type ())
-G_DECLARE_FINAL_TYPE (NaGrid, na_grid, NA, GRID, GtkBox)
+G_DECLARE_FINAL_TYPE (NaGrid, na_grid, NA, GRID, GtkGrid)
 
+void            na_grid_set_min_icon_size       (NaGrid *grid,
+                                                 gint    min_icon_size);
 GtkWidget      *na_grid_new                     (GtkOrientation orientation);
 void            na_grid_force_redraw            (NaGrid *grid);
 

--- a/applets/notification_area/testtray.c
+++ b/applets/notification_area/testtray.c
@@ -30,7 +30,7 @@
 #ifdef PROVIDE_WATCHER_SERVICE
 # include "libstatus-notifier-watcher/gf-status-notifier-watcher.h"
 #endif
-#include "na-box.h"
+#include "na-grid.h"
 
 #define NOTIFICATION_AREA_ICON "mate-panel-notification-area"
 
@@ -181,7 +181,7 @@ create_tray_on_screen (GdkScreen *screen,
   gtk_label_set_yalign (GTK_LABEL (label), 0.5);
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
 
-  data->traybox = na_box_new (GTK_ORIENTATION_HORIZONTAL);
+  data->traybox = na_grid_new (GTK_ORIENTATION_HORIZONTAL);
   gtk_box_pack_start (GTK_BOX (vbox), GTK_WIDGET (data->traybox), TRUE, TRUE, 0);
 
   g_signal_connect_after (data->traybox, "add", G_CALLBACK (tray_added_cb), data);

--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -303,35 +303,40 @@ calc_arrow (PanelOrientation  orientation,
 	    gdouble          *size)
 {
 	GtkArrowType retval = GTK_ARROW_UP;
-	double scale;
 
-	scale = (orientation & PANEL_HORIZONTAL_MASK ? button_height : button_width) / 48.0;
-
-	*size = 12 * scale;
+	if (orientation & PANEL_HORIZONTAL_MASK) {
+		if (button_width > 50)
+			button_width = 50;
+	} else {
+		if (button_height > 50)
+			button_height = 50;
+	}
+	
+	*size = (orientation & PANEL_HORIZONTAL_MASK ? button_width : button_height) / 2;
 	*angle = 0;
 
 	switch (orientation) {
 	case PANEL_ORIENTATION_TOP:
-		*x     = scale * 3;
-		*y     = scale * (48 - 13);
+		*x     = (button_width - (*size)) / 2;
+		*y     = button_height * .99 - (*size) / (3/2);	// 3/2 is the approximate ratio of GTK arrows
 		*angle = G_PI;
 		retval = GTK_ARROW_DOWN;
 		break;
 	case PANEL_ORIENTATION_BOTTOM:
-		*x     = scale * (48 - 13);
-		*y     = scale * 1;
+		*x     = (button_width - (*size)) / 2;
+		*y     = button_height * .01;
 		*angle = 0;
 		retval = GTK_ARROW_UP;
 		break;
 	case PANEL_ORIENTATION_LEFT:
-		*x     = scale * (48 - 13);
-		*y     = scale * 3;
+		*x     = button_width * .99 - (*size) / (3/2);	// 3/2 is the approximate ratio of GTK arrows
+		*y     = (button_height - (*size)) / 2;
 		*angle = G_PI / 2;
 		retval = GTK_ARROW_RIGHT;
 		break;
 	case PANEL_ORIENTATION_RIGHT:
-		*x     = scale * 1;
-		*y     = scale * 3;
+		*x     = button_width * .01;
+		*y     = (button_height - (*size)) / 2;
 		*angle = 3 * (G_PI / 2);
 		retval = GTK_ARROW_LEFT;
 		break;
@@ -446,9 +451,14 @@ button_widget_get_preferred_width (GtkWidget *widget,
 
 	parent = gtk_widget_get_parent (widget);
 
-	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK)
+	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK){
 		size = gtk_widget_get_allocated_height (parent);
-	else
+
+		/* should get this value (50) from gsettings, user defined value in properties of the panel (max_icon_size) OR use 48*/
+		if ( size > 50 )
+			size = 50;	
+
+	} else
 		size = gtk_widget_get_allocated_width (parent);
 
 	*minimal_width = *natural_width = size;
@@ -467,8 +477,14 @@ button_widget_get_preferred_height (GtkWidget *widget,
 
 	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK)
 		size = gtk_widget_get_allocated_height (parent);
-	else
+	else {
 		size = gtk_widget_get_allocated_width (parent);
+		
+		/* should get this value (50) from gsettings, user defined value in properties of the panel (max_icon_size) OR use 48*/
+		if ( size > 50 )
+			size = 50;	
+	
+	}
 
 	*minimal_height = *natural_height = size;
 }
@@ -480,6 +496,17 @@ button_widget_size_allocate (GtkWidget     *widget,
 	ButtonWidget *button_widget = BUTTON_WIDGET (widget);
 	int           size;
 
+	/* should get this value (50) from gsettings, user defined value in properties of the panel (max_icon_size) OR use 48?*/
+	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK) {
+		if ( allocation->height > 50 ) {
+			allocation->width = 50;	
+		}
+	} else {
+		if ( allocation->width > 50 ) {
+			allocation->height = 50;	
+		}
+	}
+	
 	GTK_WIDGET_CLASS (button_widget_parent_class)->size_allocate (widget, allocation);
 
 	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK)


### PR DESCRIPTION
This is a simple cherry-pick of GtkGrid port in master branch and fixes https://github.com/mate-desktop/mate-panel/issues/907
For reproducing the issue you need to use MATE 1.20.x and follow instructions from report.
With master branch all works well.
Use the script with the `yad` command.
Without the PR you will see a broken na-tray applet with high cpu load.
Note, you need to kill all `yad` processes before reloading the panel.

With the PR you will see 30 instances of `yad` UI in na-tray applet without increasing the cpu load.