### PR TITLE
notification_area: Add do-not-disturb toggle menu item

### DIFF
--- a/applets/notification_area/notification-area-menu.xml
+++ b/applets/notification_area/notification-area-menu.xml
@@ -1,4 +1,4 @@
 <menuitem name="Notification Area Preferences Item" action="SystemTrayPreferences" />
 <menuitem name="Notification Area Help Item" action="SystemTrayHelp" />
 <menuitem name="Notification Area About Item" action="SystemTrayAbout" />
-
+<menuitem name="Notification Area do-not-disturb Item" action="SystemTrayDoNotDisturb" />


### PR DESCRIPTION
closes https://github.com/mate-desktop/mate-notification-daemon/issues/166

![VirtualBox_11 Fedora Rawhide_16_03_2020_15_35_33](https://user-images.githubusercontent.com/10171411/76768809-d4712c80-679b-11ea-8a1b-4b610f3c3c7d.png)
