### PR TITLE
window-list: Show window previews on hover

### DIFF
--- a/applets/wncklet/Makefile.am
+++ b/applets/wncklet/Makefile.am
@@ -90,9 +90,16 @@ BUILT_SOURCES = 		\
 	wncklet-resources.c	\
 	wncklet-resources.h
 
+if HAVE_WINDOW_PREVIEWS
+wncklet_gschemas_in = \
+	org.mate.panel.applet.window-list.gschema.xml.in \
+	org.mate.panel.applet.window-list-previews.gschema.xml.in \
+	org.mate.panel.applet.workspace-switcher.gschema.xml.in
+else
 wncklet_gschemas_in = \
 	org.mate.panel.applet.window-list.gschema.xml.in \
 	org.mate.panel.applet.workspace-switcher.gschema.xml.in
+endif
 gsettings_SCHEMAS = $(wncklet_gschemas_in:.xml.in=.xml)
 
 @INTLTOOL_XML_NOMERGE_RULE@

--- a/applets/wncklet/org.mate.panel.applet.window-list-previews.gschema.xml.in
+++ b/applets/wncklet/org.mate.panel.applet.window-list-previews.gschema.xml.in
@@ -1,0 +1,14 @@
+<schemalist gettext-domain="@GETTEXT_PACKAGE@">
+  <schema id="org.mate.panel.applet.window-list-previews">
+    <key name="show-window-thumbnails" type="b">
+      <default>true</default>
+      <summary>Display window thumbnails on hover</summary>
+      <description>If true, then when hovering over a taskbar item, a thumbnail of the window will appear. It will go away as soon as the mouse leaves the item.</description>
+    </key>
+    <key name="thumbnail-window-size" type="i">
+      <default>200</default>
+      <summary>Size of window thumbnails</summary>
+      <description>Size in pixels of the window preview thumbnail. The largest between width and height will use this value, the other one will be calculated to maintain the correct aspect ratio.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in
+++ b/applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in
@@ -10,16 +10,6 @@
       <summary>Show windows from all workspaces</summary>
       <description>If true, the window list will show windows from all workspaces. Otherwise it will only display windows from the current workspace.</description>
     </key>
-    <key name="show-window-thumbnails" type="b">
-      <default>true</default>
-      <summary>Display window thumbnails on hover</summary>
-      <description>If true, then when hovering over a taskbar item, a thumbnail of the window will appear. It will go away as soon as the mouse leaves the item.</description>
-    </key>
-    <key name="thumbnail-window-size" type="i">
-      <default>200</default>
-      <summary>Size of window thumbnails</summary>
-      <description>Size in pixels of the window preview thumbnail. The largest between width and height will use this value, the other one will be calculated to maintain the correct aspect ratio.</description>
-    </key>
     <key name="group-windows" enum="org.mate.panel.applet.window-list.GroupingType">
       <default>'never'</default>
       <summary>When to group windows</summary>

--- a/applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in
+++ b/applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in
@@ -10,6 +10,16 @@
       <summary>Show windows from all workspaces</summary>
       <description>If true, the window list will show windows from all workspaces. Otherwise it will only display windows from the current workspace.</description>
     </key>
+    <key name="show-window-thumbnails" type="b">
+      <default>true</default>
+      <summary>Display window thumbnails on hover</summary>
+      <description>If true, then when hovering over a taskbar item, a thumbnail of the window will appear. It will go away as soon as the mouse leaves the item.</description>
+    </key>
+    <key name="thumbnail-window-size" type="i">
+      <default>200</default>
+      <summary>Size of window thumbnails</summary>
+      <description>Size in pixels of the window preview thumbnail. The largest between width and height will use this value, the other one will be calculated to maintain the correct aspect ratio.</description>
+    </key>
     <key name="group-windows" enum="org.mate.panel.applet.window-list.GroupingType">
       <default>'never'</default>
       <summary>When to group windows</summary>

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -19,10 +19,12 @@
 
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
-#include <gdk/gdkx.h>
 #define WNCK_I_KNOW_THIS_IS_UNSTABLE
 #include <libwnck/libwnck.h>
 #include <gio/gio.h>
+#if WNCK_CHECK_VERSION (3, 32, 0)
+#include <gdk/gdkx.h>
+#endif
 
 #define MATE_DESKTOP_USE_UNSTABLE_API
 #include <libmate-desktop/mate-desktop-utils.h>
@@ -36,11 +38,13 @@
 typedef struct {
 	GtkWidget* applet;
 	GtkWidget* tasklist;
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	GtkWidget* preview;
 
-	gboolean include_all_workspaces;
 	gboolean show_window_thumbnails;
 	gint thumbnail_size;
+#endif
+	gboolean include_all_workspaces;
 	WnckTasklistGroupingType grouping;
 	gboolean move_unminimized_windows;
 
@@ -56,9 +60,11 @@ typedef struct {
 	GtkWidget* properties_dialog;
 	GtkWidget* show_current_radio;
 	GtkWidget* show_all_radio;
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	GtkWidget* show_thumbnails_radio;
 	GtkWidget* hide_thumbnails_radio;
 	GtkWidget* thumbnail_size_spin;
+#endif
 	GtkWidget* never_group_radio;
 	GtkWidget* auto_group_radio;
 	GtkWidget* always_group_radio;
@@ -146,6 +152,7 @@ static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBac
 	}
 }
 
+#if WNCK_CHECK_VERSION (3, 32, 0)
 static GdkPixbuf *preview_window_thumbnail (WnckWindow *wnck_window, TasklistData *tasklist)
 {
 	GdkWindow *window;
@@ -310,6 +317,7 @@ static gboolean applet_leave_notify_event (WnckTasklist *tl, GList *wnck_windows
 
 	return FALSE;
 }
+#endif
 
 static void applet_change_pixel_size(MatePanelApplet* applet, gint size, TasklistData* tasklist)
 {
@@ -399,6 +407,7 @@ static void display_all_workspaces_changed(GSettings* settings, gchar* key, Task
 	tasklist_properties_update_content_radio(tasklist);
 }
 
+#if WNCK_CHECK_VERSION (3, 32, 0)
 static void tasklist_update_thumbnails_radio(TasklistData* tasklist)
 {
 	GtkWidget* button;
@@ -447,6 +456,7 @@ static void thumbnail_size_changed(GSettings *settings, gchar* key, TasklistData
 	tasklist->thumbnail_size = g_settings_get_int(settings, key);
 	tasklist_update_thumbnail_size_spin(tasklist);
 }
+#endif
 
 static GtkWidget* get_grouping_button(TasklistData* tasklist, WnckTasklistGroupingType type)
 {
@@ -524,6 +534,7 @@ static void setup_gsettings(TasklistData* tasklist)
 					  "changed::display-all-workspaces",
 					  G_CALLBACK (display_all_workspaces_changed),
 					  tasklist);
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	g_signal_connect (tasklist->settings,
 					  "changed::show-window-thumbnails",
 					  G_CALLBACK (window_thumbnails_changed),
@@ -532,6 +543,7 @@ static void setup_gsettings(TasklistData* tasklist)
 					  "changed::thumbnail-window-size",
 					  G_CALLBACK (thumbnail_size_changed),
 					  tasklist);
+#endif
 	g_signal_connect (tasklist->settings,
 					  "changed::group-windows",
 					  G_CALLBACK (group_windows_changed),
@@ -650,9 +662,11 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 
 	tasklist->include_all_workspaces = g_settings_get_boolean (tasklist->settings, "display-all-workspaces");
 
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	tasklist->show_window_thumbnails = g_settings_get_boolean (tasklist->settings, "show-window-thumbnails");
 
 	tasklist->thumbnail_size = g_settings_get_int (tasklist->settings, "thumbnail-window-size");
+#endif
 
 	tasklist->grouping = g_settings_get_enum (tasklist->settings, "group-windows");
 
@@ -684,8 +698,10 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 	wnck_tasklist_set_icon_loader(WNCK_TASKLIST(tasklist->tasklist), icon_loader_func, tasklist, NULL);
 
 	g_signal_connect(G_OBJECT(tasklist->tasklist), "destroy", G_CALLBACK(destroy_tasklist), tasklist);
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	g_signal_connect(G_OBJECT(tasklist->tasklist), "task_enter_notify", G_CALLBACK(applet_enter_notify_event), tasklist);
 	g_signal_connect(G_OBJECT(tasklist->tasklist), "task_leave_notify", G_CALLBACK(applet_leave_notify_event), tasklist);
+#endif
 
 	g_signal_connect(G_OBJECT(tasklist->applet), "size_allocate", G_CALLBACK(applet_size_allocate), tasklist);
 
@@ -819,6 +835,7 @@ static void group_windows_toggled(GtkToggleButton* button, TasklistData* tasklis
 	}
 }
 
+#if WNCK_CHECK_VERSION (3, 32, 0)
 static void show_thumbnails_toggled(GtkToggleButton* button, TasklistData* tasklist)
 {
 	g_settings_set_boolean(tasklist->settings, "show-window-thumbnails", gtk_toggle_button_get_active(button));
@@ -828,6 +845,7 @@ static void thumbnail_size_spin_changed(GtkSpinButton* button, TasklistData* tas
 {
 	g_settings_set_int(tasklist->settings, "thumbnail-window-size", gtk_spin_button_get_value_as_int(button));
 }
+#endif
 
 static void move_minimized_toggled(GtkToggleButton* button, TasklistData* tasklist)
 {
@@ -872,7 +890,9 @@ static void setup_sensitivity(TasklistData* tasklist, GtkBuilder* builder, const
 static void setup_dialog(GtkBuilder* builder, TasklistData* tasklist)
 {
 	GtkWidget* button;
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	GtkAdjustment *adjustment;
+#endif
 
 	tasklist->show_current_radio = WID("show_current_radio");
 	tasklist->show_all_radio = WID("show_all_radio");
@@ -885,6 +905,7 @@ static void setup_dialog(GtkBuilder* builder, TasklistData* tasklist)
 
 	setup_sensitivity(tasklist, builder, "never_group_radio", "auto_group_radio", "always_group_radio", "group-windows" /* key */);
 
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	tasklist->show_thumbnails_radio = WID("show_thumbnails_radio");
 	tasklist->hide_thumbnails_radio = WID("hide_thumbnails_radio");
 	tasklist->thumbnail_size_spin = WID("thumbnail_size_spin");
@@ -895,6 +916,7 @@ static void setup_dialog(GtkBuilder* builder, TasklistData* tasklist)
 	gtk_adjustment_set_lower (adjustment, 0);
 	gtk_adjustment_set_upper (adjustment, 999);
 	gtk_adjustment_set_step_increment (adjustment, 1);
+#endif
 
 	tasklist->minimized_windows_label = WID("minimized_windows_label");
 	tasklist->move_minimized_radio = WID("move_minimized_radio");
@@ -913,12 +935,14 @@ static void setup_dialog(GtkBuilder* builder, TasklistData* tasklist)
 	g_signal_connect(G_OBJECT(tasklist->auto_group_radio), "toggled", (GCallback) group_windows_toggled, tasklist);
 	g_signal_connect(G_OBJECT(tasklist->always_group_radio), "toggled", (GCallback) group_windows_toggled, tasklist);
 
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	/* show thumbnails on hover: */
 	tasklist_update_thumbnails_radio(tasklist);
 	g_signal_connect(G_OBJECT(tasklist->show_thumbnails_radio), "toggled", (GCallback) show_thumbnails_toggled, tasklist);
 	/* change thumbnail size: */
 	tasklist_update_thumbnail_size_spin(tasklist);
 	g_signal_connect(G_OBJECT(tasklist->thumbnail_size_spin), "value-changed", (GCallback) thumbnail_size_spin_changed, tasklist);
+#endif
 
 	/* move window when unminimizing: */
 	tasklist_update_unminimization_radio(tasklist);
@@ -962,7 +986,9 @@ static void destroy_tasklist(GtkWidget* widget, TasklistData* tasklist)
 {
 	g_signal_handlers_disconnect_by_data (G_OBJECT (tasklist->applet), tasklist);
 
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	g_signal_handlers_disconnect_by_data (G_OBJECT (tasklist->tasklist), tasklist);
+#endif
 
 	g_signal_handlers_disconnect_by_data (tasklist->settings, tasklist);
 
@@ -971,8 +997,10 @@ static void destroy_tasklist(GtkWidget* widget, TasklistData* tasklist)
 	if (tasklist->properties_dialog)
 		gtk_widget_destroy(tasklist->properties_dialog);
 
+#if WNCK_CHECK_VERSION (3, 32, 0)
 	if (tasklist->preview)
 		gtk_widget_destroy(tasklist->preview);
+#endif
 
 	g_free(tasklist);
 }

--- a/applets/wncklet/window-list.ui
+++ b/applets/wncklet/window-list.ui
@@ -161,7 +161,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="vbox15">
+              <object class="GtkBox" id="window_thumbnails">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>

--- a/applets/wncklet/window-list.ui
+++ b/applets/wncklet/window-list.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image1">
@@ -17,6 +17,9 @@
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Window List Preferences</property>
     <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="visible">True</property>
@@ -158,6 +161,138 @@
               </packing>
             </child>
             <child>
+              <object class="GtkBox" id="vbox15">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkLabel" id="label4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Window Thumbnails</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkAlignment" id="alignment4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkBox" id="vbox16">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkRadioButton" id="show_thumbnails_radio">
+                            <property name="label" translatable="yes">Show _thumbnails on hover</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="hide_thumbnails_radio">
+                            <property name="label" translatable="yes">_Hide thumbnails on hover</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">show_thumbnails_radio</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkAlignment" id="alignment5">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkBox" id="hbox1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkLabel" id="label2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="tooltip_text" translatable="yes">Thumbnail width in pixels. Window aspect ratio will be maintained.</property>
+                            <property name="label" translatable="yes">Thumbnail width:</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="thumbnail_size_spin">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="max_length">3</property>
+                            <property name="caps_lock_warning">False</property>
+                            <property name="placeholder_text" translatable="yes">px</property>
+                            <property name="input_purpose">number</property>
+                            <property name="climb_rate">1</property>
+                            <property name="numeric">True</property>
+                            <property name="value">200</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkBox" id="vbox11">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -251,7 +386,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -332,7 +467,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>
@@ -348,8 +483,5 @@
       <action-widget response="-11">help_button</action-widget>
       <action-widget response="0">done_button</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
 </interface>

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,7 @@ DCONF_REQUIRED=0.13.4
 LIBRSVG_REQUIRED=2.36.2
 GTK_REQUIRED=3.22.0
 LIBWNCK_REQUIRED=3.4.6
+LIBWNCK_PREVIEWS_OPTIONAL=3.32.0
 WEATHER_REQUIRED=1.17.0
 
 dnl pkg-config dependency checks
@@ -89,9 +90,16 @@ PKG_CHECK_MODULES(NOTIFICATION_AREA, gtk+-3.0 >= $GTK_REQUIRED mate-desktop-2.0 
 AC_SUBST(NOTIFICATION_AREA_CFLAGS)
 AC_SUBST(NOTIFICATION_AREA_LIBS)
 
-PKG_CHECK_MODULES(WNCKLET, gtk+-3.0 >= $GTK_REQUIRED libwnck-3.0 >= $LIBWNCK_REQUIRED mate-desktop-2.0 >= $LIBMATE_DESKTOP_REQUIRED)
+# Check if we have a version of libwnck that allows for window previews
+PKG_CHECK_MODULES(WNCKLET, gtk+-3.0 >= $GTK_REQUIRED libwnck-3.0 >= $LIBWNCK_PREVIEWS_OPTIONAL mate-desktop-2.0 >= $LIBMATE_DESKTOP_REQUIRED, have_window_previews=yes, [
+   PKG_CHECK_MODULES(WNCKLET, gtk+-3.0 >= $GTK_REQUIRED libwnck-3.0 >= $LIBWNCK_REQUIRED mate-desktop-2.0 >= $LIBMATE_DESKTOP_REQUIRED, have_window_previews=no)
+])
 AC_SUBST(WNCKLET_CFLAGS)
 AC_SUBST(WNCKLET_LIBS)
+AM_CONDITIONAL(HAVE_WINDOW_PREVIEWS, [test "x$have_window_previews" = "xyes"])
+if test "x$have_window_previews" = "xyes"; then
+   AC_DEFINE([HAVE_WINDOW_PREVIEWS], 1, [Defined when using a version of libwnck that provides window-list previews])
+fi
 
 AC_CHECK_HEADERS(langinfo.h)
 AC_CHECK_FUNCS(nl_langinfo)
@@ -319,6 +327,7 @@ applets/notification_area/status-notifier/Makefile
 applets/notification_area/system-tray/Makefile
 applets/wncklet/Makefile
 applets/wncklet/org.mate.panel.applet.window-list.gschema.xml
+applets/wncklet/org.mate.panel.applet.window-list-previews.gschema.xml
 applets/wncklet/org.mate.panel.applet.workspace-switcher.gschema.xml
 doc/Makefile
 doc/reference/Makefile


### PR DESCRIPTION
Note: This feature requires `libwnck` version [3.32.0](https://gitlab.gnome.org/GNOME/libwnck/commit/d3a714db6af5c1a146effb8d8f827b8973bbb91c) or higher.

When hovering on taskbar entries, display a popup with a thumbnail
of the associated window. Popup goes away when leaving the button.

If a window has not been mapped since the applet started, it will
not display a thumbnail. Once mapped, however, it will use its
latest available thumbnail as preview, even when minimized.

Fixes #391 