### PR TITLE
Load layouts from absolute paths

### DIFF
--- a/mate-panel/panel-layout.c
+++ b/mate-panel/panel-layout.c
@@ -102,7 +102,12 @@ panel_layout_filename ()
 
     settings = g_settings_new (PANEL_SCHEMA);
     layout = g_settings_get_string (settings, PANEL_DEFAULT_LAYOUT);
-    filename = g_strdup_printf (PANEL_LAYOUTS_DIR "%s.layout", layout);
+    if (g_str_has_prefix (layout, "/")) {
+        filename = g_strdup (layout);
+    }
+    else {
+        filename = g_strdup_printf (PANEL_LAYOUTS_DIR "%s.layout", layout);
+    }
     g_free (layout);
     g_object_unref (settings);
 


### PR DESCRIPTION
If the layout name begins with a '/', load from that filename instead of
from PANEL_LAYOUTS_DIR.  This allows loading of layouts from home
directories and other write-permitted locations.