### PR TITLE
Use docker-build on the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 before_install:
-  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/travis/travis/docker-build
+  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/docker-build
   - chmod +x docker-build
 
 install:


### PR DESCRIPTION
This can fix #933 build fail on travis. The build log is here: https://travis-ci.org/mate-desktop/mate-panel/builds/493723076