### PR TITLE
Fix popup placement on Wayland

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -852,10 +852,26 @@ mate_panel_applet_menu_popup (MatePanelApplet *applet,
 	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
 	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
 	gtk_style_context_add_class(context,"mate-panel-menu-bar");
+	GdkGravity widget_anchor = GDK_GRAVITY_NORTH_WEST;
+	GdkGravity menu_anchor = GDK_GRAVITY_NORTH_WEST;
+	switch (applet->priv->orient) {
+	case MATE_PANEL_APPLET_ORIENT_UP:
+		menu_anchor = GDK_GRAVITY_SOUTH_WEST;
+		break;
+	case MATE_PANEL_APPLET_ORIENT_DOWN:
+		widget_anchor = GDK_GRAVITY_SOUTH_WEST;
+		break;
+	case MATE_PANEL_APPLET_ORIENT_LEFT:
+		menu_anchor = GDK_GRAVITY_NORTH_EAST;
+		break;
+	case MATE_PANEL_APPLET_ORIENT_RIGHT:
+		widget_anchor = GDK_GRAVITY_NORTH_EAST;
+		break;
+	}
 	gtk_menu_popup_at_widget (GTK_MENU (menu),
 	                          GTK_WIDGET (applet),
-	                          GDK_GRAVITY_NORTH_WEST,
-	                          GDK_GRAVITY_NORTH_WEST,
+	                          widget_anchor,
+	                          menu_anchor,
 	                          event);
 }
 

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -456,15 +456,31 @@ panel_menu_button_popup_menu (PanelMenuButton *button,
 	gtk_window_set_attached_to (GTK_WINDOW (gtk_widget_get_toplevel (button->priv->menu)),
 				    GTK_WIDGET (button));
 
-	/*using these same anchor points lets default "anchor-hints" properly position the menu
-	 *so that on a vertical panel the menu aligns with the outside edge of a menu button
-	 *placed at the top or bottom of a left or a right panel
-	 */
+	GdkGravity widget_anchor = GDK_GRAVITY_NORTH_WEST;
+	GdkGravity menu_anchor = GDK_GRAVITY_NORTH_WEST;
+	switch (panel_toplevel_get_orientation (button->priv->toplevel)) {
+	case PANEL_ORIENTATION_TOP:
+		widget_anchor = GDK_GRAVITY_SOUTH_WEST;
+		g_message ("PANEL_ORIENTATION_TOP");
+		break;
+	case PANEL_ORIENTATION_BOTTOM:
+		menu_anchor = GDK_GRAVITY_SOUTH_WEST;
+		g_message ("PANEL_ORIENTATION_BOTTOM");
+		break;
+	case PANEL_ORIENTATION_LEFT:
+		widget_anchor = GDK_GRAVITY_NORTH_EAST;
+		g_message ("PANEL_ORIENTATION_LEFT");
+		break;
+	case PANEL_ORIENTATION_RIGHT:
+		menu_anchor = GDK_GRAVITY_NORTH_EAST;
+		g_message ("PANEL_ORIENTATION_RIGHT");
+		break;
+	}
 
 	gtk_menu_popup_at_widget (GTK_MENU (button->priv->menu),
 	                          GTK_WIDGET (button),
-	                          GDK_GRAVITY_NORTH_WEST,
-	                          GDK_GRAVITY_NORTH_WEST,
+	                          widget_anchor,
+	                          menu_anchor,
 	                          NULL);
 }
 


### PR DESCRIPTION
This PR effects right-click menus on applets and opening the application menu.

On X, it appears the X struts we create automatically push the menus off the panel. The same does not happen on Wayland, so popups cover up the panel. This fixes the two cases where this is definitely bad, by adjusting the anchors so the popups appear in the right place. This should not change behavior on X (the X server will just no longer need to shove popups out of the way).

There are still cases where on X popups appear off the panel and on Wayland over top of it (ex right clicking on the empty space on the panel). However, the remaining cases use `gtk_menu_popup_at_pointer ()`. IMO this looks fine and is arguably preferable behavior in those cases to what X does.