### PR TITLE
Remove warnings: function declaration isn’t a prototype

### DIFF
--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -74,7 +74,7 @@ void panel_background_apply_css (PanelBackground *background, GtkWidget *widget)
 }
 
 static void
-panel_background_prepare_css ()
+panel_background_prepare_css (void)
 {
 	GtkCssProvider      *provider;
 

--- a/mate-panel/panel-layout.c
+++ b/mate-panel/panel-layout.c
@@ -94,7 +94,7 @@ static PanelLayoutKeyDefinition panel_layout_object_keys[] = {
  * distributions
  */
 static gchar *
-panel_layout_filename ()
+panel_layout_filename (void)
 {
     GSettings *settings;
     gchar *layout;


### PR DESCRIPTION
```
panel-background.c:77:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   77 | panel_background_prepare_css ()
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

panel-layout.c:97:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   97 | panel_layout_filename ()
      | ^~~~~~~~~~~~~~~~~~~~~
```