### PR TITLE
Check X11 support before using X11 specific features

### DIFF
--- a/mate-panel/panel-action-protocol.c
+++ b/mate-panel/panel-action-protocol.c
@@ -24,6 +24,10 @@
 
 #include <config.h>
 
+#ifndef HAVE_X11
+#error file should only be built when HAVE_X11 is enabled
+#endif
+
 #include "panel-action-protocol.h"
 
 #include <gdk/gdk.h>
@@ -131,6 +135,8 @@ panel_action_protocol_filter (GdkXEvent *gdk_xevent,
 
 	screen = gdk_event_get_screen (event);
 	display = gdk_screen_get_display (screen);
+	if (!GDK_IS_X11_DISPLAY (display))
+		return GDK_FILTER_CONTINUE;
 	window = gdk_x11_window_lookup_for_display (display, xevent->xclient.window);
 	if (!window)
 		return GDK_FILTER_CONTINUE;
@@ -160,6 +166,7 @@ panel_action_protocol_init (void)
 	GdkDisplay *display;
 
 	display = gdk_display_get_default ();
+	g_assert(GDK_IS_X11_DISPLAY (display));
 
 	atom_mate_panel_action =
 		XInternAtom (GDK_DISPLAY_XDISPLAY (display),

--- a/mate-panel/panel-action-protocol.h
+++ b/mate-panel/panel-action-protocol.h
@@ -25,6 +25,12 @@
 #ifndef __PANEL_ACTION_PROTOCOL_H__
 #define __PANEL_ACTION_PROTOCOL_H__
 
+#ifdef PACKAGE_NAME // only check HAVE_X11 if config.h has been included
+#ifndef HAVE_X11
+#error file should only be included when HAVE_X11 is enabled
+#endif
+#endif
+
 #include <glib.h>
 
 G_BEGIN_DECLS

--- a/mate-panel/panel-force-quit.c
+++ b/mate-panel/panel-force-quit.c
@@ -24,6 +24,10 @@
 
 #include <config.h>
 
+#ifndef HAVE_X11
+#error file should only be built when HAVE_X11 is enabled
+#endif
+
 #include "panel-force-quit.h"
 
 #include <glib/gi18n.h>
@@ -334,6 +338,8 @@ panel_force_quit (GdkScreen *screen,
 	GdkWindow     *root;
 	GdkDisplay    *display;
 	GdkSeat       *seat;
+
+	g_return_if_fail (GDK_IS_X11_DISPLAY (gdk_screen_get_display (screen)));
 
 	popup = display_popup_window (screen);
 

--- a/mate-panel/panel-force-quit.h
+++ b/mate-panel/panel-force-quit.h
@@ -25,6 +25,12 @@
 #ifndef __PANEL_FORCE_QUIT_H__
 #define __PANEL_FORCE_QUIT_H__
 
+#ifdef PACKAGE_NAME // only check HAVE_X11 if config.h has been included
+#ifndef HAVE_X11
+#error file should only be included when HAVE_X11 is enabled
+#endif
+#endif
+
 #include <gdk/gdk.h>
 
 #ifdef __cplusplus

--- a/mate-panel/panel-xutils.c
+++ b/mate-panel/panel-xutils.c
@@ -24,6 +24,10 @@
 
 #include "config.h"
 
+#ifndef HAVE_X11
+#error file should only be built when HAVE_X11 is enabled
+#endif
+
 #include "panel-xutils.h"
 
 #include <glib.h>
@@ -63,6 +67,7 @@ panel_xutils_set_strut (GdkWindow        *gdk_window,
 	GdkDisplay *display;
 
 	g_return_if_fail (GDK_IS_WINDOW (gdk_window));
+	g_return_if_fail (GDK_IS_X11_DISPLAY (gdk_window_get_display (gdk_window)));
 
 	xdisplay = GDK_WINDOW_XDISPLAY (gdk_window);
 	window = GDK_WINDOW_XID (gdk_window);
@@ -116,6 +121,7 @@ panel_warp_pointer (GdkWindow *gdk_window,
 	GdkDisplay *display;
 
 	g_return_if_fail (GDK_IS_WINDOW (gdk_window));
+	g_return_if_fail (GDK_IS_X11_DISPLAY (gdk_window_get_display (gdk_window)));
 
 	xdisplay = GDK_WINDOW_XDISPLAY (gdk_window);
 	window = GDK_WINDOW_XID (gdk_window);
@@ -143,6 +149,7 @@ panel_get_real_modifier_mask (guint mask)
 		return mask;
 	}
 
+	g_return_val_if_fail (GDK_IS_X11_DISPLAY (gdk_display_get_default ()), mask);
 	display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
 
 	XDisplayKeycodes (display, &min_keycode, &max_keycode);

--- a/mate-panel/panel-xutils.h
+++ b/mate-panel/panel-xutils.h
@@ -25,6 +25,12 @@
 #ifndef __PANEL_XUTILS_H__
 #define __PANEL_XUTILS_H__
 
+#ifdef PACKAGE_NAME // only check HAVE_X11 if config.h has been included
+#ifndef HAVE_X11
+#error file should only be included when HAVE_X11 is enabled
+#endif
+#endif
+
 #include <glib.h>
 #include <gdk/gdk.h>
 #include <gdk/gdkx.h>

--- a/mate-panel/xstuff.c
+++ b/mate-panel/xstuff.c
@@ -46,6 +46,11 @@ static gboolean xstuff_display_is_dead = FALSE;
 #define ZOOM_STEPS  14
 #define ZOOM_DELAY 10
 
+gboolean is_using_x11 ()
+{
+	return GDK_IS_X11_DISPLAY (gdk_display_get_default ());
+}
+
 typedef struct {
 	int size;
 	int size_start;

--- a/mate-panel/xstuff.c
+++ b/mate-panel/xstuff.c
@@ -12,7 +12,13 @@
  *  Copyright (c) 1997-2002 Alfredo K. Kojima
 
  */
+
 #include <config.h>
+
+#ifndef HAVE_X11
+#error file should only be built when HAVE_X11 is enabled
+#endif
+
 #include <string.h>
 #include <unistd.h>
 

--- a/mate-panel/xstuff.h
+++ b/mate-panel/xstuff.h
@@ -12,6 +12,8 @@
 
 #include "panel-enums-gsettings.h"
 
+gboolean is_using_x11                   (void);
+
 void xstuff_zoom_animate                (GtkWidget        *widget,
 					 cairo_surface_t  *surface,
 					 PanelOrientation  orientation,

--- a/mate-panel/xstuff.h
+++ b/mate-panel/xstuff.h
@@ -10,6 +10,9 @@
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
 
+#include <gdk/gdkx.h>
+#include <gtk/gtkx.h>
+
 #include "panel-enums-gsettings.h"
 
 gboolean is_using_x11                   (void);

--- a/mate-panel/xstuff.h
+++ b/mate-panel/xstuff.h
@@ -1,8 +1,16 @@
 #ifndef __XSTUFF_H__
 #define __XSTUFF_H__
 
+#ifdef PACKAGE_NAME // only check HAVE_X11 if config.h has been included
+#ifndef HAVE_X11
+#error file should only be included when HAVE_X11 is enabled
+#endif
+#endif
+
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
+
+#include "panel-enums-gsettings.h"
 
 void xstuff_zoom_animate                (GtkWidget        *widget,
 					 cairo_surface_t  *surface,


### PR DESCRIPTION
Add various compile time and runtime checks to keep X11 specific files running on Wayland.