### PR TITLE
fix crash on removing tray

### DIFF
--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -333,6 +333,7 @@ na_tray_applet_realize (GtkWidget *widget)
 static void
 na_tray_applet_dispose (GObject *object)
 {
+  g_clear_object (&NA_TRAY_APPLET (object)->priv->settings);
 #ifdef PROVIDE_WATCHER_SERVICE
   g_clear_object (&NA_TRAY_APPLET (object)->priv->sn_watcher);
 #endif

--- a/applets/notification_area/na-grid.c
+++ b/applets/notification_area/na-grid.c
@@ -183,9 +183,9 @@ void
 na_grid_set_min_icon_size (NaGrid *grid,
                            gint    min_icon_size)
 {
-  grid->min_icon_size = min_icon_size;
-  
   g_return_if_fail (NA_IS_GRID (grid));
+
+  grid->min_icon_size = min_icon_size;
   
   refresh_grid (grid);
 }


### PR DESCRIPTION
*clear applet gsettings on dispose to stop crash and memory leak introduced in github.com/mate-desktop/mate-panel/commit/10b9c30fc79de5f8d9516ba153df233c4968da65
    
*tray: fix misplaced g_return_if_fail check