### PR TITLE
Set compressed="true" for gresource text files

### DIFF
--- a/applets/clock/clock.gresource.xml
+++ b/applets/clock/clock.gresource.xml
@@ -3,12 +3,12 @@
   <gresource prefix="/org/mate/panel/applet/clock">
     <file compressed="true">clock.ui</file>
     <file compressed="true">clock-menu.xml</file>
-    <file alias="icons/clock-face-large.svg">pixmaps/clock-face-large.svg</file>
-    <file alias="icons/clock-face-small.svg">pixmaps/clock-face-small.svg</file>
-    <file alias="icons/clock-face-small-morning.svg">pixmaps/clock-face-small-morning.svg</file>
-    <file alias="icons/clock-face-small-day.svg">pixmaps/clock-face-small-day.svg</file>
-    <file alias="icons/clock-face-small-evening.svg">pixmaps/clock-face-small-evening.svg</file>
-    <file alias="icons/clock-face-small-night.svg">pixmaps/clock-face-small-night.svg</file>
+    <file compressed="true" alias="icons/clock-face-large.svg">pixmaps/clock-face-large.svg</file>
+    <file compressed="true" alias="icons/clock-face-small.svg">pixmaps/clock-face-small.svg</file>
+    <file compressed="true" alias="icons/clock-face-small-morning.svg">pixmaps/clock-face-small-morning.svg</file>
+    <file compressed="true" alias="icons/clock-face-small-day.svg">pixmaps/clock-face-small-day.svg</file>
+    <file compressed="true" alias="icons/clock-face-small-evening.svg">pixmaps/clock-face-small-evening.svg</file>
+    <file compressed="true" alias="icons/clock-face-small-night.svg">pixmaps/clock-face-small-night.svg</file>
     <file alias="icons/clock-map.png">pixmaps/clock-map.png</file>
     <file alias="icons/clock-map-location-marker.png">pixmaps/clock-map-location-marker.png</file>
     <file alias="icons/clock-map-location-current.png">pixmaps/clock-map-location-current.png</file>

--- a/mate-panel/panel.gresource.xml
+++ b/mate-panel/panel.gresource.xml
@@ -5,7 +5,7 @@
     <file compressed="true">panel-run-dialog.ui</file>
   </gresource>
   <gresource prefix="/org/mate/panel/theme">
-    <file alias="mate-panel.css">../data/theme/mate-panel.css</file>
-    <file alias="panel-grid-symbolic.svg">../data/theme/panel-grid-symbolic.svg</file>
+    <file compressed="true" alias="mate-panel.css">../data/theme/mate-panel.css</file>
+    <file compressed="true" alias="panel-grid-symbolic.svg">../data/theme/panel-grid-symbolic.svg</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
shrink the size of binary files:
```shell
$ ./autogen.sh --prefix=/usr && make && LANG=C ls -la applets/clock/.libs/clock-applet
-rwxrwxr-x. 1 robert robert 748592 May  8 11:47 applets/clock/.libs/clock-applet
$ make distclean
$ git checkout dd161527f822ab152ee97c4ff8f4e111da10d27f
$ ./autogen.sh --prefix=/usr && make && LANG=C ls -la applets/clock/.libs/clock-applet
-rwxrwxr-x. 1 robert robert 818232 May  8 12:25 applets/clock/.libs/clock-applet
```