### PR TITLE
Dropped *-protocol suffix from generated files

### DIFF
--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -16,6 +16,11 @@ AM_CPPFLAGS = \
 	-DPANELDATADIR=\""$(datadir)/mate-panel"\" \
 	$(DISABLE_DEPRECATED_CFLAGS)
 
+if ENABLE_WAYLAND
+AM_CPPFLAGS += \
+	-I$(top_builddir)/mate-panel/wayland-protocols
+endif
+
 AM_CFLAGS = $(WARN_CFLAGS)
 
 panel_sources = \
@@ -63,8 +68,8 @@ panel_sources = \
 
 if ENABLE_WAYLAND
 panel_sources += \
-	wayland-protocols/wlr-layer-shell-unstable-v1-protocol.c \
-	wayland-protocols/xdg-shell-protocol.c
+	wayland-protocols/wlr-layer-shell-unstable-v1.c \
+	wayland-protocols/xdg-shell.c
 endif
 
 if ENABLE_X11
@@ -125,8 +130,8 @@ panel_headers = \
 
 if ENABLE_WAYLAND
 panel_headers += \
-	wayland-protocols/wlr-layer-shell-unstable-v1-client-protocol.h \
-	wayland-protocols/xdg-shell-client-protocol.h
+	wayland-protocols/wlr-layer-shell-unstable-v1-client.h \
+	wayland-protocols/xdg-shell-client.h
 endif
 
 if ENABLE_X11

--- a/mate-panel/wayland-protocols/Makefile.am
+++ b/mate-panel/wayland-protocols/Makefile.am
@@ -1,23 +1,23 @@
 if ENABLE_WAYLAND
-all: wlr-layer-shell-unstable-v1-client-protocol.h wlr-layer-shell-unstable-v1-protocol.c xdg-shell-client-protocol.h xdg-shell-protocol.c
+all: wlr-layer-shell-unstable-v1-client.h wlr-layer-shell-unstable-v1.c xdg-shell-client.h xdg-shell.c
 
-wlr-layer-shell-unstable-v1-client-protocol.h: wlr-layer-shell-unstable-v1.xml
-	wayland-scanner -c client-header wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-client-protocol.h
-
-# 'code' is depricated, and can be replaced with 'private-code' when all platforms have a new enough wayland-scanner
-wlr-layer-shell-unstable-v1-protocol.c: wlr-layer-shell-unstable-v1.xml
-	wayland-scanner -c code wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-protocol.c
-
-xdg-shell-client-protocol.h: xdg-shell.xml
-	wayland-scanner -c client-header xdg-shell.xml xdg-shell-client-protocol.h
+wlr-layer-shell-unstable-v1-client.h: wlr-layer-shell-unstable-v1.xml
+	wayland-scanner -c client-header wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1-client.h
 
 # 'code' is depricated, and can be replaced with 'private-code' when all platforms have a new enough wayland-scanner
-xdg-shell-protocol.c: xdg-shell.xml
-	wayland-scanner -c code xdg-shell.xml xdg-shell-protocol.c
+wlr-layer-shell-unstable-v1.c: wlr-layer-shell-unstable-v1.xml
+	wayland-scanner -c code wlr-layer-shell-unstable-v1.xml wlr-layer-shell-unstable-v1.c
+
+xdg-shell-client.h: xdg-shell.xml
+	wayland-scanner -c client-header xdg-shell.xml xdg-shell-client.h
+
+# 'code' is depricated, and can be replaced with 'private-code' when all platforms have a new enough wayland-scanner
+xdg-shell.c: xdg-shell.xml
+	wayland-scanner -c code xdg-shell.xml xdg-shell.c
 endif
 
 clean:
-	rm -f wlr-layer-shell-unstable-v1-client-protocol.h
-	rm -f wlr-layer-shell-unstable-v1-protocol.c
-	rm -f xdg-shell-client-protocol.h
-	rm -f xdg-shell-protocol.c
+	rm -f wlr-layer-shell-unstable-v1-client.h
+	rm -f wlr-layer-shell-unstable-v1.c
+	rm -f xdg-shell-client.h
+	rm -f xdg-shell.c


### PR DESCRIPTION
They're already in the `wayland-protocols` directory, so `-protocol` is just noise. I was the one who originally put it there, and this commit to fix it has been sitting around my branches for a while.