### PR TITLE
clock-utils: avoid deprecated 'rsvg_handle_free'

### DIFF
--- a/applets/clock/clock-utils.c
+++ b/applets/clock/clock-utils.c
@@ -168,7 +168,7 @@ clock_utils_pixbuf_from_svg_resource_at_size (const char *resource,
 out:
 	if (handle) {
 		rsvg_handle_close (handle, NULL);
-		rsvg_handle_free (handle);
+		g_object_unref (handle);
 	}
 	if (stream)
 		g_object_unref (stream);


### PR DESCRIPTION
Fixes the warning:
```
clock-utils.c:171:3: warning: 'rsvg_handle_free' is deprecated: Use 'g_object_unref' instead [-Wdeprecated-declarations]
                rsvg_handle_free (handle);
                ^
```