### PR TITLE
Ask the user what to do when receiving an image drop

### DIFF
--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -604,10 +604,12 @@ drop_urilist (PanelWidget *panel,
 	      char        *urilist)
 {
 	char     **uris;
+	guint      n_uris;
 	gboolean   success;
 	int        i;
 
 	uris = g_uri_list_extract_uris (urilist);
+	n_uris = g_strv_length (uris);
 
 	success = TRUE;
 	for (i = 0; uris[i]; i++) {
@@ -657,8 +659,8 @@ drop_urilist (PanelWidget *panel,
 			can_exec = g_file_info_get_attribute_boolean (info,
 								      G_FILE_ATTRIBUTE_ACCESS_CAN_EXECUTE);
 
-			if (mime &&
-			    g_str_has_prefix (mime, "image")) {
+			if (n_uris == 1 &&
+			    mime && g_str_has_prefix (mime, "image")) {
 				if (!set_background_image_from_uri (panel->toplevel, uri))
 					success = FALSE;
 			} else if (mime &&


### PR DESCRIPTION
Instead of unconditionally setting the panel's background when an image file URI gets dropped on a panel, ask the user whether to create a launcher for that URI (like for non-image URIs) or to use the image as the panel's background.

A number of users have seen their panel's background changed unexpectedly due to unwanted drop of an image file over the panel, sometimes seeing this as a panel's bug (I personally know 2, at least a couple others have popped here and there).

Also, this behavior is inconsistent with dropping a URI pointing to any other type of file, where it would create a launcher for it.

Consequently, and as setting the panel's background doesn't seem like a so common task it ought to be super fast, ask the user what to do when receiving an image URI drop.

Also, when a drop consists of more than one URI, just create launchers without asking because it doesn't make sense to set the background more than once at a time.