### PR TITLE
build: show warning flags on configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -370,6 +370,7 @@ echo "
         source code location:          ${srcdir}
         compiler:                      ${CC}
         cflags:                        ${CFLAGS}
+        warning flags:                 ${WARN_CFLAGS}
         Maintainer mode:               ${USE_MAINTAINER_MODE}
         Use *_DISABLE_DEPRECATED:      ${enable_deprecation_flags}
         Applets to build in-process:   ${PANEL_INPROCESS_APPLETS}


### PR DESCRIPTION
```shell
$ ./autogen.sh --enable-compile-warnings=maximum  --enable-debug
<cut>

              mate-panel 1.23.3
              =================

        prefix:                        /usr/local
        exec_prefix:                   ${prefix}
        libdir:                        ${exec_prefix}/lib
        bindir:                        ${exec_prefix}/bin
        sbindir:                       ${exec_prefix}/sbin
        sysconfdir:                    ${prefix}/etc
        localstatedir:                 ${prefix}/var
        datadir:                       ${datarootdir}
        source code location:          .
        compiler:                      gcc
        cflags:                         -g -O0
        Maintainer mode:               yes
        Use *_DISABLE_DEPRECATED:      no
        Applets to build in-process:   (none)
        Wayland support:               yes
        X11 support:                   yes
        XRandr support:                yes
        Build introspection support:   yes
        Build gtk-doc documentation:   no


Now type `make' to compile mate-panel
<cut>
```