### PR TITLE
button-widget: Fix memory leak

### DIFF
--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -111,6 +111,7 @@ make_hc_surface (cairo_surface_t *surface)
 	cr = cairo_create (new);
 	cairo_set_operator (cr, CAIRO_OPERATOR_DEST_IN);
 	cairo_mask_surface (cr, surface, 0, 0);
+	cairo_destroy (cr);
 
 	return new;
 }


### PR DESCRIPTION
Test: hover color mask on buttons panel.
```
Indirect leak of 4320 byte(s) in 3 object(s) allocated from:
    #0 0x7f0dae0e6c58 in __interceptor_malloc (/lib64/libasan.so.5+0x10dc58)
    #1 0x7f0dad440fff  (/lib64/libcairo.so.2+0x2afff)
    #2 0x4378ed in button_widget_reload_surface /home/robert/sanitizer/mate-panel/mate-panel/button-widget.c:195
    #3 0x439cb0 in button_widget_size_allocate /home/robert/sanitizer/mate-panel/mate-panel/button-widget.c:529
    #4 0x7f0dad162647 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x13647)
```