### PR TITLE
Clarify calculation precedence for '&' and '?'

### DIFF
--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -177,8 +177,8 @@ button_widget_reload_surface (ButtonWidget *button)
 			panel_load_icon (button->priv->icon_theme,
 					 button->priv->filename,
 					 button->priv->size * scale,
-					 button->priv->orientation & PANEL_VERTICAL_MASK   ? button->priv->size * scale : -1,
-					 button->priv->orientation & PANEL_HORIZONTAL_MASK ? button->priv->size * scale: -1,
+					 (button->priv->orientation & PANEL_VERTICAL_MASK)   ? button->priv->size * scale : -1,
+					 (button->priv->orientation & PANEL_HORIZONTAL_MASK) ? button->priv->size * scale: -1,
 					 &error);
 		if (error) {
 			//FIXME: this is not rendered at button->priv->size
@@ -312,7 +312,7 @@ calc_arrow (PanelOrientation  orientation,
 			button_height = 50;
 	}
 	
-	*size = (orientation & PANEL_HORIZONTAL_MASK ? button_width : button_height) / 2;
+	*size = ((orientation & PANEL_HORIZONTAL_MASK) ? button_width : button_height) / 2;
 	*angle = 0;
 
 	switch (orientation) {

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -2312,7 +2312,7 @@ calculate_minimum_height (GtkWidget        *widget,
 	pango_font_description_free (font_desc);
 	pango_font_metrics_unref (metrics);
 
-	thickness = orientation & PANEL_HORIZONTAL_MASK ?
+	thickness = (orientation & PANEL_HORIZONTAL_MASK) ?
 		padding.top + padding.bottom :
 		padding.left + padding.right;
 
@@ -4684,7 +4684,7 @@ panel_toplevel_setup_widgets (PanelToplevel *toplevel)
 
 	container = panel_widget_new (toplevel,
 				      !toplevel->priv->expand,
-				      toplevel->priv->orientation & PANEL_HORIZONTAL_MASK ?
+				      (toplevel->priv->orientation & PANEL_HORIZONTAL_MASK) ?
 						GTK_ORIENTATION_HORIZONTAL :
 						GTK_ORIENTATION_VERTICAL,
 				      toplevel->priv->size);
@@ -5033,7 +5033,7 @@ panel_toplevel_set_orientation (PanelToplevel    *toplevel,
 
 	panel_widget_set_orientation (
 		toplevel->priv->panel_widget,
-		toplevel->priv->orientation & PANEL_HORIZONTAL_MASK ?
+		(toplevel->priv->orientation & PANEL_HORIZONTAL_MASK) ?
 					GTK_ORIENTATION_HORIZONTAL :
 					GTK_ORIENTATION_VERTICAL);
 


### PR DESCRIPTION
Fixes `cppcheck` warnings:

```
[mate-panel/button-widget.c:180]: (style) Clarify calculation precedence for '&' and '?'.
[mate-panel/button-widget.c:181]: (style) Clarify calculation precedence for '&' and '?'.
[mate-panel/button-widget.c:315]: (style) Clarify calculation precedence for '&' and '?'.

[mate-panel/panel-toplevel.c:2315]: (style) Clarify calculation precedence for '&' and '?'.
[mate-panel/panel-toplevel.c:4687]: (style) Clarify calculation precedence for '&' and '?'.
[mate-panel/panel-toplevel.c:5036]: (style) Clarify calculation precedence for '&' and '?'.
```

https://en.cppreference.com/w/c/language/operator_precedence