### PR TITLE
Get panel background ready for Wayland

### DIFF
--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -43,7 +43,6 @@ panel_sources = \
 	panel-applets-manager.c \
 	panel-shell.c \
 	panel-background.c \
-	panel-background-monitor.c \
 	panel-stock-icons.c \
 	panel-action-button.c \
 	panel-menu-bar.c \
@@ -77,7 +76,8 @@ panel_sources += \
 	xstuff.c \
 	panel-xutils.c \
 	panel-force-quit.c \
-	panel-action-protocol.c
+	panel-action-protocol.c \
+	panel-background-monitor.c
 endif
 
 panel_headers = \
@@ -101,7 +101,6 @@ panel_headers = \
 	panel-applets-manager.h \
 	panel-shell.h \
 	panel-background.h \
-	panel-background-monitor.h \
 	panel-stock-icons.h \
 	panel-action-button.h \
 	panel-menu-bar.h \
@@ -139,7 +138,8 @@ panel_sources += \
 	xstuff.h \
 	panel-xutils.h \
 	panel-force-quit.h \
-	panel-action-protocol.h
+	panel-action-protocol.h \
+	panel-background-monitor.h
 endif
 
 mate_panel_SOURCES = \

--- a/mate-panel/panel-background-monitor.c
+++ b/mate-panel/panel-background-monitor.c
@@ -24,6 +24,12 @@
  *      Mark McLoughlin <mark@skynet.ie>
  */
 
+#include <config.h>
+
+#ifndef HAVE_X11
+#error file should only be compiled when HAVE_X11 is enabled
+#endif
+
 #include <glib.h>
 #include <glib-object.h>
 #include <gdk/gdk.h>
@@ -82,6 +88,7 @@ static guint signals [LAST_SIGNAL] = { 0 };
 
 gboolean gdk_window_check_composited_wm(GdkWindow* window)
 {
+	g_return_val_if_fail (GDK_IS_X11_WINDOW (window), TRUE);
 	return gdk_screen_is_composited(gdk_window_get_screen(window));
 }
 
@@ -182,6 +189,8 @@ panel_background_monitor_new (GdkScreen *screen)
 PanelBackgroundMonitor *
 panel_background_monitor_get_for_screen (GdkScreen *screen)
 {
+	g_return_val_if_fail (GDK_IS_X11_SCREEN (screen), NULL);
+
 	if (!global_background_monitor) {
 		global_background_monitor = panel_background_monitor_new (screen);
 
@@ -360,6 +369,9 @@ panel_background_monitor_get_region (PanelBackgroundMonitor *monitor,
 	GdkPixbuf *pixbuf, *tmpbuf;
 	int        subwidth, subheight;
 	int        subx, suby;
+
+	g_return_val_if_fail (monitor, NULL);
+	g_return_val_if_fail (GDK_IS_X11_WINDOW (monitor->gdkwindow), NULL);
 
 	if (!monitor->gdkpixbuf)
 		panel_background_monitor_setup_pixbuf (monitor);

--- a/mate-panel/panel-background-monitor.h
+++ b/mate-panel/panel-background-monitor.h
@@ -27,6 +27,12 @@
 #ifndef __PANEL_BACKGROUND_MONITOR_H__
 #define __PANEL_BACKGROUND_MONITOR_H__
 
+#ifdef PACKAGE_NAME // only check HAVE_X11 if config.h has been included
+#ifndef HAVE_X11
+#error file should only be included when HAVE_X11 is enabled
+#endif
+#endif
+
 #include <glib.h>
 #include <glib-object.h>
 #include <gdk/gdk.h>

--- a/mate-panel/panel-background.h
+++ b/mate-panel/panel-background.h
@@ -25,12 +25,17 @@
 #ifndef __PANEL_BACKGROUND_H__
 #define __PANEL_BACKGROUND_H__
 
+#include <config.h>
+
 #include <glib.h>
 #include <gtk/gtk.h>
 
 #include "panel-enums.h"
 #include "panel-types.h"
+
+#ifdef HAVE_X11
 #include "panel-background-monitor.h"
+#endif
 
 typedef struct _PanelBackground PanelBackground;
 
@@ -54,9 +59,11 @@ struct _PanelBackground {
 	GdkPixbuf              *transformed_image;
 	cairo_pattern_t        *composited_pattern;
 
+#ifdef HAVE_X11
 	PanelBackgroundMonitor *monitor;
 	GdkPixbuf              *desktop;
 	gulong                  monitor_signal;
+#endif // HAVE_X11
 
 	GdkWindow              *window;
 	cairo_pattern_t        *default_pattern;


### PR DESCRIPTION
`PanelBackgroundMonitor` pulls the desktop background out of the root window for in-process compositing. This is both impossible and unneeded on Wayland, so I made the files X11-only. Unfortunately the desktop pixmap (`PanelBackground->desktop`) was previously retrieved even when it was not needed, so I had to shuffle some logic around a bit to make that happen only on X11.