### PR TITLE
panel-toplevel: Fix -Wenum-conversion warning

### DIFF
--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -5063,7 +5063,7 @@ panel_toplevel_set_orientation (PanelToplevel    *toplevel,
 PanelOrientation
 panel_toplevel_get_orientation (PanelToplevel *toplevel)
 {
-	g_return_val_if_fail (PANEL_IS_TOPLEVEL (toplevel), GTK_ORIENTATION_HORIZONTAL);
+	g_return_val_if_fail (PANEL_IS_TOPLEVEL (toplevel), PANEL_ORIENTATION_TOP);
 
 	return toplevel->priv->orientation;
 }


### PR DESCRIPTION
```
panel-toplevel.c: In function 'panel_toplevel_get_orientation':
/usr/include/glib-2.0/glib/gmessages.h:644:16: warning: implicit conversion from 'enum <anonymous>' to 'PanelOrientation' [-Wenum-conversion]
  644 |         return (val); \
      |                ^
panel-toplevel.c:5066:2: note: in expansion of macro 'g_return_val_if_fail'
 5066 |  g_return_val_if_fail (PANEL_IS_TOPLEVEL (toplevel), GTK_ORIENTATION_HORIZONTAL);
      |  ^~~~~~~~~~~~~~~~~~~~
```