### PR TITLE
Fix missing scrollbars on too-high menu-button and alt-F1 menus

### DIFF
--- a/mate-panel/panel-action-protocol.c
+++ b/mate-panel/panel-action-protocol.c
@@ -100,6 +100,8 @@ panel_action_protocol_main_menu (GdkScreen *screen,
 	gdk_event_set_device (event, device);
 
 	gtk_menu_popup_at_pointer (GTK_MENU (menu),event);
+	/*Ensure scrollbars show up if vertical space is limited*/
+	gtk_menu_reposition(GTK_MENU(menu));
 }
 
 static void

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -477,6 +477,9 @@ panel_menu_button_popup_menu (PanelMenuButton *button,
 	                          GDK_GRAVITY_NORTH_WEST,
 	                          NULL);
 
+	/*Ensure scrollbars show up if vertical space is limited*/
+	gtk_menu_reposition (GTK_MENU (button->priv->menu));
+
 	g_signal_connect(GTK_MENU_SHELL (button->priv->menu), "deactivate", G_CALLBACK (panel_menu_button_menu_deactivate), button);
 	toplevel = gtk_widget_get_toplevel(GTK_WIDGET(button->priv->toplevel));
 	button->priv->interrupted_window = panel_util_get_current_active_window (toplevel);


### PR DESCRIPTION
This fixes part of  https://github.com/mate-desktop/mate-panel/issues/920