### PR TITLE
panel-util: avoid X11-specific header

### DIFF
--- a/mate-panel/panel-util.c
+++ b/mate-panel/panel-util.c
@@ -28,7 +28,7 @@
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdkx.h>
+#include <gdk/gdk.h>
 
 #define MATE_DESKTOP_USE_UNSTABLE_API
 #include <libmate-desktop/mate-desktop-utils.h>


### PR DESCRIPTION
When building with `--disable-x11` (Wayland-only) one X11-related header appears to be included outside of `#ifdef HAVE_X11`. However, Gtk+ 3 only installs the header if built with `--enable-x11-backend`.