### PR TITLE
Fix panel applet keyboard focus trap

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -985,13 +985,19 @@ mate_panel_applet_button_release (GtkWidget      *widget,
 	return mate_panel_applet_button_event (applet, event);
 }
 
+/*Open the applet context menu only on Menu key
+ *Do not open it on Return or some applets won't work
+ */
 static gboolean
 mate_panel_applet_key_press_event (GtkWidget   *widget,
 			      GdkEventKey *event)
 {
-	mate_panel_applet_menu_popup (MATE_PANEL_APPLET (widget), (GdkEvent *) event);
-
-	return TRUE;
+    if (event->keyval == GDK_KEY_Menu) {
+        mate_panel_applet_menu_popup (MATE_PANEL_APPLET (widget), (GdkEvent *) event);
+        return TRUE;
+    }
+    else
+        return FALSE;
 }
 
 static void


### PR DESCRIPTION
Do not open the context menu on tab-or on anything but the menu key. Note that Return must be used by some applets (e.g. the clock) for something else. Fixes https://github.com/mate-desktop/mate-panel/issues/952