### PR TITLE
clock: Set window hint to GDK_WINDOW_TYPE_HINT_MENU

### DIFF
--- a/applets/clock/calendar-window.c
+++ b/applets/clock/calendar-window.c
@@ -474,7 +474,7 @@ calendar_window_init (CalendarWindow *calwin)
 	calwin->priv = calendar_window_get_instance_private (calwin);
 
 	window = GTK_WINDOW (calwin);
-	gtk_window_set_type_hint (window, GDK_WINDOW_TYPE_HINT_DOCK);
+	gtk_window_set_type_hint (window, GDK_WINDOW_TYPE_HINT_MENU);
 	gtk_window_set_decorated (window, FALSE);
 	gtk_window_set_resizable (window, FALSE);
 	gtk_window_set_default_size (window, 337, -1);


### PR DESCRIPTION
This makes the window appear properly when using [i3](https://i3wm.org/l) WM.

Without this patch, the clock window appears as a dock/panel window covering the full width of the screen:
![2020-11-24-221653_7680x2160_scrot](https://user-images.githubusercontent.com/5933427/100146844-3180be80-2ea3-11eb-8b09-d0726b16758d.png)

According to these [docs](http://gtk.php.net/manual/en/html/gdk/gdk.enum.windowtypehint.html) a GDK_WINDOW_TYPE_HINT_MENU is more appropriate, as the current GDK_WINDOW_TYPE_HINT_DOCK is reserved for dock/panel windows.
