### PR TITLE
Drop 'xau' from PKG_CHECK_MODULES call

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -49,7 +49,6 @@ requires:
     - libsoup2.4-dev
     - libwnck-3-dev
     - libx11-dev
-    - libxau-dev
     - libxrandr-dev
     - lsb-release
     - make
@@ -104,7 +103,6 @@ requires:
     - libsoup2.4-dev
     - libwnck-3-dev
     - libx11-dev
-    - libxau-dev
     - libxrandr-dev
     - lsb-release
     - make

--- a/configure.ac
+++ b/configure.ac
@@ -213,7 +213,7 @@ AC_SUBST(GTK_LAYER_SHELL_LIBS)
 # Check if we have the X development libraries
 have_x11=no
 if test "x$enable_x11" != "xno"; then
-  PKG_CHECK_MODULES(X, x11 xau, have_x11=yes, [
+  PKG_CHECK_MODULES(X, x11, have_x11=yes, [
       if test "x$enable_x11" = "xyes"; then
         AC_MSG_ERROR([X development libraries not found])
       fi


### PR DESCRIPTION
It appears this is no longer being used (if it ever was)