### PR TITLE
Avoid double a11y description on panel toplevels

### DIFF
--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -1685,7 +1685,7 @@ static void panel_toplevel_update_description(PanelToplevel* toplevel)
 				      toplevel->priv->description);
 
 	panel_a11y_set_atk_name_desc (
-		GTK_WIDGET (toplevel->priv->panel_widget),
+		GTK_WIDGET (toplevel),
 		toplevel->priv->name ? toplevel->priv->name :
 				       toplevel->priv->description,
 		toplevel->priv->description);
@@ -4854,7 +4854,7 @@ panel_toplevel_update_name (PanelToplevel *toplevel)
 	gtk_window_set_title (GTK_WINDOW (toplevel), title);
 
 	panel_a11y_set_atk_name_desc (
-		GTK_WIDGET (toplevel->priv->panel_widget),
+		GTK_WIDGET (toplevel),
 		title, toplevel->priv->description);
 }
 


### PR DESCRIPTION
Do not set an extra a11y name and description on an internal child of the panel, because its toplevel has most of it already through setting the GTK window title.  Instead, explicitly set the a11y name and description on the toplevel directly, possibly overriding GTK's value implicitly set via `gtk_window_set_title()`, but which would be the same anyway.

This prevents e.g. a screen reader vocalizing the panel name twice when entering it, once for the toplevel and once for the internal child.
This also avoids announcing the panel again when moving from one of the hide buttons to one of the applets or launcher.

---

To test, you can:
* See in Accerciser that now the panels don't have the same name on their toplevel and its 3rd child (`0 0 0` path under it in Accerciser's parlance)
* With Orca speaking, focus a panel (<kbd>Ctrl+Alt+Tab</kbd> with Marco), and hear that the "top panel" is announced only once.  Also, with the hide buttons enabled, hear that the panel is not announced again when <kbd>Tab</kbd>bing from one of the hide buttons to one of the applets or launcher.