### PR TITLE
Wayland support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,8 +223,6 @@ AM_CONDITIONAL(ENABLE_X11, [test "x$have_x11" = "xyes"])
 
 if test "x$have_x11" = "xyes"; then
   AC_DEFINE(HAVE_X11, 1, [Have the X11 development library])
-else
-  AC_MSG_ERROR([No support yet for non-X11 builds])
 fi
 
 if test "x$have_x11" != "xyes" -a "x$have_wayland" != "xyes"; then

--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -61,6 +61,8 @@ panel_sources = \
 	panel-reset.c
 
 if ENABLE_WAYLAND
+panel_sources += \
+	wayland-backend.c
 endif
 
 if ENABLE_X11
@@ -120,6 +122,8 @@ panel_headers = \
 	panel-schemas.h
 
 if ENABLE_WAYLAND
+panel_headers += \
+	wayland-backend.h
 endif
 
 if ENABLE_X11

--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -37,6 +37,10 @@
 #include "xstuff.h"
 #endif
 
+#ifdef HAVE_WAYLAND
+#include "wayland-backend.h"
+#endif
+
 /* globals */
 GSList *panels = NULL;
 GSList *panel_list = NULL;
@@ -180,6 +184,12 @@ main (int argc, char **argv)
 	                 NULL);
 
 	gboolean found_backend = FALSE;
+
+#ifdef HAVE_WAYLAND
+	if (GDK_IS_WAYLAND_DISPLAY (display)) {
+		found_backend = TRUE;
+	}
+#endif
 
 #ifdef HAVE_X11
 	if (GDK_IS_X11_DISPLAY (display)) {

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -57,6 +57,9 @@
 #include "panel-xutils.h"
 #include "panel-struts.h"
 #endif
+#ifdef HAVE_WAYLAND
+#include "wayland-backend.h"
+#endif
 
 #define DEFAULT_SIZE              48
 #define DEFAULT_AUTO_HIDE_SIZE    1
@@ -1557,6 +1560,11 @@ static gboolean panel_toplevel_update_struts(PanelToplevel* toplevel, gboolean e
 	}
 #endif // HAVE_X11
 
+#ifdef HAVE_WAYLAND
+	if (GDK_IS_WAYLAND_DISPLAY (gtk_widget_get_display (GTK_WIDGET (toplevel)))) {
+		wayland_panel_toplevel_update_placement (toplevel);
+	}
+#endif // HAVE_WAYLAND
 	return geometry_changed;
 }
 
@@ -4815,6 +4823,12 @@ panel_toplevel_init (PanelToplevel *toplevel)
 			       toplevel);	
 
 	update_style_classes (toplevel);
+
+#ifdef HAVE_WAYLAND
+	if (GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default ())) {
+		wayland_panel_toplevel_init (toplevel);
+	}
+#endif // HAVE_WAYLAND
 }
 
 PanelWidget *
@@ -5059,6 +5073,12 @@ panel_toplevel_set_orientation (PanelToplevel    *toplevel,
 	g_object_notify (G_OBJECT (toplevel), "orientation");
 
 	g_object_thaw_notify (G_OBJECT (toplevel));
+
+#ifdef HAVE_WAYLAND
+	if (GDK_IS_WAYLAND_DISPLAY (gtk_widget_get_display (GTK_WIDGET (toplevel)))) {
+		wayland_panel_toplevel_update_placement (toplevel);
+	}
+#endif // HAVE_WAYLAND
 }
 
 PanelOrientation

--- a/mate-panel/wayland-backend.c
+++ b/mate-panel/wayland-backend.c
@@ -1,0 +1,57 @@
+#include <config.h>
+
+#include <gtk-layer-shell/gtk-layer-shell.h>
+
+#include "wayland-backend.h"
+
+void
+wayland_panel_toplevel_init (PanelToplevel* toplevel)
+{
+	GtkWindow* window;
+
+	window = GTK_WINDOW (toplevel);
+	gtk_layer_init_for_window (window);
+	gtk_layer_set_layer (window, GTK_LAYER_SHELL_LAYER_TOP);
+	gtk_layer_set_namespace (window, "panel");
+	gtk_layer_auto_exclusive_zone_enable (window);
+	wayland_panel_toplevel_update_placement (toplevel);
+}
+
+void
+wayland_panel_toplevel_update_placement (PanelToplevel* toplevel)
+{
+	GtkWindow* window;
+	gboolean expand;
+	PanelOrientation orientation;
+	gboolean anchor[GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER];
+
+	window = GTK_WINDOW (toplevel);
+	expand = panel_toplevel_get_expand (toplevel);
+	orientation = panel_toplevel_get_orientation (toplevel);
+	for (int i = 0; i < GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER; i++)
+		anchor[i] = expand;
+
+	switch (orientation) {
+	case PANEL_ORIENTATION_LEFT:
+		anchor[GTK_LAYER_SHELL_EDGE_LEFT] = TRUE;
+		anchor[GTK_LAYER_SHELL_EDGE_RIGHT] = FALSE;
+		break;
+	case PANEL_ORIENTATION_RIGHT:
+		anchor[GTK_LAYER_SHELL_EDGE_RIGHT] = TRUE;
+		anchor[GTK_LAYER_SHELL_EDGE_LEFT] = FALSE;
+		break;
+	case PANEL_ORIENTATION_TOP:
+		anchor[GTK_LAYER_SHELL_EDGE_TOP] = TRUE;
+		anchor[GTK_LAYER_SHELL_EDGE_BOTTOM] = FALSE;
+		break;
+	case PANEL_ORIENTATION_BOTTOM:
+		anchor[GTK_LAYER_SHELL_EDGE_BOTTOM] = TRUE;
+		anchor[GTK_LAYER_SHELL_EDGE_TOP] = FALSE;
+		break;
+	default:
+		g_warning ("Invalid panel orientation %d", orientation);
+	}
+
+	for (int i = 0; i < GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER; i++)
+		gtk_layer_set_anchor (window, i, anchor[i]);
+}

--- a/mate-panel/wayland-backend.c
+++ b/mate-panel/wayland-backend.c
@@ -1,3 +1,27 @@
+/*
+ * wayland-backend.c: Support for running on Wayland compositors
+ *
+ * Copyright (C) 2019 William Wold
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * Authors:
+ *	William Wold <wm@wmww.sh>
+ */
+
 #include <config.h>
 
 #include <gtk-layer-shell/gtk-layer-shell.h>

--- a/mate-panel/wayland-backend.h
+++ b/mate-panel/wayland-backend.h
@@ -1,0 +1,18 @@
+#ifndef __WAYLAND_BACKEND_H__
+#define __WAYLAND_BACKEND_H__
+
+#include <config.h>
+
+#ifndef HAVE_WAYLAND
+#error file should only be included when HAVE_WAYLAND is enabled
+#endif
+
+#include <gdk/gdk.h>
+#include <gdk/gdkwayland.h>
+
+#include "panel-toplevel.h"
+
+void wayland_panel_toplevel_init (PanelToplevel* toplevel);
+void wayland_panel_toplevel_update_placement (PanelToplevel* toplevel);
+
+#endif /* __WAYLAND_BACKEND_H__ */

--- a/mate-panel/wayland-backend.h
+++ b/mate-panel/wayland-backend.h
@@ -1,3 +1,27 @@
+/*
+ * wayland-backend.h: Support for running on Wayland compositors
+ *
+ * Copyright (C) 2019 William Wold
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * Authors:
+ *	William Wold <wm@wmww.sh>
+ */
+
 #ifndef __WAYLAND_BACKEND_H__
 #define __WAYLAND_BACKEND_H__
 


### PR DESCRIPTION
This is the PR we've all been waiting for. The one that finally adds full Wayland support to the panel. You can test this without even building from source (see the Mir section of 'To run')

Based on ~#983~, ~#984~, ~#985~, ~#986~, ~#988~, ~#989~, ~#990~ 

## To build
You'll need to compile and install [GTK Layer Shell](https://github.com/wmww/gtk-layer-shell). After that run `./autogen.sh --with-in-process-applets=all --enable-wayland --enable-x11` and make and install. Installing is required if the build that is currently installed did not have `--with-in-process-applets=all`. If you don't install it will try to use out-of-process applets, which fail on Wayland.

## To run
First, you'll need a Wayland compositor that supports Layer Shell.

* Wlroots based compositors
  * On sway the basics work, but popups don't (so you can't add to the panel or open properties)
  * If you compile wlroots from source you'll get rootston. Nested popups don't work but at least toplevel ones do.
* Mir
  * The normal Mir demos don't have layer shell enabled
  * The `mate-wayland` snap is built from a branch of Mir with Layer Shell. It also comes with a copy mate-panel compiled from the same commits as are in this branch.
  * To install on a system that supports snaps: `sudo snap install --edge --classic mate-wayland`
  * To run Mir and the bundled version of mate-panel: `mate-wayland`
  * To run just the version of Mir with Layer Shell support: `mate-wayland.mirco`

If compiling the panel yourself, once you have a compositor with Layer Shell support you'll want to run mate-panel in it. To do this, run `WAYLAND_DISPLAY=wayland-0 ./mate-panel`. That's assuming your Wayland compositor is running on `wayland-0` which I think is a safe assumption if it's the only compositor running.