### PR TITLE
clock: assignment to 'GSList *' from incompatible pointer type 'GList *'

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1177,8 +1177,8 @@ create_cities_section (ClockData *cd)
         }
 
         /* Copy the existing list, so we can sort it nondestructively */
-        node = g_list_copy (cities);
-        node = g_list_sort (node, sort_locations_by_time_reverse_and_name);
+        node = g_slist_copy (cities);
+        node = g_slist_sort (node, sort_locations_by_time_reverse_and_name);
 
         for (l = node; l; l = g_slist_next (l)) {
                 ClockLocation *loc = l->data;


### PR DESCRIPTION
```
clock.c:1180:14: warning: assignment to 'GSList *' {aka 'struct _GSList *'} from incompatible pointer type 'GList *' {aka 'struct _GList *'} [-Wincompatible-pointer-types]
 1180 |         node = g_list_copy (cities);
      |              ^
clock.c:1181:29: warning: passing argument 1 of 'g_list_sort' from incompatible pointer type [-Wincompatible-pointer-types]
 1181 |         node = g_list_sort (node, sort_locations_by_time_reverse_and_name);
      |                             ^~~~
      |                             |
      |                             GSList * {aka struct _GSList *}
```