### PR TITLE
Fix creating several launchers at once

### DIFF
--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -1236,6 +1236,11 @@ panel_profile_prepare_object_with_id (PanelObjectType  object_type,
 	g_settings_set_int (settings, PANEL_OBJECT_POSITION_KEY, position);
 	g_settings_set_boolean (settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY, right_stick);
 
+	/* Force writing the settings in order to reserve the object ID *now*,
+	 * so that a later call to panel_profile_find_new_id() won't find the same
+	 * one. */
+	g_settings_sync ();
+
 	g_free (settings_path);
 	g_object_unref (settings);
 


### PR DESCRIPTION
When creating a new launcher, we try and find an available object ID by browsing the existing ones.  This however fails to take into account objects that were created but that didn't make it to the backend yet, leading to likely re-using the same ID when creating several objects roughly at the same time.  This happens e.g. when dropping several URIs together.

# Test

Drag 2 or more **non-image** files from Caja over to a panel.

## Actual behavior (without this patch)

Only one launcher gets created for the the last URI.

## Expected behavior (with this patch)
A launcher gets created for each URI.