### PR TITLE
drawer: Fix heap-use-after-free

### DIFF
--- a/mate-panel/drawer.h
+++ b/mate-panel/drawer.h
@@ -7,6 +7,7 @@
 extern "C" {
 #endif
 
+#define HANDLERS 3
 
 typedef struct {
     char          *tooltip;
@@ -16,6 +17,8 @@ typedef struct {
 
     gboolean       opened_for_drag;
     guint          close_timeout_id;
+
+    gint handler_id[HANDLERS];
 
     AppletInfo    *info;
 } Drawer;


### PR DESCRIPTION
```
==721283==ERROR: AddressSanitizer: heap-use-after-free on address 0x6040001188e0 at pc 0x000000447f07 bp 0x7fff98abb9a0 sp 0x7fff98abb990
WRITE of size 8 at 0x6040001188e0 thread T0
Window manager warning: CurrentTime used to choose focus window; focus window may not be correct.
Window manager warning: Got a request to focus the no_focus_window with a timestamp of 0.  This shouldn't happen!
    #0 0x447f06 in toplevel_destroyed /home/robert/sanitizer/mate-panel/mate-panel/drawer.c:347
    #1 0x7f6f10b90741 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x13741)
    #2 0x7f6f10ba4603  (/lib64/libgobject-2.0.so.0+0x27603)
    #3 0x7f6f10bad3ad in g_signal_emit_valist (/lib64/libgobject-2.0.so.0+0x303ad)
    #4 0x7f6f10bad9d2 in g_signal_emit (/lib64/libgobject-2.0.so.0+0x309d2)
    #5 0x7f6f1159743f  (/lib64/libgtk-3.so.0+0x39c43f)
    #6 0x7f6f115aad0b  (/lib64/libgtk-3.so.0+0x3afd0b)
    #7 0x49d5c0 in panel_toplevel_dispose /home/robert/sanitizer/mate-panel/mate-panel/panel-toplevel.c:3130
    #8 0x7f6f10b97485 in g_object_run_dispose (/lib64/libgobject-2.0.so.0+0x1a485)
    #9 0x46af80 in panel_shell_quit /home/robert/sanitizer/mate-panel/mate-panel/panel-shell.c:160
    #10 0x43c10d in panel_session_handle_quit /home/robert/sanitizer/mate-panel/mate-panel/panel-session.c:42
    #11 0x7f6f10b90741 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x13741)
    #12 0x7f6f10ba4603  (/lib64/libgobject-2.0.so.0+0x27603)
    #13 0x7f6f10bad3ad in g_signal_emit_valist (/lib64/libgobject-2.0.so.0+0x303ad)
    #14 0x7f6f10bad9d2 in g_signal_emit (/lib64/libgobject-2.0.so.0+0x309d2)
    #15 0x4e464b in egg_sm_client_quit /home/robert/sanitizer/mate-panel/mate-panel/libegg/eggsmclient.c:575
    #16 0x4e816f in xsmp_die /home/robert/sanitizer/mate-panel/mate-panel/libegg/eggsmclient-xsmp.c:964
    #17 0x7f6f119e30b8 in _SmcProcessMessage (/lib64/libSM.so.6+0x50b8)
    #18 0x7f6f119faf55 in IceProcessMessages (/lib64/libICE.so.6+0x11f55)
    #19 0x4e99ed in process_ice_messages /home/robert/sanitizer/mate-panel/mate-panel/libegg/eggsmclient-xsmp.c:1289
    #20 0x4e9a7e in ice_iochannel_watch /home/robert/sanitizer/mate-panel/mate-panel/libegg/eggsmclient-xsmp.c:1313
    #21 0x7f6f10aa651f in g_main_context_dispatch (/lib64/libglib-2.0.so.0+0x5151f)
    #22 0x7f6f10aa68af  (/lib64/libglib-2.0.so.0+0x518af)
    #23 0x7f6f10aa6ba2 in g_main_loop_run (/lib64/libglib-2.0.so.0+0x51ba2)
    #24 0x7f6f1144a3bc in gtk_main (/lib64/libgtk-3.so.0+0x24f3bc)
    #25 0x424a3a in main /home/robert/sanitizer/mate-panel/mate-panel/main.c:227
    #26 0x7f6f105e31a2 in __libc_start_main (/lib64/libc.so.6+0x271a2)
    #27 0x4239bd in _start (/usr/bin/mate-panel+0x4239bd)
```