### PR TITLE
Fix Makefile.am to install in a given prefix path

### DIFF
--- a/libmate-panel-applet/Makefile.am
+++ b/libmate-panel-applet/Makefile.am
@@ -133,10 +133,10 @@ MatePanelApplet_4_0_gir_FILES = $(addprefix $(srcdir)/,$(introspection_sources))
 MatePanelApplet_4_0_gir_SCANNERFLAGS = --strip-prefix=MatePanel --pkg-export=libmatepanelapplet-4.0
 INTROSPECTION_GIRS += MatePanelApplet-4.0.gir
 
-girdir = $(INTROSPECTION_GIRDIR)
+girdir = $(datadir)/gir-1.0
 gir_DATA = $(INTROSPECTION_GIRS)
 
-typelibdir = $(INTROSPECTION_TYPELIBDIR)
+typelibdir = $(libdir)/girepository-1.0
 typelib_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
 
 CLEANFILES += $(gir_DATA) $(typelib_DATA)


### PR DESCRIPTION
Currently installing mate-panel fails with the error

     /bin/mkdir -p '/usr/share/gir-1.0'
     /usr/bin/install -c -m 644 MatePanelApplet-4.0.gir '/usr/share/gir-1.0'
    /usr/bin/install: cannot create regular file '/usr/share/gir-1.0/MatePanelApplet-4.0.gir': Permission denied

when configure is called with the --prefix option.

This fix is the same used in:

* caja (libcaja-extension/Makefile.am)
* eom (src/Makefile.am)
* libmatekbd (libmatekbd/Makefile.am)
* mate-desktop (libmate-desktop/Makefile.am)
* pluma (pluma/Makefile.am)