### PR TITLE
Panel multiscreen -> panel multimonitor

### DIFF
--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -50,7 +50,7 @@ panel_sources = \
 	panel-toplevel.c \
 	panel-struts.c \
 	panel-frame.c \
-	panel-multiscreen.c \
+	panel-multimonitor.c \
 	panel-a11y.c \
 	panel-bindings.c \
 	panel-layout.c \
@@ -105,7 +105,7 @@ panel_headers = \
 	panel-toplevel.h \
 	panel-struts.h \
 	panel-frame.h \
-	panel-multiscreen.h \
+	panel-multimonitor.h \
 	panel-a11y.h \
 	panel-bindings.h \
 	panel-layout.h \

--- a/mate-panel/launcher.c
+++ b/mate-panel/launcher.c
@@ -39,7 +39,6 @@
 #include "panel-toplevel.h"
 #include "panel-a11y.h"
 #include "panel-globals.h"
-#include "panel-multiscreen.h"
 #include "panel-lockdown.h"
 #include "panel-ditem-editor.h"
 #include "panel-icon-names.h"

--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -23,7 +23,7 @@
 #include "panel-profile.h"
 #include "panel-config-global.h"
 #include "panel-shell.h"
-#include "panel-multiscreen.h"
+#include "panel-multimonitor.h"
 #include "panel-session.h"
 #include "panel-schemas.h"
 #include "panel-stock-icons.h"

--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -134,7 +134,7 @@ main (int argc, char **argv)
 	if (run_dialog == TRUE)
 	{
 		panel_init_stock_icons_and_items ();
-		panel_multiscreen_init ();
+		panel_multimonitor_init ();
 		panel_global_config_load ();
 		panel_lockdown_init ();
 		panel_profile_settings_load ();
@@ -158,7 +158,7 @@ main (int argc, char **argv)
 	}
 
 	panel_action_protocol_init ();
-	panel_multiscreen_init ();
+	panel_multimonitor_init ();
 	panel_init_stock_icons_and_items ();
 
 	panel_global_config_load ();

--- a/mate-panel/panel-multimonitor.c
+++ b/mate-panel/panel-multimonitor.c
@@ -1,5 +1,5 @@
 /*
- * panel-multiscreen.c: Multi-screen and Xinerama support for the panel.
+ * panel-multimonitor.c: Multi-monitor and Xinerama support for the panel.
  *
  * Copyright (C) 2001 George Lebl <jirka@5z.com>
  *               2002 Sun Microsystems Inc.

--- a/mate-panel/panel-multimonitor.h
+++ b/mate-panel/panel-multimonitor.h
@@ -1,5 +1,5 @@
 /*
- * panel-multiscreen.h: Multi-screen and Xinerama support for the panel.
+ * panel-multimonitor.h: Multi-monitor and Xinerama support for the panel.
  *
  * Copyright (C) 2001 George Lebl <jirka@5z.com>
  *               2002 Sun Microsystems Inc.
@@ -23,8 +23,8 @@
  *          Mark McLoughlin <mark@skynet.ie>
  */
 
-#ifndef __PANEL_MULTISCREEN_H__
-#define __PANEL_MULTISCREEN_H__
+#ifndef __PANEL_MULTIMONITOR_H__
+#define __PANEL_MULTIMONITOR_H__
 
 #include <gtk/gtk.h>
 
@@ -53,4 +53,4 @@ void    panel_multiscreen_is_at_visible_extreme (GdkScreen *screen,
 						 gboolean  *topmost,
 						 gboolean  *bottommost);
 
-#endif /* __PANEL_MULTISCREEN_H__ */
+#endif /* __PANEL_MULTIMONITOR_H__ */

--- a/mate-panel/panel-multimonitor.h
+++ b/mate-panel/panel-multimonitor.h
@@ -28,29 +28,22 @@
 
 #include <gtk/gtk.h>
 
-void	panel_multiscreen_init                  (void);
-void	panel_multiscreen_reinit                (void);
+void	panel_multimonitor_init                  (void);
+void	panel_multimonitor_reinit                (void);
 
-int	panel_multiscreen_screens               (void);
-int	panel_multiscreen_monitors              (GdkScreen *screen);
+int	panel_multimonitor_monitors              (void);
 
-int	panel_multiscreen_x                     (GdkScreen *screen,
-						 int        monitor);
-int	panel_multiscreen_y                     (GdkScreen *screen,
-						 int        monitor);
-int	panel_multiscreen_width                 (GdkScreen *screen,
-						 int        monitor);
-int	panel_multiscreen_height                (GdkScreen *screen,
-						 int        monitor);
-int	panel_multiscreen_locate_widget_monitor (GtkWidget *widget);
-int     panel_multiscreen_get_monitor_at_point  (GdkScreen *screen,
-						 int        x,
-						 int        y);
-void    panel_multiscreen_is_at_visible_extreme (GdkScreen *screen,
-						 int        monitor,
-						 gboolean  *leftmost,
-						 gboolean  *rightmost,
-						 gboolean  *topmost,
-						 gboolean  *bottommost);
+int	panel_multimonitor_x                     (int monitor);
+int	panel_multimonitor_y                     (int monitor);
+int	panel_multimonitor_width                 (int monitor);
+int	panel_multimonitor_height                (int monitor);
+
+int	panel_multimonitor_locate_widget_monitor (GtkWidget *widget);
+int	panel_multimonitor_get_monitor_at_point  (int x, int y);
+void	panel_multimonitor_is_at_visible_extreme (int        monitor_id,
+						  gboolean  *leftmost,
+						  gboolean  *rightmost,
+						  gboolean  *topmost,
+						  gboolean  *bottommost);
 
 #endif /* __PANEL_MULTIMONITOR_H__ */

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -41,7 +41,7 @@
 #include "panel.h"
 #include "panel-widget.h"
 #include "panel-util.h"
-#include "panel-multiscreen.h"
+#include "panel-multimonitor.h"
 #include "panel-toplevel.h"
 #include "panel-lockdown.h"
 #include "panel-schemas.h"

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -909,7 +909,7 @@ panel_profile_find_empty_spot (GdkScreen *screen,
 	*monitor = 0;
 	*orientation = PANEL_ORIENTATION_TOP;
 
-	filled_spots = g_new0 (int, panel_multiscreen_monitors (screen));
+	filled_spots = g_new0 (int, panel_multimonitor_monitors ());
 
 	for (li = panel_toplevel_list_toplevels (); li != NULL; li = li->next) {
 		PanelToplevel *toplevel = li->data;
@@ -924,7 +924,7 @@ panel_profile_find_empty_spot (GdkScreen *screen,
 		filled_spots[toplevel_monitor] |= panel_toplevel_get_orientation (toplevel);
 	}
 
-	for (i = 0; i < panel_multiscreen_monitors (screen); i++) {
+	for (i = 0; i < panel_multimonitor_monitors (); i++) {
 		/* These are ordered based on "priority" of the
 		   orientation when picking it */
 		if ( ! (filled_spots[i] & PANEL_ORIENTATION_TOP)) {

--- a/mate-panel/panel-recent.c
+++ b/mate-panel/panel-recent.c
@@ -38,7 +38,6 @@
 #include "panel-globals.h"
 #include "panel-recent.h"
 #include "panel-stock-icons.h"
-#include "panel-multiscreen.h"
 #include "panel-icon-names.h"
 
 static gboolean

--- a/mate-panel/panel-run-dialog.c
+++ b/mate-panel/panel-run-dialog.c
@@ -57,7 +57,7 @@
 #include "panel-profile.h"
 #include "panel-schemas.h"
 #include "panel-stock-icons.h"
-#include "panel-multiscreen.h"
+#include "panel-multimonitor.h"
 #include "menu.h"
 #include "panel-lockdown.h"
 #include "panel-icon-names.h"

--- a/mate-panel/panel-run-dialog.c
+++ b/mate-panel/panel-run-dialog.c
@@ -1742,7 +1742,6 @@ static void
 panel_run_dialog_setup_entry (PanelRunDialog *dialog,
 			      GtkBuilder     *gui)
 {
-	GdkScreen             *screen;
 	int                    width_request;
 	GtkWidget             *entry;
 
@@ -1756,10 +1755,8 @@ panel_run_dialog_setup_entry (PanelRunDialog *dialog,
 	gtk_combo_box_set_entry_text_column
 		(GTK_COMBO_BOX (dialog->combobox), 0);
 
-	screen = gtk_window_get_screen (GTK_WINDOW (dialog->run_dialog));
-
         /* 1/4 the width of the first monitor should be a good value */
-	width_request = panel_multiscreen_width (screen, 0) / 4;
+	width_request = panel_multimonitor_width (0) / 4;
 	g_object_set (G_OBJECT (dialog->combobox),
 		      "width_request", width_request,
 		      NULL);

--- a/mate-panel/panel-struts.c
+++ b/mate-panel/panel-struts.c
@@ -68,17 +68,16 @@ panel_struts_find_strut (PanelToplevel *toplevel)
 }
 
 static void
-panel_struts_get_monitor_geometry (GdkScreen *screen,
-				   int        monitor,
+panel_struts_get_monitor_geometry (int        monitor,
 				   int       *x,
 				   int       *y,
 				   int       *width,
 				   int       *height)
 {
-        *x      = panel_multiscreen_x      (screen, monitor);
-        *y      = panel_multiscreen_y      (screen, monitor);
-        *width  = panel_multiscreen_width  (screen, monitor);
-        *height = panel_multiscreen_height (screen, monitor);
+        *x      = panel_multimonitor_x      (monitor);
+        *y      = panel_multimonitor_y      (monitor);
+        *width  = panel_multimonitor_width  (monitor);
+        *height = panel_multimonitor_height (monitor);
 }
 
 static PanelStrut *
@@ -201,7 +200,7 @@ panel_struts_allocate_struts (PanelToplevel *toplevel,
 		if (strut->screen != screen || strut->monitor != monitor)
 			continue;
 
-		panel_struts_get_monitor_geometry (strut->screen, strut->monitor,
+		panel_struts_get_monitor_geometry (strut->monitor,
 						   &monitor_x, &monitor_y,
 						   &monitor_width, &monitor_height);
 
@@ -274,19 +273,17 @@ panel_struts_set_window_hint (PanelToplevel *toplevel)
 	screen_width  = WidthOfScreen (gdk_x11_screen_get_xscreen (strut->screen)) / scale;
 	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (strut->screen)) / scale;
 
-	panel_struts_get_monitor_geometry (strut->screen,
-					   strut->monitor,
+	panel_struts_get_monitor_geometry (strut->monitor,
 					   &monitor_x,
 					   &monitor_y,
 					   &monitor_width,
 					   &monitor_height);
 
-        panel_multiscreen_is_at_visible_extreme (strut->screen,
-                                                 strut->monitor,
-                                                 &leftmost,
-                                                 &rightmost,
-                                                 &topmost,
-                                                 &bottommost);
+        panel_multimonitor_is_at_visible_extreme (strut->monitor,
+                                                  &leftmost,
+                                                  &rightmost,
+                                                  &topmost,
+                                                  &bottommost);
 
 	switch (strut->orientation) {
 	case PANEL_ORIENTATION_TOP:
@@ -434,7 +431,7 @@ panel_struts_register_strut (PanelToplevel    *toplevel,
 	strut->strut_start = strut_start;
 	strut->strut_end   = strut_end;
 
-	panel_struts_get_monitor_geometry (screen, monitor,
+	panel_struts_get_monitor_geometry (monitor,
 					   &monitor_x, &monitor_y,
 					   &monitor_width, &monitor_height);
 

--- a/mate-panel/panel-struts.c
+++ b/mate-panel/panel-struts.c
@@ -26,7 +26,7 @@
 
 #include "panel-struts.h"
 
-#include "panel-multiscreen.h"
+#include "panel-multimonitor.h"
 #include "panel-xutils.h"
 
 

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -39,7 +39,7 @@
 #include "panel-profile.h"
 #include "panel-frame.h"
 #include "panel-xutils.h"
-#include "panel-multiscreen.h"
+#include "panel-multimonitor.h"
 #include "panel-a11y.h"
 #include "panel-typebuiltins.h"
 #include "panel-marshal.h"

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -41,7 +41,6 @@
 #include "panel-action-button.h"
 #include "panel-menu-bar.h"
 #include "panel-separator.h"
-#include "panel-multiscreen.h"
 #include "panel-toplevel.h"
 #include "panel-menu-button.h"
 #include "panel-globals.h"


### PR DESCRIPTION
Since GTK 3.10 (older than our current required version of 3.22) GTK has not supported multiple screens. In panel-multiscreen.c, `screens = 1` was hard coded, but the logic to handle multiple screens was still laying around. This renames panel-multiscreen to panel-multimonitor, and removes all logic dealing with screens from it. I needed this for Wayland, but It is also a step toward GTK4 (where `GdkScreen` doesn't exist).

There is still some logic around RANDR in panel-multimonitor that I think is left over from times long past, but that can be dealt with another time by someone else.