### PR TITLE
Remove variableScope warnings reported by cppcheck

### DIFF
--- a/applets/clock/calendar-window.c
+++ b/applets/clock/calendar-window.c
@@ -181,7 +181,6 @@ create_hig_frame (CalendarWindow *calwin,
                   GCallback   callback)
 {
         GtkWidget *vbox;
-        GtkWidget *label;
         GtkWidget *hbox;
         char      *bold_title;
         GtkWidget *expander;
@@ -211,9 +210,10 @@ create_hig_frame (CalendarWindow *calwin,
 	g_signal_connect (hbox, "add", G_CALLBACK (add_child), expander);
 
         if (button_label) {
+                GtkWidget *label;
                 GtkWidget *button_box;
                 GtkWidget *button;
-                gchar *text;
+                gchar     *text;
 
                 button_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
                 gtk_widget_show (button_box);

--- a/applets/clock/clock-location-tile.c
+++ b/applets/clock/clock-location-tile.c
@@ -173,14 +173,12 @@ press_on_tile      (GtkWidget             *widget,
 static void
 make_current_cb (gpointer data, GError *error)
 {
-        GtkWidget *dialog;
-
         if (error) {
-                dialog = gtk_message_dialog_new (NULL,
-                                                 0,
-                                                 GTK_MESSAGE_ERROR,
-                                                 GTK_BUTTONS_CLOSE,
-                                                 _("Failed to set the system timezone"));
+                GtkWidget *dialog = gtk_message_dialog_new (NULL,
+                                                            0,
+                                                            GTK_MESSAGE_ERROR,
+                                                            GTK_BUTTONS_CLOSE,
+                                                            _("Failed to set the system timezone"));
                 gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog), "%s", error->message);
                 g_signal_connect (dialog, "response",
                                   G_CALLBACK (gtk_widget_destroy), NULL);

--- a/applets/clock/clock-location.c
+++ b/applets/clock/clock-location.c
@@ -76,10 +76,11 @@ clock_location_find_and_ref (GSList       *locations,
                              const gchar *code)
 {
         GSList *l;
-        ClockLocationPrivate *priv;
 
         for (l = locations; l != NULL; l = l->next) {
-                priv = clock_location_get_instance_private (l->data);
+
+                ClockLocationPrivate *priv =
+                        clock_location_get_instance_private (l->data);
 
                 if (priv->latitude == latitude &&
                     priv->longitude == longitude &&

--- a/applets/clock/clock-map.c
+++ b/applets/clock/clock-map.c
@@ -430,7 +430,6 @@ clock_map_place_locations (ClockMap *this)
 {
         ClockMapPrivate *priv = clock_map_get_instance_private (this);
         GSList *locs;
-        ClockLocation *loc;
 
         if (priv->location_map_pixbuf) {
                 g_object_unref (priv->location_map_pixbuf);
@@ -443,10 +442,8 @@ clock_map_place_locations (ClockMap *this)
 	g_signal_emit (this, signals[NEED_LOCATIONS], 0, &locs);
 
         while (locs) {
-                loc = CLOCK_LOCATION (locs->data);
-
+                ClockLocation *loc = CLOCK_LOCATION (locs->data);
                 clock_map_place_location (this, loc, FALSE);
-
                 locs = locs->next;
         }
 

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -424,7 +424,6 @@ get_updated_timeformat (ClockData *cd)
   */
         char       *result;
         const char *time_format;
-        const char *date_format;
         char       *clock_format;
         const gchar *env_language;
         const gchar *env_lc_time;
@@ -462,7 +461,7 @@ get_updated_timeformat (ClockData *cd)
                  * the day of the month as a decimal number is a single digit,
                  * it should begin with a 0 in your locale (e.g. "May 01"
                  * instead of "May  1"). */
-                date_format = _("%a %b %e");
+                const char *date_format = _("%a %b %e");
 
                 if (use_two_line_format (cd))
                         /* translators: reverse the order of these arguments
@@ -1152,7 +1151,6 @@ static void
 create_cities_section (ClockData *cd)
 {
         GSList *node;
-        ClockLocationTile *city;
         GSList *cities;
         GSList *l;
 
@@ -1182,8 +1180,7 @@ create_cities_section (ClockData *cd)
 
         for (l = node; l; l = g_slist_next (l)) {
                 ClockLocation *loc = l->data;
-
-                city = clock_location_tile_new (loc, CLOCK_FACE_SMALL);
+                ClockLocationTile *city = clock_location_tile_new (loc, CLOCK_FACE_SMALL);
                 g_signal_connect (city, "tile-pressed",
                                   G_CALLBACK (location_tile_pressed_cb), cd);
                 g_signal_connect (city, "need-clock-format",
@@ -1700,14 +1697,13 @@ static void
 set_time_callback (ClockData *cd, GError *error)
 {
         GtkWidget *window;
-        GtkWidget *dialog;
 
         if (error) {
-                dialog = gtk_message_dialog_new (NULL,
-                                                 0,
-                                                 GTK_MESSAGE_ERROR,
-                                                 GTK_BUTTONS_CLOSE,
-                                                 _("Failed to set the system time"));
+                GtkWidget *dialog = gtk_message_dialog_new (NULL,
+                                                            0,
+                                                            GTK_MESSAGE_ERROR,
+                                                            GTK_BUTTONS_CLOSE,
+                                                            _("Failed to set the system time"));
 
                 gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog), "%s", error->message);
                 g_signal_connect (dialog, "response",
@@ -2132,7 +2128,6 @@ static void
 locations_changed (ClockData *cd)
 {
         GSList *l;
-        ClockLocation *loc;
         glong id;
 
         if (!cd->locations) {
@@ -2150,7 +2145,7 @@ locations_changed (ClockData *cd)
         }
 
         for (l = cd->locations; l; l = l->next) {
-                loc = l->data;
+                ClockLocation *loc = l->data;
 
                 id = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (loc), "weather-updated"));
                 if (id == 0) {

--- a/applets/clock/system-timezone.c
+++ b/applets/clock/system-timezone.c
@@ -854,11 +854,10 @@ system_timezone_is_valid (const char *tz)
 static char *
 system_timezone_find (void)
 {
-        char *tz;
-        int   i;
+        int i;
 
         for (i = 0; get_system_timezone_methods[i] != NULL; i++) {
-                tz = get_system_timezone_methods[i] ();
+                char *tz = get_system_timezone_methods[i] ();
 
                 if (system_timezone_is_valid (tz))
                         return tz;

--- a/applets/fish/fish.c
+++ b/applets/fish/fish.c
@@ -261,7 +261,6 @@ static void command_value_changed(GtkEntry* entry, FishApplet *fish)
 	    !strcmp  (text, "uptime")  ||
 	    !strncmp (text, "tail ", 5)) {
 		static gboolean message_given = FALSE;
-		char       *message;
 		const char *warning_format =
 				_("Warning:  The command "
 				  "appears to be something actually useful.\n"
@@ -272,13 +271,10 @@ static void command_value_changed(GtkEntry* entry, FishApplet *fish)
 				   "which would make the applet "
 				   "\"practical\" or useful.");
 
-		if ( ! message_given) {
-			message = g_strdup_printf (warning_format, fish->name);
-
+		if (!message_given) {
+			char *message = g_strdup_printf (warning_format, fish->name);
 			something_fishy_going_on (fish, message);
-
 			g_free (message);
-
 			message_given = TRUE;
 		}
 	}
@@ -729,7 +725,6 @@ static void clear_fortune_text(FishApplet* fish)
 static gboolean fish_read_output(GIOChannel* source, GIOCondition condition, gpointer data)
 {
 	char        output[4096];
-	char       *utf8_output;
 	gsize       bytes_read;
 	GError     *error = NULL;
 	GIOStatus   status;
@@ -763,6 +758,8 @@ static gboolean fish_read_output(GIOChannel* source, GIOCondition condition, gpo
 		return TRUE;
 
 	if (bytes_read > 0) {
+		char *utf8_output;
+
 		/* The output is not guarantied to be in UTF-8 format, most
 		 * likely it's just in ASCII-7 or in the user locale
 		 */

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -742,12 +742,11 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 
 static void call_system_monitor(GtkAction* action, TasklistData* tasklist)
 {
-	char *programpath;
 	int i;
 
 	for (i = 0; i < G_N_ELEMENTS(system_monitors); i += 1)
 	{
-		programpath = g_find_program_in_path(system_monitors[i]);
+		char *programpath = g_find_program_in_path(system_monitors[i]);
 
 		if (programpath != NULL)
 		{

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -673,14 +673,13 @@ static void num_rows_value_changed(GtkSpinButton* button, PagerData* pager)
 
 static void update_workspaces_model(PagerData* pager)
 {
-	int nr_ws, i;
-	WnckWorkspace* workspace;
-	GtkTreeIter iter;
-
-	nr_ws = wnck_screen_get_workspace_count(pager->screen);
+	int nr_ws = wnck_screen_get_workspace_count (pager->screen);
 
 	if (pager->properties_dialog)
 	{
+		int i;
+		GtkTreeIter iter;
+
 		if (nr_ws != gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(pager->num_workspaces_spin)))
 			gtk_spin_button_set_value(GTK_SPIN_BUTTON(pager->num_workspaces_spin), nr_ws);
 
@@ -688,7 +687,7 @@ static void update_workspaces_model(PagerData* pager)
 
 		for (i = 0; i < nr_ws; i++)
 		{
-			workspace = wnck_screen_get_workspace(pager->screen, i);
+			WnckWorkspace *workspace = wnck_screen_get_workspace(pager->screen, i);
 			gtk_list_store_append(pager->workspaces_store, &iter);
 			gtk_list_store_set(pager->workspaces_store, &iter, 0, wnck_workspace_get_name(workspace), -1);
 		}
@@ -697,12 +696,9 @@ static void update_workspaces_model(PagerData* pager)
 
 static void workspace_renamed(WnckWorkspace* space, PagerData* pager)
 {
-	int i;
 	GtkTreeIter iter;
 
-	i = wnck_workspace_get_number(space);
-
-	if (gtk_tree_model_iter_nth_child(GTK_TREE_MODEL(pager->workspaces_store), &iter, NULL, i))
+	if (gtk_tree_model_iter_nth_child (GTK_TREE_MODEL (pager->workspaces_store), &iter, NULL, wnck_workspace_get_number (space)))
 		gtk_list_store_set(pager->workspaces_store, &iter, 0, wnck_workspace_get_name(space), -1);
 }
 

--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -814,7 +814,6 @@ mate_panel_applet_finalize (GObject *object)
 static gboolean
 container_has_focusable_child (GtkContainer *container)
 {
-	GtkWidget *child;
 	GList *list;
 	GList *t;
 	gboolean retval = FALSE;
@@ -822,7 +821,7 @@ container_has_focusable_child (GtkContainer *container)
 	list = gtk_container_get_children (container);
 
 	for (t = list; t; t = t->next) {
-		child = GTK_WIDGET (t->data);
+		GtkWidget *child = GTK_WIDGET (t->data);
 		if (gtk_widget_get_can_focus (child)) {
 			retval = TRUE;
 			break;
@@ -1084,19 +1083,16 @@ mate_panel_applet_size_allocate (GtkWidget     *widget,
 			    GtkAllocation *allocation)
 {
 	GtkAllocation  child_allocation;
-	GtkBin        *bin;
-	GtkWidget     *child;
-	int            border_width;
 	MatePanelApplet   *applet;
 
 	if (!mate_panel_applet_can_focus (widget)) {
 		GTK_WIDGET_CLASS (mate_panel_applet_parent_class)->size_allocate (widget, allocation);
 	} else {
 
-		border_width = gtk_container_get_border_width (GTK_CONTAINER (widget));
+		int border_width = gtk_container_get_border_width (GTK_CONTAINER (widget));
 
 		gtk_widget_set_allocation (widget, allocation);
-		bin = GTK_BIN (widget);
+		GtkBin *bin = GTK_BIN (widget);
 
 		child_allocation.x = 0;
 		child_allocation.y = 0;
@@ -1111,7 +1107,7 @@ mate_panel_applet_size_allocate (GtkWidget     *widget,
 						child_allocation.width,
 						child_allocation.height);
 
-		child = gtk_bin_get_child (bin);
+		GtkWidget *child = gtk_bin_get_child (bin);
 		if (child)
 			gtk_widget_size_allocate (child, &child_allocation);
 	}
@@ -1515,8 +1511,7 @@ mate_panel_applet_change_background(MatePanelApplet *applet,
 				    GdkRGBA* color,
 				    cairo_pattern_t *pattern)
 {
-	GtkStyleContext* context;
-	GdkWindow* window;
+	GdkWindow *window;
 
 	if (applet->priv->out_of_process)
 		window = gtk_widget_get_window (GTK_WIDGET (applet->priv->plug));
@@ -1553,7 +1548,9 @@ mate_panel_applet_change_background(MatePanelApplet *applet,
 	}
 
 	if (applet->priv->out_of_process){
-		context = gtk_widget_get_style_context (GTK_WIDGET(applet->priv->plug));
+		GtkStyleContext *context =
+			gtk_widget_get_style_context (GTK_WIDGET(applet->priv->plug));
+
 		if (applet->priv->orient == MATE_PANEL_APPLET_ORIENT_UP ||
 			applet->priv->orient == MATE_PANEL_APPLET_ORIENT_DOWN){
 			gtk_style_context_add_class(context,"horizontal");
@@ -2085,16 +2082,15 @@ button_press_event_new (MatePanelApplet *applet,
 
 static void
 method_call_cb (GDBusConnection       *connection,
-		const gchar           *sender,
-		const gchar           *object_path,
-		const gchar           *interface_name,
-		const gchar           *method_name,
-		GVariant              *parameters,
-		GDBusMethodInvocation *invocation,
-		gpointer               user_data)
+                const gchar           *sender,
+                const gchar           *object_path,
+                const gchar           *interface_name,
+                const gchar           *method_name,
+                GVariant              *parameters,
+                GDBusMethodInvocation *invocation,
+                gpointer               user_data)
 {
 	MatePanelApplet *applet = MATE_PANEL_APPLET (user_data);
-	GdkEvent *event;
 
 	if (g_strcmp0 (method_name, "PopupMenu") == 0) {
 		guint button;
@@ -2102,7 +2098,7 @@ method_call_cb (GDBusConnection       *connection,
 
 		g_variant_get (parameters, "(uu)", &button, &time);
 
-		event = button_press_event_new (applet, button, time);
+		GdkEvent *event = button_press_event_new (applet, button, time);
 		mate_panel_applet_menu_popup (applet, event);
 		gdk_event_free (event);
 

--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -60,8 +60,6 @@ do_colorshift (cairo_surface_t *dest, cairo_surface_t *src, int shift)
 	gint width, height, has_alpha, srcrowstride, destrowstride;
 	guchar *target_pixels;
 	guchar *original_pixels;
-	guchar *pixsrc;
-	guchar *pixdest;
 	int val;
 	guchar r,g,b;
 
@@ -74,8 +72,8 @@ do_colorshift (cairo_surface_t *dest, cairo_surface_t *src, int shift)
 	target_pixels = cairo_image_surface_get_data (dest);
 
 	for (i = 0; i < height; i++) {
-		pixdest = target_pixels + i*destrowstride;
-		pixsrc = original_pixels + i*srcrowstride;
+		guchar *pixdest = target_pixels + i*destrowstride;
+		guchar *pixsrc = original_pixels + i*srcrowstride;
 		for (j = 0; j < width; j++) {
 			r = *(pixsrc++);
 			g = *(pixsrc++);

--- a/mate-panel/drawer.c
+++ b/mate-panel/drawer.c
@@ -727,12 +727,8 @@ panel_drawer_set_dnd_enabled (Drawer   *drawer,
 void
 drawer_query_deletion (Drawer *drawer)
 {
-    GtkWidget *dialog;
-
      if (drawer->toplevel) {
-        PanelWidget *panel_widget;
-
-        panel_widget = panel_toplevel_get_panel_widget (drawer->toplevel);
+        PanelWidget *panel_widget = panel_toplevel_get_panel_widget (drawer->toplevel);
 
         if (!panel_global_config_get_confirm_panel_remove () ||
             !g_list_length (panel_widget->applet_list)) {
@@ -740,7 +736,7 @@ drawer_query_deletion (Drawer *drawer)
                 return;
         }
 
-        dialog = panel_deletion_dialog (drawer->toplevel);
+        GtkWidget *dialog = panel_deletion_dialog (drawer->toplevel);
 
         g_signal_connect (dialog, "response", G_CALLBACK (drawer_deletion_response), drawer);
 

--- a/mate-panel/launcher.c
+++ b/mate-panel/launcher.c
@@ -663,15 +663,12 @@ static char *
 panel_launcher_find_writable_uri (const char *launcher_location,
 				  const char *source)
 {
-	char *path;
-	char *uri;
-
 	if (!launcher_location)
 		return panel_make_unique_desktop_uri (NULL, source);
 
 	if (!strchr (launcher_location, G_DIR_SEPARATOR)) {
-		path = panel_make_full_path (NULL, launcher_location);
-		uri = g_filename_to_uri (path, NULL, NULL);
+		char *path = panel_make_full_path (NULL, launcher_location);
+		char *uri  = g_filename_to_uri (path, NULL, NULL);
 		g_free (path);
 		return uri;
 	}
@@ -701,18 +698,13 @@ launcher_changed (PanelDItemEditor *dialog,
 
 static void
 launcher_command_changed (PanelDItemEditor *dialog,
-			  const char       *command,
-			  Launcher         *launcher)
+                          const char       *command,
+                          Launcher         *launcher)
 {
-	char     *exec;
-	char     *old_exec;
-	GKeyFile *revert_key_file;
-
-	revert_key_file = panel_ditem_editor_get_revert_key_file (dialog);
-
+	GKeyFile *revert_key_file = panel_ditem_editor_get_revert_key_file (dialog);
 	if (revert_key_file) {
-		exec = panel_key_file_get_string (launcher->key_file, "Exec");
-		old_exec = panel_key_file_get_string (revert_key_file, "Exec");
+		char *exec = panel_key_file_get_string (launcher->key_file, "Exec");
+		char *old_exec = panel_key_file_get_string (revert_key_file, "Exec");
 
 		if (!old_exec || !exec || strcmp (old_exec, exec))
 			panel_key_file_remove_key (launcher->key_file,
@@ -1163,8 +1155,6 @@ void
 panel_launcher_set_dnd_enabled (Launcher *launcher,
 				gboolean  dnd_enabled)
 {
-	cairo_surface_t *surface;
-
 	if (dnd_enabled) {
 		static GtkTargetEntry dnd_targets[] = {
 			{ "application/x-panel-icon-internal", 0, TARGET_ICON_INTERNAL },
@@ -1176,7 +1166,7 @@ panel_launcher_set_dnd_enabled (Launcher *launcher,
 				     GDK_BUTTON1_MASK,
 				     dnd_targets, 2,
 				     GDK_ACTION_COPY | GDK_ACTION_MOVE);
-		surface = button_widget_get_surface (BUTTON_WIDGET (launcher->button));
+		cairo_surface_t *surface = button_widget_get_surface (BUTTON_WIDGET (launcher->button));
 		if (surface) {
 			GdkPixbuf *pixbuf;
 			pixbuf = gdk_pixbuf_get_from_surface (surface,

--- a/mate-panel/libpanel-util/panel-cleanup.c
+++ b/mate-panel/libpanel-util/panel-cleanup.c
@@ -74,7 +74,6 @@ panel_cleanup_unregister (PanelCleanFunc func,
 			  gpointer       data)
 {
 	GSList *l, *next;
-	PanelClean *clean;
 
 	g_return_if_fail (func != NULL);
 
@@ -86,7 +85,7 @@ panel_cleanup_unregister (PanelCleanFunc func,
 	do {
 		next = l->next;
 
-		clean = l->data;
+		PanelClean *clean = l->data;
 		if (clean->func == func && clean->data == data) {
 			g_slice_free (PanelClean, clean);
 			cleaner = g_slist_delete_link (cleaner, l);

--- a/mate-panel/libpanel-util/panel-keyfile.c
+++ b/mate-panel/libpanel-util/panel-keyfile.c
@@ -341,18 +341,15 @@ panel_key_file_remove_all_locale_key (GKeyFile    *keyfile,
 
 void
 panel_key_file_ensure_C_key (GKeyFile   *keyfile,
-			     const char *key)
+                             const char *key)
 {
-	char *C_value;
-	char *buffer;
-
 	/* Make sure we set the "C" locale strings to the terms we set here.
 	 * This is so that if the user logs into another locale they get their
 	 * own description there rather then empty. It is not the C locale
 	 * however, but the user created this entry herself so it's OK */
-	C_value = panel_key_file_get_string (keyfile, key);
+	char *C_value = panel_key_file_get_string (keyfile, key);
 	if (C_value == NULL || C_value [0] == '\0') {
-		buffer = panel_key_file_get_locale_string (keyfile, key);
+		char *buffer = panel_key_file_get_locale_string (keyfile, key);
 		if (buffer) {
 			panel_key_file_set_string (keyfile, key, buffer);
 			g_free (buffer);

--- a/mate-panel/menu.c
+++ b/mate-panel/menu.c
@@ -61,10 +61,9 @@ static gboolean panel_menu_key_press_handler (GtkWidget   *widget,
 static inline gboolean desktop_is_home_dir(void)
 {
 	gboolean retval = FALSE;
-	GSettings *settings;
 
 	if (mate_gsettings_schema_exists (CAJA_PREFS_SCHEMA)) {
-		settings = g_settings_new (CAJA_PREFS_SCHEMA);
+		GSettings *settings = g_settings_new (CAJA_PREFS_SCHEMA);
 		retval = g_settings_get_boolean (settings, CAJA_PREFS_DESKTOP_IS_HOME_DIR_KEY);
 		g_object_unref (settings);
 	}
@@ -855,31 +854,31 @@ setup_internal_applet_drag (GtkWidget             *menuitem,
 static void
 submenu_to_display (GtkWidget *menu)
 {
-	MateMenuTree           *tree;
-	MateMenuTreeDirectory  *directory;
-	const char          *menu_path;
-	void               (*append_callback) (GtkWidget *, gpointer);
-	gpointer             append_data;
+	void      (*append_callback) (GtkWidget *, gpointer);
+	gpointer  append_data;
 
 	if (!g_object_get_data (G_OBJECT (menu), "panel-menu-needs-loading"))
 		return;
 
 	g_object_set_data (G_OBJECT (menu), "panel-menu-needs-loading", NULL);
 
-	directory = g_object_get_data (G_OBJECT (menu),
-				       "panel-menu-tree-directory");
+	MateMenuTreeDirectory *directory =
+		g_object_get_data (G_OBJECT (menu),
+		                   "panel-menu-tree-directory");
 	if (!directory) {
-		menu_path = g_object_get_data (G_OBJECT (menu),
-					       "panel-menu-tree-path");
+		const char *menu_path =
+			g_object_get_data (G_OBJECT (menu),
+		                           "panel-menu-tree-path");
 		if (!menu_path)
 			return;
 
-		tree = g_object_get_data (G_OBJECT (menu), "panel-menu-tree");
+		MateMenuTree *tree =
+			g_object_get_data (G_OBJECT (menu),
+			                   "panel-menu-tree");
 		if (!tree)
 			return;
 
-		directory = matemenu_tree_get_directory_from_path (tree,
-								menu_path);
+		directory = matemenu_tree_get_directory_from_path (tree, menu_path);
 
 		g_object_set_data_full (G_OBJECT (menu),
 					"panel-menu-tree-directory",

--- a/mate-panel/panel-addto.c
+++ b/mate-panel/panel-addto.c
@@ -449,7 +449,6 @@ panel_addto_append_item (PanelAddtoDialog *dialog,
 			 GtkListStore *model,
 			 PanelAddtoItemInfo *applet)
 {
-	char *text;
 	GtkTreeIter iter;
 
 	if (applet == NULL) {
@@ -464,8 +463,8 @@ panel_addto_append_item (PanelAddtoDialog *dialog,
 	} else {
 		gtk_list_store_append (model, &iter);
 
-		text = panel_addto_make_text (applet->name,
-					      applet->description);
+		char *text = panel_addto_make_text (applet->name,
+		                                    applet->description);
 
 		gtk_list_store_set (model, &iter,
 				    COLUMN_ICON_NAME, applet->icon,
@@ -673,20 +672,18 @@ panel_addto_make_application_list (GSList             **parent_list,
 
 static void
 panel_addto_populate_application_model (GtkTreeStore *store,
-					GtkTreeIter  *parent,
-					GSList       *app_list)
+                                        GtkTreeIter  *parent,
+                                        GSList       *app_list)
 {
-	PanelAddtoAppList *data;
-	GtkTreeIter        iter;
-	char              *text;
-	GSList            *app;
+	GtkTreeIter  iter;
+	GSList      *app;
 
 	for (app = app_list; app != NULL; app = app->next) {
-		data = app->data;
-		gtk_tree_store_append (store, &iter, parent);
+		PanelAddtoAppList *data = app->data;
 
-		text = panel_addto_make_text (data->item_info.name,
-					      data->item_info.description);
+		gtk_tree_store_append (store, &iter, parent);
+		char *text = panel_addto_make_text (data->item_info.name,
+		                                    data->item_info.description);
 		gtk_tree_store_set (store, &iter,
 				    COLUMN_ICON_NAME, data->item_info.icon,
 				    COLUMN_TEXT, text,
@@ -831,7 +828,6 @@ panel_addto_dialog_response (GtkWidget *widget_dialog,
 {
 	GtkTreeSelection *selection;
 	GtkTreeModel     *filter_model;
-	GtkTreeModel     *child_model;
 	GtkTreeIter       iter;
 	GtkTreeIter       filter_iter;
 
@@ -850,7 +846,7 @@ panel_addto_dialog_response (GtkWidget *widget_dialog,
 			gtk_tree_model_filter_convert_iter_to_child_iter (GTK_TREE_MODEL_FILTER (filter_model),
 									  &iter,
 									  &filter_iter);
-			child_model = gtk_tree_model_filter_get_model (GTK_TREE_MODEL_FILTER (filter_model));
+			GtkTreeModel *child_model = gtk_tree_model_filter_get_model (GTK_TREE_MODEL_FILTER (filter_model));
 			gtk_tree_model_get (child_model, &iter,
 					    COLUMN_DATA, &data, -1);
 
@@ -1185,7 +1181,6 @@ panel_addto_selection_changed (GtkTreeSelection *selection,
 	GtkTreeIter         iter;
 	GtkTreeIter         filter_iter;
 	PanelAddtoItemInfo *data;
-	char               *iid;
 
 	if (!gtk_tree_selection_get_selected (selection,
 					      &filter_model,
@@ -1230,7 +1225,9 @@ panel_addto_selection_changed (GtkTreeSelection *selection,
 		case PANEL_ADDTO_LAUNCHER_MENU:
 			gtk_tree_view_unset_rows_drag_source (GTK_TREE_VIEW (dialog->tree_view));
 			break;
-		case PANEL_ADDTO_MENU:
+		case PANEL_ADDTO_MENU: {
+			char *iid;
+
 			/* build the iid for menus other than the main menu */
 			if (data->iid == NULL) {
 				iid = g_strdup_printf ("MENU:%s/%s",
@@ -1243,6 +1240,7 @@ panel_addto_selection_changed (GtkTreeSelection *selection,
 							        iid);
 			g_free (iid);
 			break;
+		}
 		default:
 			panel_addto_setup_internal_applet_drag (GTK_TREE_VIEW (dialog->tree_view),
 							        data->iid);

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -380,8 +380,6 @@ mate_panel_applet_frame_button_changed (GtkWidget      *widget,
 {
 	MatePanelAppletFrame *frame;
 	gboolean              handled = FALSE;
-	GdkDisplay *display;
-	GdkSeat *seat;
 
 	frame = MATE_PANEL_APPLET_FRAME (widget);
 
@@ -410,8 +408,8 @@ mate_panel_applet_frame_button_changed (GtkWidget      *widget,
 	case 3:
 		if (event->type == GDK_BUTTON_PRESS ||
 		    event->type == GDK_2BUTTON_PRESS) {
-			display = gtk_widget_get_display (widget);
-			seat = gdk_display_get_default_seat (display);
+			GdkDisplay *display = gtk_widget_get_display (widget);
+			GdkSeat    *seat    = gdk_display_get_default_seat (display);
 			gdk_seat_ungrab (seat);
 
 			MATE_PANEL_APPLET_FRAME_GET_CLASS (frame)->popup_menu (frame,

--- a/mate-panel/panel-applet-info.c
+++ b/mate-panel/panel-applet-info.c
@@ -38,28 +38,25 @@ struct _MatePanelAppletInfo {
 
 MatePanelAppletInfo *
 mate_panel_applet_info_new (const gchar  *iid,
-			    const gchar  *name,
-			    const gchar  *comment,
-			    const gchar  *icon,
-			    const gchar **old_ids,
-			    gboolean      x11_supported,
-			    gboolean      wayland_supported)
+                            const gchar  *name,
+                            const gchar  *comment,
+                            const gchar  *icon,
+                            const gchar **old_ids,
+                            gboolean      x11_supported,
+                            gboolean      wayland_supported)
 {
-	MatePanelAppletInfo *info;
+	MatePanelAppletInfo *info = g_slice_new0 (MatePanelAppletInfo);
 
-	info = g_slice_new0 (MatePanelAppletInfo);
-
-	info->iid = g_strdup (iid);
-	info->name = g_strdup (name);
+	info->iid     = g_strdup (iid);
+	info->name    = g_strdup (name);
 	info->comment = g_strdup (comment);
-	info->icon = g_strdup (icon);
+	info->icon    = g_strdup (icon);
 
 	/* MateComponent compatibility */
 	if (old_ids != NULL) {
-		int i, len;
-
-		len = g_strv_length ((gchar **) old_ids);
-		if (len > 0) {
+		int len;
+		if ((len = g_strv_length ((gchar **) old_ids)) > 0) {
+			int i;
 			info->old_ids = g_new0 (gchar *, len + 1);
 			for (i = 0; i < len; i++)
 				info->old_ids[i] = g_strdup (old_ids[i]);

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -110,16 +110,14 @@ panel_background_prepare (PanelBackground *background)
 			* backing region is cleared
 			* (gdk_window_clear_backing_region), the correctly
 			* scaled pattern is used */
-			cairo_matrix_t m;
 			cairo_surface_t *surface;
-			double width, height;
 
-			surface = NULL;
-			width = 1.0;
-			height = 1.0;
 			cairo_pattern_get_surface(background->default_pattern, &surface);
 			/* catch invalid images (e.g. -gtk-gradient) before scaling and rendering */
 			if (surface != NULL ){
+				double width, height;
+				cairo_matrix_t m;
+
 				cairo_surface_reference(surface);
 				width = cairo_image_surface_get_width (surface);
 				height = cairo_image_surface_get_height (surface);

--- a/mate-panel/panel-ditem-editor.c
+++ b/mate-panel/panel-ditem-editor.c
@@ -223,7 +223,6 @@ panel_ditem_editor_constructor (GType                  type,
 {
 	GObject          *obj;
 	PanelDItemEditor *dialog;
-	GFile            *file;
 	gboolean          loaded;
 	char             *desktop_type;
 
@@ -248,7 +247,7 @@ panel_ditem_editor_constructor (GType                  type,
 	}
 
 	if (!loaded && dialog->priv->uri) {
-		file = g_file_new_for_uri (dialog->priv->uri);
+		GFile *file = g_file_new_for_uri (dialog->priv->uri);
 		if (g_file_query_exists (file, NULL)) {
 			/* FIXME what if there's an error? */
 			panel_ditem_editor_load_uri (dialog, NULL);
@@ -932,25 +931,24 @@ panel_ditem_editor_icon_changed (PanelDItemEditor *dialog,
 
 static void
 command_browse_chooser_response (GtkFileChooser   *chooser,
-				 gint              response_id,
-				 PanelDItemEditor *dialog)
+                                 gint              response_id,
+                                 PanelDItemEditor *dialog)
 {
-	char *uri;
-	char *text;
-
 	if (response_id == GTK_RESPONSE_ACCEPT) {
+		char *uri;
 		switch (panel_ditem_editor_get_item_type (dialog)) {
-		case PANEL_DITEM_EDITOR_TYPE_APPLICATION:
-		case PANEL_DITEM_EDITOR_TYPE_TERMINAL_APPLICATION:
-			text = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (chooser));
-			uri = panel_util_make_exec_uri_for_desktop (text);
-			g_free (text);
-			break;
-		case PANEL_DITEM_EDITOR_TYPE_LINK:
-			uri = gtk_file_chooser_get_uri (GTK_FILE_CHOOSER (chooser));
-			break;
-		default:
-			g_assert_not_reached ();
+			case PANEL_DITEM_EDITOR_TYPE_APPLICATION:
+			case PANEL_DITEM_EDITOR_TYPE_TERMINAL_APPLICATION: {
+				char *text = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (chooser));
+				uri = panel_util_make_exec_uri_for_desktop (text);
+				g_free (text);
+				break;
+			}
+			case PANEL_DITEM_EDITOR_TYPE_LINK:
+				uri = gtk_file_chooser_get_uri (GTK_FILE_CHOOSER (chooser));
+				break;
+			default:
+				g_assert_not_reached ();
 		}
 
 		gtk_entry_set_text (GTK_ENTRY (dialog->priv->command_entry),

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -108,24 +108,27 @@ static void panel_menu_bar_setup_tooltip(PanelMenuBar* menubar)
 	g_signal_connect(GTK_MENU_SHELL (menubar), "deactivate", G_CALLBACK (panel_menu_bar_reinit_tooltip), menubar);
 }
 
-static void panel_menu_bar_update_visibility (GSettings* settings, gchar* key, PanelMenuBar* menubar)
+static void
+panel_menu_bar_update_visibility (GSettings    *settings,
+                                  gchar        *key,
+                                  PanelMenuBar *menubar)
 {
-	GtkWidget* image;
-	gchar *str;
-	GtkIconSize icon_size;
-	gint icon_height;
-
 	if (!GTK_IS_WIDGET (menubar))
 		return;
 
-	gtk_widget_set_visible (GTK_WIDGET (menubar->priv->applications_item), g_settings_get_boolean (settings, PANEL_MENU_BAR_SHOW_APPLICATIONS_KEY));
-	gtk_widget_set_visible (GTK_WIDGET (menubar->priv->places_item), g_settings_get_boolean (settings, PANEL_MENU_BAR_SHOW_PLACES_KEY));
-	gtk_widget_set_visible (GTK_WIDGET (menubar->priv->desktop_item), g_settings_get_boolean (settings, PANEL_MENU_BAR_SHOW_DESKTOP_KEY));
+	gtk_widget_set_visible (GTK_WIDGET (menubar->priv->applications_item),
+	                        g_settings_get_boolean (settings, PANEL_MENU_BAR_SHOW_APPLICATIONS_KEY));
+	gtk_widget_set_visible (GTK_WIDGET (menubar->priv->places_item),
+	                        g_settings_get_boolean (settings, PANEL_MENU_BAR_SHOW_PLACES_KEY));
+	gtk_widget_set_visible (GTK_WIDGET (menubar->priv->desktop_item),
+	                        g_settings_get_boolean (settings, PANEL_MENU_BAR_SHOW_DESKTOP_KEY));
 
-	if (g_settings_get_boolean (settings, PANEL_MENU_BAR_SHOW_ICON_KEY))
-	{
-		str = g_settings_get_string (settings, PANEL_MENU_BAR_ICON_NAME_KEY);
-		icon_size = panel_menu_bar_icon_get_size ();
+	if (g_settings_get_boolean (settings, PANEL_MENU_BAR_SHOW_ICON_KEY)) {
+		GtkWidget   *image;
+		gint         icon_height;
+		gchar       *str = g_settings_get_string (settings, PANEL_MENU_BAR_ICON_NAME_KEY);
+		GtkIconSize  icon_size = panel_menu_bar_icon_get_size ();
+
 		gtk_icon_size_lookup (icon_size, NULL, &icon_height);
 		if (str != NULL && str[0] != 0)
 			image = gtk_image_new_from_icon_name(str, icon_size);

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -721,10 +721,7 @@ panel_menu_button_load (const char  *menu_path,
 static char *
 panel_menu_button_get_icon (PanelMenuButton *button)
 {
-	MateMenuTreeDirectory *directory;
-        char               *retval;
-
-	retval = NULL;
+        char *retval = NULL;
 
 	if (button->priv->use_custom_icon &&
 	    button->priv->custom_icon)
@@ -734,9 +731,9 @@ panel_menu_button_get_icon (PanelMenuButton *button)
 	    button->priv->use_menu_path &&
 	    button->priv->menu_path     &&
 	    panel_menu_button_create_menu (button)) {
-		directory = g_object_get_data (G_OBJECT (button->priv->menu),
-					       "panel-menu-tree-directory");
-
+		MateMenuTreeDirectory *directory =
+			g_object_get_data (G_OBJECT (button->priv->menu),
+					   "panel-menu-tree-directory");
 		if (!directory) {
 			MateMenuTree *tree;
 

--- a/mate-panel/panel-modules.c
+++ b/mate-panel/panel-modules.c
@@ -34,12 +34,10 @@ static void
 panel_modules_ensure_extension_points_registered (void)
 {
 	static gboolean registered_extensions = FALSE;
-	GIOExtensionPoint *ep;
 
 	if (!registered_extensions) {
 		registered_extensions = TRUE;
-
-		ep = g_io_extension_point_register (MATE_PANEL_APPLETS_MANAGER_EXTENSION_POINT_NAME);
+		GIOExtensionPoint *ep = g_io_extension_point_register (MATE_PANEL_APPLETS_MANAGER_EXTENSION_POINT_NAME);
 		g_io_extension_point_set_required_type (ep, PANEL_TYPE_APPLETS_MANAGER);
 	}
  }
@@ -48,11 +46,11 @@ void
 panel_modules_ensure_loaded (void)
 {
 	static gboolean loaded_dirs = FALSE;
-	const char *module_path;
 
 	panel_modules_ensure_extension_points_registered ();
 
 	if (!loaded_dirs) {
+		const char *module_path;
 		GList *modules;
 		loaded_dirs = TRUE;
 

--- a/mate-panel/panel-multimonitor.c
+++ b/mate-panel/panel-multimonitor.c
@@ -70,7 +70,6 @@ _panel_multimonitor_output_should_be_first (Display       *xdisplay,
 	unsigned long  nitems;
 	unsigned long  bytes_after;
 	unsigned char *prop;
-	char          *connector_type;
 	gboolean       retval;
 
 	connector_type_atom = XInternAtom (xdisplay, "ConnectorType", False);
@@ -80,7 +79,7 @@ _panel_multimonitor_output_should_be_first (Display       *xdisplay,
 				  &actual_type, &actual_format,
 				  &nitems, &bytes_after, &prop) == Success) {
 		if (actual_type == XA_ATOM && nitems == 1 && actual_format == 32) {
-			connector_type = XGetAtomName (xdisplay, prop[0]);
+			char *connector_type = XGetAtomName (xdisplay, prop[0]);
 			retval = g_strcmp0 (connector_type, "Panel") == 0;
 			XFree (connector_type);
 			return retval;

--- a/mate-panel/panel-test-applets.c
+++ b/mate-panel/panel-test-applets.c
@@ -268,7 +268,6 @@ setup_options (void)
 	char                *prefs_path = NULL;
 	char                *unique_key = NULL;
 	gboolean             unique_key_found = FALSE;
-	gchar              **dconf_paths;
 	GtkListStore        *model;
 	GtkTreeIter          iter;
 	GtkCellRenderer     *renderer;
@@ -312,7 +311,7 @@ setup_options (void)
 		g_free (unique_key);
 		unique_key = g_strdup_printf ("mate-panel-test-applet-%d", i);
 		unique_key_found = TRUE;
-		dconf_paths = mate_dconf_list_subdirs ("/tmp/", TRUE);
+		gchar **dconf_paths = mate_dconf_list_subdirs ("/tmp/", TRUE);
 		for (j = 0; dconf_paths[j] != NULL; j++)
 		{
 			if (g_strcmp0(unique_key, dconf_paths[j]) == 0) {
@@ -335,7 +334,6 @@ int
 main (int argc, char **argv)
 {
 	GtkBuilder *builder;
-	char       *applets_dir;
 	GError     *error;
 
 	bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);
@@ -357,11 +355,8 @@ main (int argc, char **argv)
 
 	panel_modules_ensure_loaded ();
 
-	if (g_file_test ("../libmate-panel-applet", G_FILE_TEST_IS_DIR)) {
-		applets_dir = g_strdup_printf ("%s:../libmate-panel-applet", MATE_PANEL_APPLETS_DIR);
-		g_setenv ("MATE_PANEL_APPLETS_DIR", applets_dir, FALSE);
-		g_free (applets_dir);
-	}
+	if (g_file_test ("../libmate-panel-applet", G_FILE_TEST_IS_DIR))
+		g_setenv ("MATE_PANEL_APPLETS_DIR", MATE_PANEL_APPLETS_DIR ":../libmate-panel-applet", FALSE);
 
 	if (cli_iid) {
 		load_applet_from_command_line ();

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -1320,7 +1320,6 @@ static void panel_toplevel_update_hide_buttons(PanelToplevel* toplevel)
 {
 
 	int panel_size = toplevel->priv->size;
-	int hb_size = 0;
 
 	if (toplevel->priv->buttons_enabled) {
 		panel_toplevel_update_buttons_showing (toplevel);
@@ -1366,11 +1365,16 @@ static void panel_toplevel_update_hide_buttons(PanelToplevel* toplevel)
 
 	/* set size after setting the arrow */
 	if (toplevel->priv->buttons_enabled) {
+		int hb_size;
 
-		if ( panel_size < 20) { hb_size = 16; }
-		else if ( panel_size < 40) { hb_size = 20; }
-		else if ( panel_size < 60) { hb_size = 26; }
-		else { hb_size = 30; }
+		if (panel_size < 20)
+			hb_size = 16;
+		else if (panel_size < 40)
+			hb_size = 20;
+		else if (panel_size < 60)
+			hb_size = 26;
+		else
+			hb_size = 30;
 
 		gtk_widget_set_size_request (toplevel->priv->hide_button_top, panel_size, hb_size);
 		gtk_widget_set_size_request (toplevel->priv->hide_button_bottom, panel_size, hb_size);
@@ -2894,8 +2898,6 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 	GtkWidget *widget;
 
 	GList *list;
-	const char *id;
-	int position;
 	gboolean stick;
 
 	widget = GTK_WIDGET (toplevel);
@@ -2920,7 +2922,7 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 	if (resize || move) {
 		for (list = toplevel->priv->panel_widget->applet_list; list != NULL; list = g_list_next (list)) {
 			AppletData *ad = list->data;
-			id = mate_panel_applet_get_id_by_widget (ad->applet);
+			const char *id = mate_panel_applet_get_id_by_widget (ad->applet);
 
 			if (!id)
 				return;
@@ -2931,7 +2933,7 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 			stick = g_settings_get_boolean (info->settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY);
 
 			if (stick) {
-				position = g_settings_get_int (info->settings, PANEL_OBJECT_POSITION_KEY);
+				int position = g_settings_get_int (info->settings, PANEL_OBJECT_POSITION_KEY);
 				if (toplevel->priv->orientation & PANEL_HORIZONTAL_MASK) {
 					ad->pos = toplevel->priv->geometry.width - position;
 				} else {

--- a/mate-panel/panel-util.c
+++ b/mate-panel/panel-util.c
@@ -828,20 +828,15 @@ panel_util_get_icon_name_from_g_icon (GIcon *gicon)
 static char *
 panel_util_get_file_display_name_if_mount (GFile *file)
 {
-	GFile          *compare;
-	GVolumeMonitor *monitor;
-	GList          *mounts, *l;
-	char           *ret;
-
-	ret = NULL;
+	GList *l;
+	char  *ret = NULL;
 
 	/* compare with all mounts */
-	monitor = g_volume_monitor_get ();
-	mounts = g_volume_monitor_get_mounts (monitor);
+	GVolumeMonitor *monitor = g_volume_monitor_get ();
+	GList *mounts = g_volume_monitor_get_mounts (monitor);
 	for (l = mounts; l != NULL; l = l->next) {
-		GMount *mount;
-		mount = G_MOUNT (l->data);
-		compare = g_mount_get_root (mount);
+		GMount *mount = G_MOUNT (l->data);
+		GFile *compare = g_mount_get_root (mount);
 		if (!ret && g_file_equal (file, compare))
 			ret = g_mount_get_name (mount);
 		g_object_unref (compare);
@@ -860,13 +855,12 @@ panel_util_get_file_display_for_common_files (GFile *file)
 
 	compare = g_file_new_for_path (g_get_home_dir ());
 	if (g_file_equal (file, compare)) {
-		GSettings *caja_desktop_settings;
 		char *caja_home_icon_name = NULL;
 
 		g_object_unref (compare);
 
 		if (mate_gsettings_schema_exists (CAJA_DESKTOP_SCHEMA)) {
-			caja_desktop_settings = g_settings_new (CAJA_DESKTOP_SCHEMA);
+			GSettings *caja_desktop_settings = g_settings_new (CAJA_DESKTOP_SCHEMA);
 			caja_home_icon_name = g_settings_get_string (caja_desktop_settings,
 														 CAJA_DESKTOP_HOME_ICON_NAME_KEY);
 			g_object_unref (caja_desktop_settings);
@@ -915,17 +909,12 @@ panel_util_get_file_description (GFile *file)
 
 static char *
 panel_util_get_file_display_name (GFile    *file,
-				  gboolean  use_fallback)
+                                 gboolean  use_fallback)
 {
-	GFileInfo *info;
-	char      *ret;
-
-	ret = NULL;
-
-	info = g_file_query_info (file, "standard::display-name",
-				  G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-				  NULL, NULL);
-
+	char *ret = NULL;
+	GFileInfo *info = g_file_query_info (file, "standard::display-name",
+	                                     G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+	                                     NULL, NULL);
 	if (info) {
 		ret = g_strdup (g_file_info_get_display_name (info));
 		g_object_unref (info);
@@ -933,9 +922,7 @@ panel_util_get_file_display_name (GFile    *file,
 
 	if (!ret && use_fallback) {
 		/* can happen with URI schemes non supported by gvfs */
-		char *basename;
-
-		basename = g_file_get_basename (file);
+		char *basename = g_file_get_basename (file);
 		ret = g_filename_display_name (basename);
 		g_free (basename);
 	}
@@ -946,20 +933,16 @@ panel_util_get_file_display_name (GFile    *file,
 static char *
 panel_util_get_file_icon_name_if_mount (GFile *file)
 {
-	GFile          *compare;
 	GVolumeMonitor *monitor;
 	GList          *mounts, *l;
-	char           *ret;
-
-	ret = NULL;
+	char           *ret = NULL;
 
 	/* compare with all mounts */
 	monitor = g_volume_monitor_get ();
 	mounts = g_volume_monitor_get_mounts (monitor);
 	for (l = mounts; l != NULL; l = l->next) {
-		GMount *mount;
-		mount = G_MOUNT (l->data);
-		compare = g_mount_get_root (mount);
+		GMount *mount = G_MOUNT (l->data);
+		GFile *compare = g_mount_get_root (mount);
 		if (!ret && g_file_equal (file, compare)) {
 			GIcon *gicon;
 			gicon = g_mount_get_icon (mount);

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1019,10 +1019,9 @@ panel_widget_switch_move (PanelWidget *panel,
 				gtk_widget_queue_resize (GTK_WIDGET (panel));
 		}
 	} else {
-		AppletData *nad;
 
 		if (list->next) {
-			nad = list->next->data;
+			AppletData *nad = list->next->data;
 			if (nad->expand_major)
 				gtk_widget_queue_resize (GTK_WIDGET (panel));
 		}
@@ -1122,7 +1121,6 @@ panel_widget_push_move (PanelWidget *panel,
 			AppletData  *ad,
 			int          moveby)
 {
-	AppletData *pad;
 	int finalpos;
 	GList *list;
 
@@ -1143,7 +1141,7 @@ panel_widget_push_move (PanelWidget *panel,
 				break;
 
                 if (list->prev) {
-			pad = list->prev->data;
+			AppletData *pad = list->prev->data;
 			if (pad->expand_major)
 				gtk_widget_queue_resize (GTK_WIDGET (panel));
 		}
@@ -1485,13 +1483,12 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 		    list!=NULL;
 		    list = g_list_previous(list)) {
 			AppletData *ad = list->data;
-			int cells;
 
 			if (ad->constrained + ad->min_cells > i)
 				ad->constrained = MAX (i - ad->min_cells, 0);
 
 			if (ad->expand_major) {
-				cells = (i - ad->constrained) - 1;
+				int cells = (i - ad->constrained) - 1;
 
 				if (ad->size_hints)
 					cells = get_size_from_hints (ad, cells);
@@ -2125,8 +2122,7 @@ panel_widget_applet_move_to_cursor (PanelWidget *panel)
 static int
 move_timeout_handler(gpointer data)
 {
-	PanelWidget   *panel = data;
-	GdkDevice      *device;
+	PanelWidget *panel = data;
 
 	g_return_val_if_fail(PANEL_IS_WIDGET(data),FALSE);
 
@@ -2139,14 +2135,12 @@ move_timeout_handler(gpointer data)
 	been_moved = FALSE;
 
 	if(panel->currently_dragged_applet && repeat_if_outside) {
-		GtkWidget     *widget;
 		GtkAllocation  allocation;
 		int            x,y;
 		int            w,h;
+		GtkWidget     *widget = panel->currently_dragged_applet->applet;
+		GdkDevice     *device = gdk_seat_get_pointer (gdk_display_get_default_seat (gtk_widget_get_display (widget)));
 
-		widget = panel->currently_dragged_applet->applet;
-
-		device = gdk_seat_get_pointer (gdk_display_get_default_seat (gtk_widget_get_display (widget)));
 		gdk_window_get_device_position (gtk_widget_get_window (widget), device, &x, &y, NULL);
 
 		gtk_widget_get_allocation (widget, &allocation);

--- a/mate-panel/xstuff.c
+++ b/mate-panel/xstuff.c
@@ -346,8 +346,6 @@ xstuff_zoom_animate (GtkWidget *widget,
 	GdkScreen *gscreen;
 	GdkRectangle rect, dest;
 	GtkAllocation allocation;
-	GdkMonitor *monitor;
-	GdkDisplay *display;
 
 	if (opt_rect)
 		rect = *opt_rect;
@@ -375,8 +373,8 @@ xstuff_zoom_animate (GtkWidget *widget,
 				pixbuf, orientation);
 		g_object_unref (pixbuf);
 	} else {
-		display = gdk_screen_get_display (gscreen);
-		monitor = gdk_display_get_monitor_at_window (display,
+		GdkDisplay *display = gdk_screen_get_display (gscreen);
+		GdkMonitor *monitor = gdk_display_get_monitor_at_window (display,
 							     gtk_widget_get_window (widget));
 		gdk_monitor_get_geometry (monitor, &dest);
 


### PR DESCRIPTION
```
cppcheck --enable=all . 2> err.txt
grep variableScope err.txt
```