### PR TITLE
na-tray: increase min_icon_size value

### DIFF
--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -191,7 +191,7 @@ ensure_prefs_window_is_created (NaTrayApplet *applet)
   applet->priv->dialog->min_icon_size_spin = GTK_WIDGET (gtk_builder_get_object (applet->priv->builder, "min_icon_size_spin"));
   g_return_if_fail (applet->priv->dialog->min_icon_size_spin != NULL);
 
-  gtk_spin_button_set_range (GTK_SPIN_BUTTON (applet->priv->dialog->min_icon_size_spin), 7, 100);
+  gtk_spin_button_set_range (GTK_SPIN_BUTTON (applet->priv->dialog->min_icon_size_spin), 7, 130);
   gtk_spin_button_set_value (GTK_SPIN_BUTTON (applet->priv->dialog->min_icon_size_spin), applet->priv->min_icon_size);
 
   g_signal_connect_swapped (applet->priv->dialog->min_icon_size_spin, "value_changed",


### PR DESCRIPTION
This is better for HIDPI resolution with larger icons.
And tray- applet can be displayed in in one row with
a full-size top/bottom panel.
Please test.