### PR TITLE
wncklet: Hide window preview on non-visible windows

### DIFF
--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -293,6 +293,11 @@ static gboolean applet_enter_notify_event (WnckTasklist *tl, GList *wnck_windows
 	if (wnck_window == NULL)
 		return FALSE;
 
+	/* Do not show preview if window is not visible nor in current workspace */
+	if (!wnck_window_is_visible_on_workspace (wnck_window,
+						  wnck_screen_get_active_workspace (wnck_screen_get_default ())))
+		return FALSE;
+
 	thumbnail = preview_window_thumbnail (wnck_window, tasklist);
 
 	if (thumbnail == NULL)


### PR DESCRIPTION
When a window is not visible we cannot capture its thumbnail. We used to
store the thumbnail when a window was visible so that we could reuse it
when minimized, but this can cause visual glitches.

Fixes #1127 