### PR TITLE
fix panel reset problems

### DIFF
--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -1435,6 +1435,18 @@ panel_profile_delete_removed_ids (PanelGSettingsKeyType    type,
 	g_slist_free (removed_ids);
 }
 
+static gboolean
+load_default_layout_idle (gpointer unused) {
+	if (g_slist_length (panel_toplevel_list_toplevels ()) != 0) {
+		/* some toplevels are not destroyed yet, waiting */
+		return TRUE;
+	}
+
+	/* load the default layout and stop this handler */
+	panel_profile_ensure_toplevel_per_screen ();
+	return FALSE;
+}
+
 static void
 panel_profile_toplevel_id_list_notify (GSettings *settings,
 									   gchar *key,
@@ -1477,7 +1489,7 @@ panel_profile_toplevel_id_list_notify (GSettings *settings,
 
 	/* if there are no panels, reset layout to default */
 	if (g_slist_length (toplevel_ids) == 0)
-		panel_profile_ensure_toplevel_per_screen ();
+		g_idle_add (load_default_layout_idle, NULL);
 
 	g_slist_free (existing_toplevels);
 	g_slist_free (toplevel_ids);

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -1029,16 +1029,6 @@ panel_profile_delete_toplevel (PanelToplevel *toplevel)
 
 	toplevel_id = panel_profile_get_toplevel_id (toplevel);
 
-	/* disable GSettings signals */
-	if (toplevel->settings) {
-		g_object_unref (toplevel->settings);
-		toplevel->settings = NULL;
-	}
-	if (toplevel->background_settings) {
-		g_object_unref (toplevel->background_settings);
-		toplevel->background_settings = NULL;
-	}
-
 	panel_profile_delete_toplevel_objects (toplevel_id);
 
 	panel_profile_remove_from_list (PANEL_GSETTINGS_TOPLEVELS, toplevel_id);


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/mate-panel/issues/436

How to test:

1. Resetting the panel layout

- use `mate-panel --reset` to reset the panel(s) to the current default layout
- use `mate-panel --reset --layout=<layout_name>` to set the new default layout and reset the panel(s) to it
- the panel should not crash
- the panel should reappear with the default layout

2. Deleting one panel in a multi-panel layout

- use "Delete this panel" menu item from the right-click menu to delete that panel
- the panel should not crash (https://github.com/mate-desktop/mate-panel/issues/65 should not happen again)

Both problems I've described in https://github.com/mate-desktop/mate-panel/issues/436#issuecomment-491845638 can be more often reproduced in Ubuntu than in Debian Testing, for example. That's the problem of race condition issues...