### PR TITLE
Properly align button menu positions on vertical panels

### DIFF
--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -471,9 +471,14 @@ panel_menu_button_popup_menu (PanelMenuButton *button,
 	screen = gtk_window_get_screen (GTK_WINDOW (button->priv->toplevel));
 	gtk_menu_set_screen (GTK_MENU (button->priv->menu), screen);
 
+	/*using these same anchor points lets default "anchor-hints" properly position the menu
+	 *so that on a vertical panel the menu aligns with the outside edge of a menu button
+	 *placed at the top or bottom of a left or a right panel
+	 */
+
 	gtk_menu_popup_at_widget (GTK_MENU (button->priv->menu),
 	                          GTK_WIDGET (button),
-	                          GDK_GRAVITY_SOUTH_WEST,
+	                          GDK_GRAVITY_NORTH_WEST,
 	                          GDK_GRAVITY_NORTH_WEST,
 	                          NULL);
 


### PR DESCRIPTION
Ensure that on a vertical panel, if the menubutton is at the top of the panel, align the menu with the top screen edge or if a top panel is also present the bottom edge of that top panel(as set by struts).

Ensure that on a vertical panel, if the menubutton is at the bottom of the panel, align the menu with the bottom screen edge or if a bottom panel is also present the top edge of that top panel(as set by struts).
```
Setting 
GDK_GRAVITY_SOUTH_WEST,
GDK_GRAVITY_NORTH_WEST,
```
for the menu button popup menu seems to allow the default anchor hints
`GDK_ANCHOR_FLIP_X | GDK_ANCHOR_FLIP_Y | GDK_ANCHOR_SLIDE_X | GDK_ANCHOR_SLIDE_Y | GDK_ANCHOR_RESIZE_X | GDK_ANCHOR_RESIZE_Y`
to automatically and correctly set up the menu positions

See
https://developer.gnome.org/gtk3/stable/GtkMenu.html#GtkMenu--anchor-hints

