### PR TITLE
Fix applets placement on expanded vertical panel

### DIFF
--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -2931,10 +2931,8 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 				   toplevel->priv->geometry.width,
 				   toplevel->priv->geometry.height);
 
-	if(resize || move)
-	{
-		for(list = toplevel->priv->panel_widget->applet_list;list!=NULL;list = g_list_next(list))
-		{
+	if (resize || move) {
+		for (list = toplevel->priv->panel_widget->applet_list; list != NULL; list = g_list_next (list)) {
 			AppletData *ad = list->data;
 			id = mate_panel_applet_get_id_by_widget (ad->applet);
 
@@ -2946,8 +2944,7 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 
 			stick = g_settings_get_boolean (info->settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY);
 
-			if(stick)
-			{
+			if (stick) {
 				position = g_settings_get_int (info->settings, PANEL_OBJECT_POSITION_KEY);
 				ad->pos = toplevel->priv->geometry.width - position;
 			}

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -2946,7 +2946,11 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 
 			if (stick) {
 				position = g_settings_get_int (info->settings, PANEL_OBJECT_POSITION_KEY);
-				ad->pos = toplevel->priv->geometry.width - position;
+				if (toplevel->priv->orientation & PANEL_HORIZONTAL_MASK) {
+					ad->pos = toplevel->priv->geometry.width - position;
+				} else {
+					ad->pos = toplevel->priv->geometry.height - position;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This fixes https://github.com/mate-desktop/mate-panel/issues/745.

A regression from https://github.com/mate-desktop/mate-panel/pull/683 caused all applets on expanded vertical panel stick to the top. In addition it made window list (if it's present on that panel) completely disappear...

For testing I've used a horizontal panel with some applet(s) set to stay on the right (tray area or workspace switcher). Then I've moved that panel to the left, making it vertical. Without this fix, all applets were stuck to the top. With this fix, tray area or workspace switcher stay at panel's bottom.