### PR TITLE
Avoid deprecated g_type_class_add_private

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -51,11 +51,8 @@
 #include "mate-panel-applet-marshal.h"
 #include "mate-panel-applet-enums.h"
 
-#define MATE_PANEL_APPLET_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PANEL_TYPE_APPLET, MatePanelAppletPrivate))
-
 struct _MatePanelAppletPrivate {
 	GtkWidget         *plug;
-	GtkWidget         *applet;
 	GDBusConnection   *connection;
 
 	gboolean           out_of_process;
@@ -153,7 +150,7 @@ static const GtkToggleActionEntry menu_toggle_entries[] = {
 	  G_CALLBACK (mate_panel_applet_menu_cmd_lock) }
 };
 
-G_DEFINE_TYPE (MatePanelApplet, mate_panel_applet, GTK_TYPE_EVENT_BOX)
+G_DEFINE_TYPE_WITH_PRIVATE (MatePanelApplet, mate_panel_applet, GTK_TYPE_EVENT_BOX)
 
 #define MATE_PANEL_APPLET_INTERFACE   "org.mate.panel.applet.Applet"
 #define MATE_PANEL_APPLET_OBJECT_PATH "/org/mate/panel/applet/%s/%d"
@@ -1767,7 +1764,7 @@ static void _mate_panel_applet_prepare_css (GtkStyleContext *context)
 static void
 mate_panel_applet_init (MatePanelApplet *applet)
 {
-	applet->priv = MATE_PANEL_APPLET_GET_PRIVATE (applet);
+	applet->priv = mate_panel_applet_get_instance_private (applet);
 
 	applet->priv->flags  = MATE_PANEL_APPLET_FLAGS_NONE;
 	applet->priv->orient = MATE_PANEL_APPLET_ORIENT_UP;
@@ -1879,8 +1876,6 @@ mate_panel_applet_class_init (MatePanelAppletClass *klass)
 
 
 	gobject_class->finalize = mate_panel_applet_finalize;
-
-	g_type_class_add_private (klass, sizeof (MatePanelAppletPrivate));
 
 	g_object_class_install_property (gobject_class,
 	                  PROP_OUT_OF_PROCESS,

--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -18,8 +18,6 @@
 #include "panel-enums.h"
 #include "panel-enums-gsettings.h"
 
-#define BUTTON_WIDGET_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), BUTTON_TYPE_WIDGET, ButtonWidgetPrivate))
-
 struct _ButtonWidgetPrivate {
 	GtkIconTheme     *icon_theme;
 	cairo_surface_t  *surface;
@@ -52,7 +50,7 @@ enum {
 
 #define BUTTON_WIDGET_DISPLACEMENT 2
 
-G_DEFINE_TYPE (ButtonWidget, button_widget, GTK_TYPE_BUTTON)
+G_DEFINE_TYPE_WITH_PRIVATE (ButtonWidget, button_widget, GTK_TYPE_BUTTON)
 
 /* colorshift a surface */
 static void
@@ -602,18 +600,18 @@ button_widget_leave_notify (GtkWidget *widget, GdkEventCrossing *event)
 static void
 button_widget_init (ButtonWidget *button)
 {
-	button->priv = BUTTON_WIDGET_GET_PRIVATE (button);
+	button->priv = button_widget_get_instance_private (button);
 
 	button->priv->icon_theme = NULL;
 	button->priv->surface    = NULL;
 	button->priv->surface_hc = NULL;
 
 	button->priv->filename   = NULL;
-	
+
 	button->priv->orientation = PANEL_ORIENTATION_TOP;
 
 	button->priv->size = 0;
-	
+
 	button->priv->activatable   = FALSE;
 	button->priv->ignore_leave  = FALSE;
 	button->priv->arrow         = FALSE;
@@ -631,8 +629,6 @@ button_widget_class_init (ButtonWidgetClass *klass)
 	gobject_class->get_property = button_widget_get_property;
 	gobject_class->set_property = button_widget_set_property;
 
-	g_type_class_add_private (klass, sizeof (ButtonWidgetPrivate));
-	  
 	widget_class->realize            = button_widget_realize;
 	widget_class->unrealize          = button_widget_unrealize;
 	widget_class->size_allocate      = button_widget_size_allocate;

--- a/mate-panel/libmate-panel-applet-private/panel-applet-container.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-container.c
@@ -69,9 +69,6 @@ static const AppletPropertyInfo applet_properties [] = {
 	{ "locked-down", "LockedDown" }
 };
 
-#define MATE_PANEL_APPLET_CONTAINER_GET_PRIVATE(o) \
-	(G_TYPE_INSTANCE_GET_PRIVATE ((o), PANEL_TYPE_APPLET_CONTAINER, MatePanelAppletContainerPrivate))
-
 #define MATE_PANEL_APPLET_BUS_NAME            "org.mate.panel.applet.%s"
 #define MATE_PANEL_APPLET_FACTORY_INTERFACE   "org.mate.panel.applet.AppletFactory"
 #define MATE_PANEL_APPLET_FACTORY_OBJECT_PATH "/org/mate/panel/applet/%s"
@@ -79,7 +76,7 @@ static const AppletPropertyInfo applet_properties [] = {
 
 static gboolean mate_panel_applet_container_plug_removed (MatePanelAppletContainer *container);
 
-G_DEFINE_TYPE (MatePanelAppletContainer, mate_panel_applet_container, GTK_TYPE_EVENT_BOX);
+G_DEFINE_TYPE_WITH_PRIVATE (MatePanelAppletContainer, mate_panel_applet_container, GTK_TYPE_EVENT_BOX);
 
 GQuark mate_panel_applet_container_error_quark (void)
 {
@@ -88,7 +85,7 @@ GQuark mate_panel_applet_container_error_quark (void)
 
 static void mate_panel_applet_container_init(MatePanelAppletContainer* container)
 {
-	container->priv = MATE_PANEL_APPLET_CONTAINER_GET_PRIVATE (container);
+	container->priv = mate_panel_applet_container_get_instance_private (container);
 
 	container->priv->pending_ops = g_hash_table_new_full (g_direct_hash,
 							      g_direct_equal,
@@ -174,8 +171,6 @@ static void
 mate_panel_applet_container_class_init (MatePanelAppletContainerClass *klass)
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-	g_type_class_add_private (klass, sizeof (MatePanelAppletContainerPrivate));
 
 	gobject_class->dispose = mate_panel_applet_container_dispose;
 

--- a/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
@@ -35,10 +35,6 @@
 #include "panel-applet-container.h"
 #include "panel-applet-frame-dbus.h"
 
-G_DEFINE_TYPE (MatePanelAppletFrameDBus,
-	       mate_panel_applet_frame_dbus,
-	       PANEL_TYPE_APPLET_FRAME)
-
 struct _MatePanelAppletFrameDBusPrivate
 {
 	MatePanelAppletContainer *container;
@@ -53,6 +49,9 @@ typedef enum {
 	APPLET_HAS_HANDLE   = 1 << 2
 } MatePanelAppletFlags;
 
+G_DEFINE_TYPE_WITH_PRIVATE (MatePanelAppletFrameDBus,
+                            mate_panel_applet_frame_dbus,
+                            PANEL_TYPE_APPLET_FRAME)
 
 static guint
 get_mate_panel_applet_orient (PanelOrientation orientation)
@@ -336,9 +335,7 @@ mate_panel_applet_frame_dbus_init (MatePanelAppletFrameDBus *frame)
 {
 	GtkWidget *container;
 
-	frame->priv = G_TYPE_INSTANCE_GET_PRIVATE (frame,
-						   PANEL_TYPE_APPLET_FRAME_DBUS,
-						   MatePanelAppletFrameDBusPrivate);
+	frame->priv = mate_panel_applet_frame_dbus_get_instance_private (frame);
 
 	container = mate_panel_applet_container_new ();
 	gtk_widget_show (container);
@@ -383,8 +380,6 @@ mate_panel_applet_frame_dbus_class_init (MatePanelAppletFrameDBusClass *class)
 
 	GtkWidgetClass *widget_class  = GTK_WIDGET_CLASS (class);
 	gtk_widget_class_set_css_name (widget_class, "MatePanelAppletFrameDBus");
-
-	g_type_class_add_private (class, sizeof (MatePanelAppletFrameDBusPrivate));
 }
 
 static void

--- a/mate-panel/libmate-panel-applet-private/panel-applets-manager-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applets-manager-dbus.c
@@ -31,19 +31,20 @@
 #include "panel-applet-frame-dbus.h"
 #include "panel-applets-manager-dbus.h"
 
-G_DEFINE_TYPE_WITH_CODE (MatePanelAppletsManagerDBus,
-			 mate_panel_applets_manager_dbus,
-			 PANEL_TYPE_APPLETS_MANAGER,
-			 g_io_extension_point_implement (MATE_PANEL_APPLETS_MANAGER_EXTENSION_POINT_NAME,
-							 g_define_type_id,
-							 "dbus",
-							 10))
-
 struct _MatePanelAppletsManagerDBusPrivate
 {
 	GHashTable *applet_factories;
 	GList      *monitors;
 };
+
+G_DEFINE_TYPE_WITH_CODE (MatePanelAppletsManagerDBus,
+			 mate_panel_applets_manager_dbus,
+			 PANEL_TYPE_APPLETS_MANAGER,
+			 G_ADD_PRIVATE(MatePanelAppletsManagerDBus)
+			 g_io_extension_point_implement (MATE_PANEL_APPLETS_MANAGER_EXTENSION_POINT_NAME,
+							 g_define_type_id,
+							 "dbus",
+							 10))
 
 typedef gint (* ActivateAppletFunc) (void);
 typedef GtkWidget * (* GetAppletWidgetFunc) (const gchar *factory_id,
@@ -600,9 +601,7 @@ mate_panel_applets_manager_dbus_finalize (GObject *object)
 static void
 mate_panel_applets_manager_dbus_init (MatePanelAppletsManagerDBus *manager)
 {
-	manager->priv = G_TYPE_INSTANCE_GET_PRIVATE (manager,
-						     PANEL_TYPE_APPLETS_MANAGER_DBUS,
-						     MatePanelAppletsManagerDBusPrivate);
+	manager->priv = mate_panel_applets_manager_dbus_get_instance_private (manager);
 
 	manager->priv->applet_factories = g_hash_table_new_full (g_str_hash,
 								 g_str_equal,
@@ -627,6 +626,4 @@ mate_panel_applets_manager_dbus_class_init (MatePanelAppletsManagerDBusClass *cl
 	manager_class->get_applet_info_from_old_id = mate_panel_applets_manager_dbus_get_applet_info_from_old_id;
 	manager_class->load_applet = mate_panel_applets_manager_dbus_load_applet;
 	manager_class->get_applet_widget = mate_panel_applets_manager_dbus_get_applet_widget;
-
-	g_type_class_add_private (class, sizeof (MatePanelAppletsManagerDBusPrivate));
 }

--- a/mate-panel/libpanel-util/panel-icon-chooser.c
+++ b/mate-panel/libpanel-util/panel-icon-chooser.c
@@ -57,9 +57,7 @@ enum {
 
 static guint panel_icon_chooser_signals[LAST_SIGNAL] = { 0 };
 
-#define PANEL_ICON_CHOOSER_GET_PRIVATE(o)  (PANEL_ICON_CHOOSER (o)->priv)
-
-G_DEFINE_TYPE (PanelIconChooser, panel_icon_chooser, GTK_TYPE_BUTTON)
+G_DEFINE_TYPE_WITH_PRIVATE (PanelIconChooser, panel_icon_chooser, GTK_TYPE_BUTTON)
 
 static void _panel_icon_chooser_clicked (GtkButton *button);
 static void _panel_icon_chooser_style_set (GtkWidget *widget,
@@ -187,9 +185,6 @@ panel_icon_chooser_class_init (PanelIconChooserClass *class)
 
 	gtkbutton_class->clicked = _panel_icon_chooser_clicked;
 
-	g_type_class_add_private (class,
-				  sizeof (PanelIconChooserPrivate));
-
 	panel_icon_chooser_signals[CHANGED] =
 		g_signal_new ("changed",
 			      G_TYPE_FROM_CLASS (gobject_class),
@@ -226,9 +221,7 @@ panel_icon_chooser_init (PanelIconChooser *chooser)
 {
 	PanelIconChooserPrivate *priv;
 
-	priv = G_TYPE_INSTANCE_GET_PRIVATE (chooser,
-					    PANEL_TYPE_ICON_CHOOSER,
-					    PanelIconChooserPrivate);
+	priv = panel_icon_chooser_get_instance_private (chooser);
 
 	chooser->priv = priv;
 

--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -60,10 +60,6 @@
 #include "panel-force-quit.h"
 #endif
 
-G_DEFINE_TYPE (PanelActionButton, panel_action_button, BUTTON_TYPE_WIDGET)
-
-#define PANEL_ACTION_BUTTON_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PANEL_TYPE_ACTION_BUTTON, PanelActionButtonPrivate))
-
 enum {
 	PROP_0,
 	PROP_ACTION_TYPE,
@@ -77,6 +73,8 @@ struct _PanelActionButtonPrivate {
 
 	guint                  dnd_enabled : 1;
 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (PanelActionButton, panel_action_button, BUTTON_TYPE_WIDGET)
 
 static void
 panel_action_button_type_changed (GSettings       *settings,
@@ -630,8 +628,6 @@ panel_action_button_class_init (PanelActionButtonClass *klass)
 
 	button_class->clicked       = panel_action_button_clicked;
 
-	g_type_class_add_private (klass, sizeof (PanelActionButtonPrivate));
-
 	g_object_class_install_property (
 			gobject_class,
 			PROP_ACTION_TYPE,
@@ -655,7 +651,7 @@ panel_action_button_class_init (PanelActionButtonClass *klass)
 static void
 panel_action_button_init (PanelActionButton *button)
 {
-	button->priv = PANEL_ACTION_BUTTON_GET_PRIVATE (button);
+	button->priv = panel_action_button_get_instance_private (button);
 
 	button->priv->type = PANEL_ACTION_NONE;
 	button->priv->info = NULL;

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -76,10 +76,6 @@ struct _MatePanelAppletFrameActivating {
 
 /* MatePanelAppletFrame implementation */
 
-G_DEFINE_TYPE (MatePanelAppletFrame, mate_panel_applet_frame, GTK_TYPE_EVENT_BOX)
-
-#define MATE_PANEL_APPLET_FRAME_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PANEL_TYPE_APPLET_FRAME, MatePanelAppletFramePrivate))
-
 #define HANDLE_SIZE 10
 #define MATE_PANEL_APPLET_PREFS_PATH "/org/mate/panel/objects/%s/prefs/"
 
@@ -96,6 +92,8 @@ struct _MatePanelAppletFramePrivate {
 
 	guint            has_handle : 1;
 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (MatePanelAppletFrame, mate_panel_applet_frame, GTK_TYPE_EVENT_BOX)
 
 static gboolean
 mate_panel_applet_frame_draw (GtkWidget *widget,
@@ -459,14 +457,12 @@ mate_panel_applet_frame_class_init (MatePanelAppletFrameClass *klass)
 	widget_class->size_allocate        = mate_panel_applet_frame_size_allocate;
 	widget_class->button_press_event   = mate_panel_applet_frame_button_changed;
 	widget_class->button_release_event = mate_panel_applet_frame_button_changed;
-
-	g_type_class_add_private (klass, sizeof (MatePanelAppletFramePrivate));
 }
 
 static void
 mate_panel_applet_frame_init (MatePanelAppletFrame *frame)
 {
-	frame->priv = MATE_PANEL_APPLET_FRAME_GET_PRIVATE (frame);
+	frame->priv = mate_panel_applet_frame_get_instance_private (frame);
 
 	frame->priv->panel       = NULL;
 	frame->priv->orientation = PANEL_ORIENTATION_TOP;

--- a/mate-panel/panel-ditem-editor.c
+++ b/mate-panel/panel-ditem-editor.c
@@ -168,9 +168,7 @@ enum {
 
 static guint ditem_edit_signals[LAST_SIGNAL] = { 0 };
 
-#define PANEL_DITEM_EDITOR_GET_PRIVATE(o)  (PANEL_DITEM_EDITOR (o)->priv)
-
-G_DEFINE_TYPE (PanelDItemEditor, panel_ditem_editor, GTK_TYPE_DIALOG)
+G_DEFINE_TYPE_WITH_PRIVATE (PanelDItemEditor, panel_ditem_editor, GTK_TYPE_DIALOG)
 
 static void panel_ditem_editor_setup_ui (PanelDItemEditor *dialog);
 
@@ -380,9 +378,6 @@ panel_ditem_editor_class_init (PanelDItemEditorClass *class)
         gobject_class->set_property = panel_ditem_editor_set_property;
 
 	gobject_class->dispose = panel_ditem_editor_dispose;
-
-	g_type_class_add_private (class,
-				  sizeof (PanelDItemEditorPrivate));
 
 	ditem_edit_signals[SAVED] =
 		g_signal_new ("saved",
@@ -1118,9 +1113,7 @@ panel_ditem_editor_init (PanelDItemEditor *dialog)
 {
 	PanelDItemEditorPrivate *priv;
 
-	priv = G_TYPE_INSTANCE_GET_PRIVATE (dialog,
-					    PANEL_TYPE_DITEM_EDITOR,
-					    PanelDItemEditorPrivate);
+	priv = panel_ditem_editor_get_instance_private (dialog);
 
 	dialog->priv = priv;
 

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -54,10 +54,6 @@
 #include "panel-icon-names.h"
 #include "panel-schemas.h"
 
-G_DEFINE_TYPE (PanelMenuBar, panel_menu_bar, GTK_TYPE_MENU_BAR)
-
-#define PANEL_MENU_BAR_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PANEL_TYPE_MENU_BAR, PanelMenuBarPrivate))
-
 struct _PanelMenuBarPrivate {
 	AppletInfo* info;
 	PanelWidget* panel;
@@ -80,6 +76,8 @@ enum {
 	PROP_0,
 	PROP_ORIENTATION,
 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (PanelMenuBar, panel_menu_bar, GTK_TYPE_MENU_BAR)
 
 static void panel_menu_bar_update_text_gravity(PanelMenuBar* menubar);
 
@@ -170,7 +168,7 @@ static void panel_menu_bar_init(PanelMenuBar* menubar)
 {
 	GtkCssProvider *provider;
 
-	menubar->priv = PANEL_MENU_BAR_GET_PRIVATE(menubar);
+	menubar->priv = panel_menu_bar_get_instance_private(menubar);
 
 	provider = gtk_css_provider_new ();
 	gtk_css_provider_load_from_data (provider,
@@ -328,8 +326,6 @@ static void panel_menu_bar_class_init(PanelMenuBarClass* klass)
 
 	widget_class->parent_set = panel_menu_bar_parent_set;
 	widget_class->size_allocate = panel_menu_bar_size_allocate;
-
-	g_type_class_add_private(klass, sizeof(PanelMenuBarPrivate));
 
 	g_object_class_install_property(gobject_class, PROP_ORIENTATION, g_param_spec_enum("orientation", "Orientation", "The PanelMenuBar orientation", PANEL_TYPE_ORIENTATION, PANEL_ORIENTATION_TOP, G_PARAM_READWRITE));
 }

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -50,10 +50,6 @@
 #include "panel-icon-names.h"
 #include "panel-schemas.h"
 
-G_DEFINE_TYPE (PanelMenuButton, panel_menu_button, BUTTON_TYPE_WIDGET)
-
-#define PANEL_MENU_BUTTON_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PANEL_TYPE_MENU_BUTTON, PanelMenuButtonPrivate))
-
 enum {
 	PROP_0,
 	PROP_MENU_PATH,
@@ -105,6 +101,8 @@ struct _PanelMenuButtonPrivate {
 	guint                  has_arrow : 1;
 	guint                  dnd_enabled : 1;
 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (PanelMenuButton, panel_menu_button, BUTTON_TYPE_WIDGET)
 
 static void panel_menu_button_disconnect_from_gsettings (PanelMenuButton *button);
 static void panel_menu_button_recreate_menu         (PanelMenuButton *button);
@@ -192,7 +190,7 @@ panel_menu_scheme_to_path_root (const char *scheme)
 static void
 panel_menu_button_init (PanelMenuButton *button)
 {
-	button->priv = PANEL_MENU_BUTTON_GET_PRIVATE (button);
+	button->priv = panel_menu_button_get_instance_private (button);
 
 	button->priv->applet_id    = NULL;
 	button->priv->toplevel     = NULL;
@@ -558,8 +556,6 @@ panel_menu_button_class_init (PanelMenuButtonClass *klass)
 
 	button_class->clicked = panel_menu_button_clicked;
 	button_class->pressed = panel_menu_button_pressed;
-
-	g_type_class_add_private (klass, sizeof (PanelMenuButtonPrivate));
 
 	g_object_class_install_property (
 			gobject_class,

--- a/mate-panel/panel-menu-items.c
+++ b/mate-panel/panel-menu-items.c
@@ -59,14 +59,6 @@
 
 #define MAX_BOOKMARK_ITEMS      100
 
-G_DEFINE_TYPE(PanelPlaceMenuItem, panel_place_menu_item, GTK_TYPE_IMAGE_MENU_ITEM)
-G_DEFINE_TYPE(PanelDesktopMenuItem, panel_desktop_menu_item, GTK_TYPE_IMAGE_MENU_ITEM)
-
-#define PANEL_PLACE_MENU_ITEM_GET_PRIVATE(o) \
-	(G_TYPE_INSTANCE_GET_PRIVATE((o), PANEL_TYPE_PLACE_MENU_ITEM, PanelPlaceMenuItemPrivate))
-#define PANEL_DESKTOP_MENU_ITEM_GET_PRIVATE(o) \
-	(G_TYPE_INSTANCE_GET_PRIVATE((o), PANEL_TYPE_DESKTOP_MENU_ITEM, PanelDesktopMenuItemPrivate))
-
 struct _PanelPlaceMenuItemPrivate {
 	GtkWidget   *menu;
 	PanelWidget *panel;
@@ -100,6 +92,9 @@ struct _PanelDesktopMenuItemPrivate {
 	guint        use_image : 1;
 	guint        append_lock_logout : 1;
 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (PanelPlaceMenuItem, panel_place_menu_item, GTK_TYPE_IMAGE_MENU_ITEM)
+G_DEFINE_TYPE_WITH_PRIVATE (PanelDesktopMenuItem, panel_desktop_menu_item, GTK_TYPE_IMAGE_MENU_ITEM)
 
 static void activate_uri_on_screen(const char* uri, GdkScreen* screen)
 {
@@ -1352,7 +1347,7 @@ panel_place_menu_item_init (PanelPlaceMenuItem *menuitem)
 	char  *bookmarks_filename;
 	GError *error;
 
-	menuitem->priv = PANEL_PLACE_MENU_ITEM_GET_PRIVATE (menuitem);
+	menuitem->priv = panel_place_menu_item_get_instance_private (menuitem);
 
 	if (mate_gsettings_schema_exists (CAJA_DESKTOP_SCHEMA)) {
 		menuitem->priv->caja_desktop_settings = g_settings_new (CAJA_DESKTOP_SCHEMA);
@@ -1454,7 +1449,7 @@ panel_place_menu_item_init (PanelPlaceMenuItem *menuitem)
 static void
 panel_desktop_menu_item_init (PanelDesktopMenuItem *menuitem)
 {
-	menuitem->priv = PANEL_DESKTOP_MENU_ITEM_GET_PRIVATE (menuitem);
+	menuitem->priv = panel_desktop_menu_item_get_instance_private (menuitem);
 }
 
 static void
@@ -1463,8 +1458,6 @@ panel_place_menu_item_class_init (PanelPlaceMenuItemClass *klass)
 	GObjectClass *gobject_class = (GObjectClass   *) klass;
 
 	gobject_class->finalize  = panel_place_menu_item_finalize;
-
-	g_type_class_add_private (klass, sizeof (PanelPlaceMenuItemPrivate));
 }
 
 static void
@@ -1473,8 +1466,6 @@ panel_desktop_menu_item_class_init (PanelDesktopMenuItemClass *klass)
 	GObjectClass *gobject_class = (GObjectClass   *) klass;
 
 	gobject_class->finalize  = panel_desktop_menu_item_finalize;
-
-	g_type_class_add_private (klass, sizeof (PanelDesktopMenuItemPrivate));
 }
 
 GtkWidget* panel_place_menu_item_new(gboolean use_image)

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -30,8 +30,6 @@
 
 #define SEPARATOR_SIZE 10
 
-#define PANEL_SEPARATOR_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PANEL_TYPE_SEPARATOR, PanelSeparatorPrivate))
-
 struct _PanelSeparatorPrivate {
 	AppletInfo     *info;
 	PanelWidget    *panel;
@@ -39,7 +37,7 @@ struct _PanelSeparatorPrivate {
 	GtkOrientation  orientation;
 };
 
-G_DEFINE_TYPE (PanelSeparator, panel_separator, GTK_TYPE_EVENT_BOX)
+G_DEFINE_TYPE_WITH_PRIVATE (PanelSeparator, panel_separator, GTK_TYPE_EVENT_BOX)
 
 static gboolean
 panel_separator_draw (GtkWidget *widget, cairo_t *cr)
@@ -190,14 +188,12 @@ panel_separator_class_init (PanelSeparatorClass *klass)
 	widget_class->parent_set    = panel_separator_parent_set;
 
 	gtk_widget_class_set_css_name (widget_class, "PanelSeparator");
-
-	g_type_class_add_private (klass, sizeof (PanelSeparator));
 }
 
 static void
 panel_separator_init (PanelSeparator *separator)
 {
-	separator->priv = PANEL_SEPARATOR_GET_PRIVATE (separator);
+	separator->priv = panel_separator_get_instance_private (separator);
 
 	separator->priv->info  = NULL;
 	separator->priv->panel = NULL;

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -50,10 +50,6 @@
 #include "panel-lockdown.h"
 #include "panel-schemas.h"
 
-G_DEFINE_TYPE (PanelToplevel, panel_toplevel, GTK_TYPE_WINDOW)
-
-#define PANEL_TOPLEVEL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), PANEL_TYPE_TOPLEVEL, PanelToplevelPrivate))
-
 #define DEFAULT_SIZE              48
 #define DEFAULT_AUTO_HIDE_SIZE    1
 #define DEFAULT_HIDE_DELAY        300
@@ -237,6 +233,8 @@ enum {
 	PROP_BUTTONS_ENABLED,
 	PROP_ARROWS_ENABLED
 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (PanelToplevel, panel_toplevel, GTK_TYPE_WINDOW)
 
 static guint toplevel_signals[LAST_SIGNAL] = {0};
 static GSList* toplevel_list = NULL;
@@ -4312,8 +4310,6 @@ panel_toplevel_class_init (PanelToplevelClass *klass)
 	klass->begin_move       = panel_toplevel_begin_move;
 	klass->begin_resize     = panel_toplevel_begin_resize;
 
-	g_type_class_add_private (klass, sizeof (PanelToplevelPrivate));
-
 	g_object_class_install_property (
 		gobject_class,
 		PROP_NAME,
@@ -4712,7 +4708,7 @@ panel_toplevel_init (PanelToplevel *toplevel)
 	GtkWidget *widget;
 	int i;
 
-	toplevel->priv = PANEL_TOPLEVEL_GET_PRIVATE (toplevel);
+	toplevel->priv = panel_toplevel_get_instance_private (toplevel);
 
 	toplevel->priv->expand          = TRUE;
 	toplevel->priv->orientation     = PANEL_ORIENTATION_BOTTOM;


### PR DESCRIPTION
Avoid deprecated g_type_class_add_private under `libmate-panel-applet` and `mate-panel` directories.
