### PR TITLE
Clock applet: Fix string comparison

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -428,6 +428,7 @@ get_updated_timeformat (ClockData *cd)
         char       *clock_format;
         const gchar *env_language;
         const gchar *env_lc_time;
+        gboolean     use_lctime;
 
         /* Override LANGUAGE with the LC_TIME environment variable
          * This is needed for gettext to fetch our clock format
@@ -435,7 +436,9 @@ get_updated_timeformat (ClockData *cd)
          */
         env_language = g_getenv("LANGUAGE");
         env_lc_time = g_getenv("LC_TIME");
-        if (env_language != NULL && env_lc_time != NULL && env_language != env_lc_time) {
+        use_lctime = (env_language != NULL) && (env_lc_time != NULL) && (g_strcmp0 (env_language, env_lc_time) != 0);
+
+        if (use_lctime) {
             g_setenv("LANGUAGE", env_lc_time, TRUE);
         }
 
@@ -480,7 +483,7 @@ get_updated_timeformat (ClockData *cd)
         }
 
         /* Set back LANGUAGE the way it was before */
-        if (env_language != NULL && env_lc_time != NULL && env_language != env_lc_time) {
+        if (use_lctime) {
             g_setenv("LANGUAGE", env_language, TRUE);
         }
 


### PR DESCRIPTION
The clock format was fixed in https://github.com/mate-desktop/mate-panel/commit/4d20a0003798eea253fed6ea8f02cec5da6ffb2d, but it only needed fixing when LC_TIME and LANGUAGE are different.

In the code introduced by this commit `env_language != env_lc_time` doesn't properly compare the strings. It compares the pointers, and thus it always returns TRUE.

This fixes the comparison so the actual values of the strings are compared and we don't apply the format fix when we don't need to.

The comparison was also duplicated in the original code, it's factorized here into a `use_lctime` variable.

Ref: https://github.com/linuxmint/cinnamon-desktop/pull/142.