### PR TITLE
configure: remove warning about option 'subdir-objects' is disabled

### DIFF
--- a/applets/wncklet/Makefile.am
+++ b/applets/wncklet/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
 AM_CPPFLAGS =							\
 	$(LIBMATE_PANEL_APPLET_CFLAGS)				\
 	$(WNCKLET_CFLAGS)					\


### PR DESCRIPTION
```
applets/wncklet/Makefile.am:32: warning: source file 'wayland-protocol/wlr-foreign-toplevel-management-unstable-v1-code.c' is in a subdirectory,
applets/wncklet/Makefile.am:32: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
```