### PR TITLE
travis: fix make distcheck error on archlinux

### DIFF
--- a/doc/reference/mate-panel-applet/Makefile.am
+++ b/doc/reference/mate-panel-applet/Makefile.am
@@ -59,6 +59,8 @@ GTKDOC_LIBS =						\
 
 include $(top_srcdir)/gtk-doc.make
 
+DISTCLEANFILES = $(DOC_MODULE).actions
+
 dist-hook-local:
 #	mkdir $(distdir)/TEXT;          \
 #	for f in $(srcdir)/TEXT/* ; do  \


### PR DESCRIPTION
Fix make distcheck failed on archlinux:
```
make[2]: Leaving directory '/rootdir/mate-panel-1.25.1/_build/sub'
rm -f config.status config.cache config.log configure.lineno config.status.lineno
rm -f Makefile
ERROR: files left in build directory after distclean:
./doc/reference/mate-panel-applet/mate-panel-applet.actions
make[1]: *** [Makefile:826: distcleancheck] Error 1
make[1]: Leaving directory '/rootdir/mate-panel-1.25.1/_build/sub'
make: *** [Makefile:755: distcheck] Error 1
!!! ERROR: run command [docker exec -t mate-panel-archlinux-build /rootdir/after_scripts].

```