### PR TITLE
Add date display format for “Clock preferences”

### DIFF
--- a/applets/clock/clock.ui
+++ b/applets/clock/clock.ui
@@ -762,6 +762,36 @@
                                 <property name="position">4</property>
                               </packing>
                             </child>
+                          <child>
+                              <object class="GtkCheckButton" id="longdate_check">
+                                <property name="label" translatable="yes">Show longdate</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="shortdate_check">
+                                <property name="label" translatable="yes">Show shortdate</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">6</property>
+                              </packing>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
+++ b/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
@@ -39,6 +39,16 @@
       <summary>Show time with seconds</summary>
       <description>If true, display seconds in time.</description>
     </key>
+    <key name="show-longdate" type="b">
+      <default>false</default>
+      <summary>Show time with seconds11</summary>
+      <description>If true, display seconds in time11.</description>
+    </key>
+    <key name="show-shortdate" type="b">
+      <default>true</default>
+      <summary>Show time with seconds22</summary>
+      <description>If true, display seconds in time22.</description>
+    </key>
     <key name="show-date" type="b">
       <default>true</default>
       <summary>Show date in clock</summary>

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -368,6 +368,14 @@ msgstr "天气"
 msgid "Time _Settings"
 msgstr "时间设置(_S)"
 
+#: ../applets/clock/clock.ui.h:35
+msgid "Show longdate"
+msgstr "长日期格式：YYYY年MM月DD日"
+
+#: ../applets/clock/clock.ui.h:35
+msgid "Show shortdate"
+msgstr "短日期格式：YYYY-MM-DD"
+
 #: ../applets/clock/clock-location-tile.c:188
 msgid "Failed to set the system timezone"
 msgstr "设置系统时区失败"


### PR DESCRIPTION
- In China, we hope that like the Windows operating system, we can set the display format of time. Therefore, I added a long/short date display format for the Chinese environment.
- Long Date Display Format:YYYY年MM月DD日
- Short Date Display Format:YYYY-MM-DD