### PR TITLE
fix release tarballs on travis CI failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ services:
 addons:
   apt:
     packages:
-      - python3-github
+      - python3-pip
+      - python3-setuptools
 
 branches:
   except:
@@ -19,6 +20,7 @@ before_install:
   - chmod +x docker-build gen-index
 
 install:
+  - pip3 install PyGithub
   - ./docker-build --name ${DISTRO} --config .build.yml --install
 
 script:


### PR DESCRIPTION
We need pygithub-1.43.8+ to release tarballs into github release page and mate release server, but python3-github on ubuntu 18.04(Travis CI) is 1.26.0, so we must use pip to install the latest version of pygithub.