### PR TITLE
Fix GTK Layer Shell include and CFLAGS

### DIFF
--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -14,7 +14,7 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/mate-panel/libpanel-util \
 	-DMATELOCALEDIR=\""$(prefix)/$(DATADIRNAME)/locale"\" \
 	-DPANELDATADIR=\""$(datadir)/mate-panel"\" \
-	$(DISABLE_DEPRECATED_CFLAGS)
+	$(DISABLE_DEPRECATED_CFLAGS) \
 	$(GTK_LAYER_SHELL_CFLAGS)
 
 AM_CFLAGS = $(WARN_CFLAGS)

--- a/mate-panel/wayland-backend.c
+++ b/mate-panel/wayland-backend.c
@@ -24,7 +24,7 @@
 
 #include <config.h>
 
-#include <gtk-layer-shell/gtk-layer-shell.h>
+#include <gtk-layer-shell.h>
 
 #include "wayland-backend.h"
 


### PR DESCRIPTION
Whoops. If you're testing, take the opertunity to update to the newest GTK Layer Shell as well, which has switched from autotools to Meson.