### PR TITLE
Add date display format for 'Clock preferences'

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -76,6 +76,8 @@
 
 #define KEY_FORMAT                "format"
 #define KEY_SHOW_SECONDS        "show-seconds"
+#define KEY_SHOW_LONGDATE	"show-longdate"
+#define KEY_SHOW_SHORTDATE	"show-shortdate"
 #define KEY_SHOW_DATE                "show-date"
 #define KEY_SHOW_WEATHER        "show-weather"
 #define KEY_SHOW_TEMPERATURE        "show-temperature"
@@ -146,6 +148,8 @@ struct _ClockData {
         ClockFormat  format;
         char        *custom_format;
         gboolean     showseconds;
+        gboolean     showlongdate;
+	gboolean     showshortdate;
         gboolean     showdate;
         gboolean     showweek;
         gboolean     show_weather;
@@ -172,6 +176,8 @@ struct _ClockData {
         int fixed_height;
 
         GtkWidget *showseconds_check;
+        GtkWidget *showlongdate_check;
+        GtkWidget *showshortdate_check;
         GtkWidget *showdate_check;
         GtkWidget *showweeks_check;
         GtkWidget *custom_hbox;
@@ -479,6 +485,88 @@ get_updated_timeformat (ClockData *cd)
                                                         time_format);
         }
 
+        if (cd->showdate){ 
+        if (cd->showlongdate && !cd->showshortdate){
+		/* Translators: This is a strftime format string.
+		 * It is used to display the date. Replace %e with %d if, when
+		 * the day of the month as a decimal number is a single digit,
+		 * it should begin with a 0 in your locale (e.g. "May 01"
+		 * instead of "May  1"). */
+		date_format = _("%Y年%m月%d日");
+
+		if (use_two_line_format (cd))
+			/* translators: reverse the order of these arguments
+			 *              if the time should come before the
+			 *              date on a clock in your locale.
+			 */
+			clock_format = g_strdup_printf (_("%1$s\n%2$s"),
+							date_format,
+							time_format);
+		else
+			/* translators: reverse the order of these arguments
+			 *              if the time should come before the
+			 *              date on a clock in your locale.
+			 */
+			clock_format = g_strdup_printf (_("%1$s, %2$s"),
+							date_format,
+							time_format);
+        }
+        else if (cd->showshortdate && !cd->showlongdate) {
+		/* Translators: This is a strftime format string.
+		 * It is used to display the date. Replace %e with %d if, when
+		 * the day of the month as a decimal number is a single digit,
+		 * it should begin with a 0 in your locale (e.g. "May 01"
+		 * instead of "May  1"). */
+		date_format = _("%F");
+
+		if (use_two_line_format (cd))
+			/* translators: reverse the order of these arguments
+			 *              if the time should come before the
+			 *              date on a clock in your locale.
+			 */
+			clock_format = g_strdup_printf (_("%1$s\n%2$s"),
+							date_format,
+							time_format);
+		else
+			/* translators: reverse the order of these arguments
+			 *              if the time should come before the
+			 *              date on a clock in your locale.
+			 */
+			clock_format = g_strdup_printf (_("%1$s, %2$s"),
+							date_format,
+							time_format);
+        }
+        else {
+		/* Translators: This is a strftime format string.
+		 * It is used to display the date. Replace %e with %d if, when
+		 * the day of the month as a decimal number is a single digit,
+		 * it should begin with a 0 in your locale (e.g. "May 01"
+		 * instead of "May  1"). */
+		date_format = _("%a %b %e");
+
+		if (use_two_line_format (cd))
+			/* translators: reverse the order of these arguments
+			 *              if the time should come before the
+			 *              date on a clock in your locale.
+			 */
+			clock_format = g_strdup_printf (_("%1$s\n%2$s"),
+							date_format,
+							time_format);
+		else
+			/* translators: reverse the order of these arguments
+			 *              if the time should come before the
+			 *              date on a clock in your locale.
+			 */
+			clock_format = g_strdup_printf (_("%1$s, %2$s"),
+							date_format,
+							time_format);
+
+        }
+        
+
+        }
+
+
         /* Set back LANGUAGE the way it was before */
         if (env_language != NULL && env_lc_time != NULL && env_language != env_lc_time) {
             g_setenv("LANGUAGE", env_language, TRUE);
@@ -682,6 +770,64 @@ update_tooltip (ClockData * cd)
                 else
                         tip = _("Click to view month calendar");
         }
+        if (!cd->showdate) {
+        if (cd->showlongdate || cd->showshortdate) {
+		struct tm *tm;
+		char date[256];
+		char *utf8, *loc;
+                char *zone;
+                time_t now_t;
+                struct tm now;
+
+		tm = localtime (&cd->current_time);
+
+		utf8 = NULL;
+
+                /* Show date in tooltip. */
+		/* Translators: This is a strftime format string.
+		 * It is used to display a date. Please leave "%%s" as it is:
+		 * it will be used to insert the timezone name later. */
+                if (cd->showlongdate && !cd->showshortdate ) {
+                    loc = g_locale_from_utf8 (_("%c (%%s)"), -1, NULL, NULL, NULL);
+                } 
+                else if (cd->showshortdate && !cd->showlongdate) {
+                    loc = g_locale_from_utf8 (_("%F %A %H时%M分%S秒 (%%s)"), -1, NULL, NULL, NULL);
+                }
+                else {
+                    loc = g_locale_from_utf8 (_("%A %B %d (%%s)"), -1, NULL, NULL, NULL);
+                 }
+
+                if (!loc)
+                        strcpy (date, "???");
+                else if (strftime (date, sizeof (date), loc, tm) <= 0)
+                        strcpy (date, "???");
+                g_free (loc);
+
+                utf8 = g_locale_to_utf8 (date, -1, NULL, NULL, NULL);
+
+               /* Add the timezone name */
+
+                tzset ();
+                time (&now_t);
+                localtime_r (&now_t, &now);
+
+                if (now.tm_isdst > 0) {
+                        zone = tzname[1];
+                } else {
+                        zone = tzname[0];
+                }
+
+                tip = g_strdup_printf (utf8, zone);
+
+                g_free (utf8);
+        }
+        } else {
+                if (cd->calendar_popup)
+                        tip = _("Click to hide month calendar");
+                else
+                        tip = _("Click to view month calendar");
+        }
+
 
         /* Update only when the new tip is different.
          * This can prevent problems with OpenGL on some drivers */
@@ -1930,6 +2076,26 @@ show_seconds_changed (GSettings    *settings,
 }
 
 static void
+show_shortdate_changed (GSettings    *settings,
+		      gchar        *key,
+		      ClockData    *clock)
+{
+	clock->showshortdate = g_settings_get_boolean (settings, key);
+	update_timeformat (clock);
+        refresh_clock (clock);
+}
+
+static void
+show_longdate_changed (GSettings    *settings,
+		      gchar        *key,
+		      ClockData    *clock)
+{
+	clock->showlongdate = g_settings_get_boolean (settings, key);
+	update_timeformat (clock);
+        refresh_clock (clock);
+}
+
+static void
 show_date_changed (GSettings    *settings,
                    gchar        *key,
                    ClockData    *clock)
@@ -2392,6 +2558,8 @@ setup_gsettings (ClockData *cd)
 
         g_signal_connect (cd->settings, "changed::" KEY_FORMAT, G_CALLBACK (format_changed), cd);
         g_signal_connect (cd->settings, "changed::" KEY_SHOW_SECONDS, G_CALLBACK (show_seconds_changed), cd);
+        g_signal_connect (cd->settings, "changed::" KEY_SHOW_LONGDATE, G_CALLBACK (show_longdate_changed), cd);
+        g_signal_connect (cd->settings, "changed::" KEY_SHOW_SHORTDATE, G_CALLBACK (show_shortdate_changed), cd);
         g_signal_connect (cd->settings, "changed::" KEY_SHOW_DATE, G_CALLBACK (show_date_changed), cd);
         g_signal_connect (cd->settings, "changed::" KEY_SHOW_WEATHER, G_CALLBACK (show_weather_changed), cd);
         g_signal_connect (cd->settings, "changed::" KEY_SHOW_TEMPERATURE, G_CALLBACK (show_temperature_changed), cd);
@@ -2438,6 +2606,8 @@ load_gsettings (ClockData *cd)
 
         cd->custom_format = g_settings_get_string (cd->settings, KEY_CUSTOM_FORMAT);
         cd->showseconds = g_settings_get_boolean (cd->settings, KEY_SHOW_SECONDS);
+	cd->showlongdate = g_settings_get_boolean (cd->settings, KEY_SHOW_LONGDATE);
+	cd->showshortdate = g_settings_get_boolean (cd->settings, KEY_SHOW_SHORTDATE);
         cd->showdate = g_settings_get_boolean (cd->settings, KEY_SHOW_DATE);
         cd->show_weather = g_settings_get_boolean (cd->settings, KEY_SHOW_WEATHER);
         cd->show_temperature = g_settings_get_boolean (cd->settings, KEY_SHOW_TEMPERATURE);
@@ -3074,6 +3244,16 @@ fill_prefs_window (ClockData *cd)
         widget = _clock_get_widget (cd, "seconds_check");
         g_settings_bind (cd->settings, KEY_SHOW_SECONDS, widget, "active",
                          G_SETTINGS_BIND_DEFAULT);
+	/* Set the "Show longdate" checkbox */
+	widget = _clock_get_widget (cd, "longdate_check");
+	g_settings_bind (cd->settings, KEY_SHOW_LONGDATE, widget, "active",
+                         G_SETTINGS_BIND_DEFAULT);
+
+	/* Set the "Show shortdate" checkbox */
+	widget = _clock_get_widget (cd, "shortdate_check");
+	g_settings_bind (cd->settings, KEY_SHOW_SHORTDATE, widget, "active",
+                         G_SETTINGS_BIND_DEFAULT);
+
 
         /* Set the "Show Week Numbers" checkbox */
         widget = _clock_get_widget (cd, "weeks_check");

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -492,7 +492,7 @@ get_updated_timeformat (ClockData *cd)
 		 * the day of the month as a decimal number is a single digit,
 		 * it should begin with a 0 in your locale (e.g. "May 01"
 		 * instead of "May  1"). */
-		date_format = _("%Y年%m月%d日");
+		date_format = _("%x");
 
 		if (use_two_line_format (cd))
 			/* translators: reverse the order of these arguments
@@ -791,7 +791,7 @@ update_tooltip (ClockData * cd)
                     loc = g_locale_from_utf8 (_("%c (%%s)"), -1, NULL, NULL, NULL);
                 } 
                 else if (cd->showshortdate && !cd->showlongdate) {
-                    loc = g_locale_from_utf8 (_("%F %A %H时%M分%S秒 (%%s)"), -1, NULL, NULL, NULL);
+                    loc = g_locale_from_utf8 (_("%F %A %X (%%s)"), -1, NULL, NULL, NULL);
                 }
                 else {
                     loc = g_locale_from_utf8 (_("%A %B %d (%%s)"), -1, NULL, NULL, NULL);

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -78,6 +78,7 @@
 #define KEY_SHOW_SECONDS        "show-seconds"
 #define KEY_SHOW_LONGDATE	"show-longdate"
 #define KEY_SHOW_SHORTDATE	"show-shortdate"
+#define KEY_SHOW_DEFAULTDATE	"show-default-format"
 #define KEY_SHOW_DATE                "show-date"
 #define KEY_SHOW_WEATHER        "show-weather"
 #define KEY_SHOW_TEMPERATURE        "show-temperature"
@@ -150,6 +151,7 @@ struct _ClockData {
         gboolean     showseconds;
         gboolean     showlongdate;
 	gboolean     showshortdate;
+        gboolean     showdefaultdate;
         gboolean     showdate;
         gboolean     showweek;
         gboolean     show_weather;
@@ -178,6 +180,7 @@ struct _ClockData {
         GtkWidget *showseconds_check;
         GtkWidget *showlongdate_check;
         GtkWidget *showshortdate_check;
+        GtkWidget *showdefaultdate_check;
         GtkWidget *showdate_check;
         GtkWidget *showweeks_check;
         GtkWidget *custom_hbox;
@@ -485,7 +488,7 @@ get_updated_timeformat (ClockData *cd)
                                                         time_format);
         }
 
-        if (cd->showdate){ 
+        if (cd->showdate && !cd->showdefaultdate){ 
         if (cd->showlongdate && !cd->showshortdate){
 		/* Translators: This is a strftime format string.
 		 * It is used to display the date. Replace %e with %d if, when
@@ -2076,6 +2079,15 @@ show_seconds_changed (GSettings    *settings,
 }
 
 static void
+show_defaultdate_changed (GSettings    *settings,
+		      gchar        *key,
+		      ClockData    *clock)
+{
+	clock->showdefaultdate = g_settings_get_boolean (settings, key);
+	update_timeformat (clock);
+        refresh_clock (clock);
+}
+static void
 show_shortdate_changed (GSettings    *settings,
 		      gchar        *key,
 		      ClockData    *clock)
@@ -2559,6 +2571,7 @@ setup_gsettings (ClockData *cd)
         g_signal_connect (cd->settings, "changed::" KEY_FORMAT, G_CALLBACK (format_changed), cd);
         g_signal_connect (cd->settings, "changed::" KEY_SHOW_SECONDS, G_CALLBACK (show_seconds_changed), cd);
         g_signal_connect (cd->settings, "changed::" KEY_SHOW_LONGDATE, G_CALLBACK (show_longdate_changed), cd);
+        g_signal_connect (cd->settings, "changed::" KEY_SHOW_DEFAULTDATE, G_CALLBACK (show_defaultdate_changed), cd);
         g_signal_connect (cd->settings, "changed::" KEY_SHOW_SHORTDATE, G_CALLBACK (show_shortdate_changed), cd);
         g_signal_connect (cd->settings, "changed::" KEY_SHOW_DATE, G_CALLBACK (show_date_changed), cd);
         g_signal_connect (cd->settings, "changed::" KEY_SHOW_WEATHER, G_CALLBACK (show_weather_changed), cd);
@@ -2607,6 +2620,7 @@ load_gsettings (ClockData *cd)
         cd->custom_format = g_settings_get_string (cd->settings, KEY_CUSTOM_FORMAT);
         cd->showseconds = g_settings_get_boolean (cd->settings, KEY_SHOW_SECONDS);
 	cd->showlongdate = g_settings_get_boolean (cd->settings, KEY_SHOW_LONGDATE);
+	cd->showdefaultdate = g_settings_get_boolean (cd->settings, KEY_SHOW_DEFAULTDATE);
 	cd->showshortdate = g_settings_get_boolean (cd->settings, KEY_SHOW_SHORTDATE);
         cd->showdate = g_settings_get_boolean (cd->settings, KEY_SHOW_DATE);
         cd->show_weather = g_settings_get_boolean (cd->settings, KEY_SHOW_WEATHER);
@@ -3247,6 +3261,11 @@ fill_prefs_window (ClockData *cd)
 	/* Set the "Show longdate" checkbox */
 	widget = _clock_get_widget (cd, "longdate_check");
 	g_settings_bind (cd->settings, KEY_SHOW_LONGDATE, widget, "active",
+                         G_SETTINGS_BIND_DEFAULT);
+
+	/* Set the "Show defaultdate" checkbox */
+	widget = _clock_get_widget (cd, "defaultdate_check");
+	g_settings_bind (cd->settings, KEY_SHOW_DEFAULTDATE, widget, "active",
                          G_SETTINGS_BIND_DEFAULT);
 
 	/* Set the "Show shortdate" checkbox */

--- a/applets/clock/clock.ui
+++ b/applets/clock/clock.ui
@@ -574,6 +574,22 @@
                                 <property name="position">6</property>
                               </packing>
                             </child>
+                             <child>
+                              <object class="GtkRadioButton" id="defaultdate_check">
+                                <property name="label" translatable="yes">Show default format</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                                <property name="group">longdate_check</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">7</property>
+                              </packing>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/applets/clock/clock.ui
+++ b/applets/clock/clock.ui
@@ -543,6 +543,37 @@
                                 <property name="position">4</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkRadioButton" id="longdate_check">
+                                <property name="label" translatable="yes">Show longdate</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkRadioButton" id="shortdate_check">
+                                <property name="label" translatable="yes">Show shortdate</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                                <property name="group">longdate_check</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">6</property>
+                              </packing>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
+++ b/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
@@ -39,6 +39,16 @@
       <summary>Show time with seconds</summary>
       <description>If true, display seconds in time.</description>
     </key>
+    <key name="show-longdate" type="b">
+      <default>false</default>
+      <summary>Show time with seconds11</summary>
+      <description>If true, display seconds in time11.</description>
+    </key>
+    <key name="show-shortdate" type="b">
+      <default>true</default>
+      <summary>Show time with seconds22</summary>
+      <description>If true, display seconds in time22.</description>
+    </key>
     <key name="show-date" type="b">
       <default>true</default>
       <summary>Show date in clock</summary>

--- a/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
+++ b/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
@@ -53,6 +53,7 @@
       <default>true</default>
       <summary>Show default format</summary>
       <description>If true, display default date format.</description>
+    </key>
     <key name="show-date" type="b">
       <default>true</default>
       <summary>Show date in clock</summary>

--- a/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
+++ b/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
@@ -41,14 +41,18 @@
     </key>
     <key name="show-longdate" type="b">
       <default>false</default>
-      <summary>Show time with seconds11</summary>
-      <description>If true, display seconds in time11.</description>
+      <summary>Show longdate format</summary>
+      <description>If true, display longdate format.</description>
     </key>
     <key name="show-shortdate" type="b">
       <default>true</default>
-      <summary>Show time with seconds22</summary>
-      <description>If true, display seconds in time22.</description>
+      <summary>Show shortdate format</summary>
+      <description>If true, display shortdate format.</description>
     </key>
+    <key name="show-default-format" type="b">
+      <default>true</default>
+      <summary>Show default format</summary>
+      <description>If true, display default date format.</description>
     <key name="show-date" type="b">
       <default>true</default>
       <summary>Show date in clock</summary>

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -313,6 +313,10 @@ msgstr "长日期格式：YYYY年MM月DD日"
 msgid "Show shortdate"
 msgstr "短日期格式：YYYY-MM-DD"
 
+#: ../applets/clock/clock.ui.h:37
+msgid "Show default format"
+msgstr "默认日期格式"
+
 
 #: ../applets/clock/clock.ui.h:9 ../applets/fish/fish.c:853
 #: ../applets/fish/fish.ui.h:3

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -305,6 +305,15 @@ msgstr "时钟首选项"
 msgid "Time _Settings"
 msgstr "时间设置(_S)"
 
+#: ../applets/clock/clock.ui.h:35
+msgid "Show longdate"
+msgstr "长日期格式：YYYY年MM月DD日"
+
+#: ../applets/clock/clock.ui.h:36
+msgid "Show shortdate"
+msgstr "短日期格式：YYYY-MM-DD"
+
+
 #: ../applets/clock/clock.ui.h:9 ../applets/fish/fish.c:853
 #: ../applets/fish/fish.ui.h:3
 #: ../applets/notification_area/notification-area-preferences-dialog.ui.h:2


### PR DESCRIPTION
Expected behaviour

    In China, we hope that like the Windows operating system, we can set the display format of time. Therefore, I added a long/short date display format for the Chinese environment.
    Long Date Display Format:YYYY年MM月DD日
    Short Date Display Format:YYYY-MM-DD

Actual behaviour
Steps to reproduce the behaviour
MATE general version

    git master master

Package version

    git master master

Linux Distribution

    Centos7.6

Link to downstream report of your Distribution