### PR TITLE
remove dead function mate_panel_applet_set_background_widget

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -2528,9 +2528,6 @@ fill_clock_applet (MatePanelApplet *applet)
                           G_CALLBACK (panel_button_change_pixel_size),
                           cd);
 
-        mate_panel_applet_set_background_widget (MATE_PANEL_APPLET (cd->applet),
-                                            GTK_WIDGET (cd->applet));
-
         action_group = gtk_action_group_new ("ClockApplet Menu Actions");
         gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
         gtk_action_group_add_actions (action_group,

--- a/applets/fish/fish.c
+++ b/applets/fish/fish.c
@@ -1881,8 +1881,6 @@ static void fish_applet_instance_init(FishApplet* fish, FishAppletClass* klass)
 	fish->april_fools = FALSE;
 
 	mate_panel_applet_set_flags (MATE_PANEL_APPLET (fish), MATE_PANEL_APPLET_EXPAND_MINOR);
-
-	mate_panel_applet_set_background_widget(MATE_PANEL_APPLET(fish), GTK_WIDGET(fish));
 }
 
 static void fish_applet_class_init(FishAppletClass* klass)

--- a/applets/wncklet/showdesktop.c
+++ b/applets/wncklet/showdesktop.c
@@ -458,8 +458,6 @@ gboolean show_desktop_applet_fill(MatePanelApplet* applet)
 	   initial oriantation, and we get that during the _add call */
 	g_signal_connect(G_OBJECT (sdd->applet), "change_orient", G_CALLBACK (applet_change_orient), sdd);
 
-	mate_panel_applet_set_background_widget(MATE_PANEL_APPLET (sdd->applet), GTK_WIDGET(sdd->applet));
-
 	action_group = gtk_action_group_new("ShowDesktop Applet Actions");
 	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);
 	gtk_action_group_add_actions(action_group, show_desktop_menu_actions, G_N_ELEMENTS (show_desktop_menu_actions), sdd);

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -788,8 +788,6 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 	g_signal_connect(G_OBJECT(tasklist->applet), "change_size", G_CALLBACK(applet_change_pixel_size), tasklist);
 	g_signal_connect(G_OBJECT(tasklist->applet), "change_background", G_CALLBACK(applet_change_background), tasklist);
 
-	mate_panel_applet_set_background_widget(MATE_PANEL_APPLET(tasklist->applet), GTK_WIDGET(tasklist->applet));
-
 	action_group = gtk_action_group_new("Tasklist Applet Actions");
 	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);
 	gtk_action_group_add_actions(action_group, tasklist_menu_actions, G_N_ELEMENTS(tasklist_menu_actions), tasklist);

--- a/applets/wncklet/window-menu.c
+++ b/applets/wncklet/window-menu.c
@@ -253,8 +253,6 @@ gboolean window_menu_applet_fill(MatePanelApplet* applet)
 	if (GDK_IS_X11_DISPLAY (gdk_display_get_default ()))
 	{
 		window_menu->selector = wnck_selector_new();
-		mate_panel_applet_set_background_widget(MATE_PANEL_APPLET(window_menu->applet), GTK_WIDGET(window_menu->selector));
-
 	}
 	else
 #endif /* HAVE_X11 */

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -646,8 +646,6 @@ gboolean workspace_switcher_applet_fill(MatePanelApplet* applet)
 	gtk_widget_show(pager->pager);
 	gtk_widget_show(pager->applet);
 
-	mate_panel_applet_set_background_widget(MATE_PANEL_APPLET(pager->applet), GTK_WIDGET(pager->applet));
-
 	action_group = gtk_action_group_new("WorkspaceSwitcher Applet Actions");
 	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);
 	gtk_action_group_add_actions(action_group, pager_menu_actions, G_N_ELEMENTS(pager_menu_actions), pager);

--- a/libmate-panel-applet/mate-panel-applet.h
+++ b/libmate-panel-applet/mate-panel-applet.h
@@ -37,138 +37,166 @@ G_BEGIN_DECLS
 G_DECLARE_DERIVABLE_TYPE (MatePanelApplet, mate_panel_applet, MATE_PANEL, APPLET, GtkEventBox)
 
 typedef enum {
-	MATE_PANEL_APPLET_ORIENT_UP,
-	MATE_PANEL_APPLET_ORIENT_DOWN,
-	MATE_PANEL_APPLET_ORIENT_LEFT,
-	MATE_PANEL_APPLET_ORIENT_RIGHT
+    MATE_PANEL_APPLET_ORIENT_UP,
+    MATE_PANEL_APPLET_ORIENT_DOWN,
+    MATE_PANEL_APPLET_ORIENT_LEFT,
+    MATE_PANEL_APPLET_ORIENT_RIGHT
 #define MATE_PANEL_APPLET_ORIENT_FIRST MATE_PANEL_APPLET_ORIENT_UP
 #define MATE_PANEL_APPLET_ORIENT_LAST  MATE_PANEL_APPLET_ORIENT_RIGHT
 } MatePanelAppletOrient;
 
 typedef enum {
-	PANEL_NO_BACKGROUND,
-	PANEL_COLOR_BACKGROUND,
-	PANEL_PIXMAP_BACKGROUND
+    PANEL_NO_BACKGROUND,
+    PANEL_COLOR_BACKGROUND,
+    PANEL_PIXMAP_BACKGROUND
 } MatePanelAppletBackgroundType;
 
 typedef enum {
-	MATE_PANEL_APPLET_FLAGS_NONE   = 0,
-	MATE_PANEL_APPLET_EXPAND_MAJOR = 1 << 0,
-	MATE_PANEL_APPLET_EXPAND_MINOR = 1 << 1,
-	MATE_PANEL_APPLET_HAS_HANDLE   = 1 << 2
+    MATE_PANEL_APPLET_FLAGS_NONE   = 0,
+    MATE_PANEL_APPLET_EXPAND_MAJOR = 1 << 0,
+    MATE_PANEL_APPLET_EXPAND_MINOR = 1 << 1,
+    MATE_PANEL_APPLET_HAS_HANDLE   = 1 << 2
 #define MATE_PANEL_APPLET_FLAGS_ALL (MATE_PANEL_APPLET_EXPAND_MAJOR|MATE_PANEL_APPLET_EXPAND_MINOR|MATE_PANEL_APPLET_HAS_HANDLE)
 } MatePanelAppletFlags;
 
-typedef gboolean (*MatePanelAppletFactoryCallback) (MatePanelApplet* applet, const gchar *iid, gpointer user_data);
+typedef gboolean (*MatePanelAppletFactoryCallback) (MatePanelApplet *applet, const gchar *iid, gpointer user_data);
 
 struct _MatePanelAppletClass {
-	GtkEventBoxClass event_box_class;
+    GtkEventBoxClass event_box_class;
 
-	void (*change_orient) (MatePanelApplet* applet, MatePanelAppletOrient orient);
+    void    (*change_orient)            (MatePanelApplet         *applet,
+                                         MatePanelAppletOrient    orient);
 
-	void (*change_size) (MatePanelApplet* applet, guint size);
+    void    (*change_size)              (MatePanelApplet   *applet,
+                                         guint              size);
 
-	void (*change_background) (MatePanelApplet *applet, MatePanelAppletBackgroundType type, GdkRGBA* color, cairo_pattern_t *pattern);
+    void    (*change_background)        (MatePanelApplet               *applet,
+                                         MatePanelAppletBackgroundType  type,
+                                         GdkRGBA                       *color,
+                                         cairo_pattern_t               *pattern);
 
-	void (*move_focus_out_of_applet) (MatePanelApplet* frame, GtkDirectionType direction);
+    void    (*move_focus_out_of_applet) (MatePanelApplet    *frame,
+                                         GtkDirectionType    direction);
 };
 
-GtkWidget* mate_panel_applet_new(void);
+GtkWidget*              mate_panel_applet_new                       (void);
 
-MatePanelAppletOrient mate_panel_applet_get_orient(MatePanelApplet* applet);
-guint mate_panel_applet_get_size(MatePanelApplet* applet);
-MatePanelAppletBackgroundType mate_panel_applet_get_background (MatePanelApplet *applet, /* return values */ GdkRGBA* color, cairo_pattern_t** pattern);
-void mate_panel_applet_set_background_widget(MatePanelApplet* applet, GtkWidget* widget);
+MatePanelAppletOrient   mate_panel_applet_get_orient                (MatePanelApplet   *applet);
 
-gchar* mate_panel_applet_get_preferences_path(MatePanelApplet* applet);
+guint                   mate_panel_applet_get_size                  (MatePanelApplet   *applet);
 
-MatePanelAppletFlags mate_panel_applet_get_flags(MatePanelApplet* applet);
-void mate_panel_applet_set_flags(MatePanelApplet* applet, MatePanelAppletFlags flags);
+MatePanelAppletBackgroundType   mate_panel_applet_get_background    (MatePanelApplet   *applet,
+                                                 /* return values */ GdkRGBA           *color,
+                                                                     cairo_pattern_t  **pattern);
 
-void mate_panel_applet_set_size_hints(MatePanelApplet* applet, const int* size_hints, int n_elements, int base_size);
+void                    mate_panel_applet_set_background_widget     (MatePanelApplet   *applet,
+                                                                     GtkWidget         *widget);
 
-gboolean mate_panel_applet_get_locked_down(MatePanelApplet* applet);
+gchar*                  mate_panel_applet_get_preferences_path      (MatePanelApplet   *applet);
+
+MatePanelAppletFlags    mate_panel_applet_get_flags                 (MatePanelApplet   *applet);
+
+void                    mate_panel_applet_set_flags                 (MatePanelApplet       *applet,
+                                                                     MatePanelAppletFlags   flags);
+
+void                    mate_panel_applet_set_size_hints            (MatePanelApplet    *applet,
+                                                                     const int          *size_hints,
+                                                                     int                 n_elements,
+                                                                     int                 base_size);
+
+gboolean                mate_panel_applet_get_locked_down           (MatePanelApplet    *applet);
 
 /* Does nothing when not on X11 */
-void mate_panel_applet_request_focus(MatePanelApplet* applet, guint32 timestamp);
+void                    mate_panel_applet_request_focus             (MatePanelApplet    *applet,
+                                                                     guint32             timestamp);
 
-void mate_panel_applet_setup_menu(MatePanelApplet* applet, const gchar* xml, GtkActionGroup* action_group);
-void mate_panel_applet_setup_menu_from_file(MatePanelApplet* applet, const gchar* filename, GtkActionGroup* action_group);
-void mate_panel_applet_setup_menu_from_resource (MatePanelApplet    *applet,
-                                                 const gchar        *resource_path,
-                                                 GtkActionGroup     *action_group);
+void                    mate_panel_applet_setup_menu                (MatePanelApplet    *applet,
+                                                                     const gchar        *xml,
+                                                                     GtkActionGroup     *action_group);
 
-int mate_panel_applet_factory_main(const gchar* factory_id,gboolean  out_process, GType applet_type, MatePanelAppletFactoryCallback callback, gpointer data);
+void                    mate_panel_applet_setup_menu_from_file      (MatePanelApplet    *applet,
+                                                                     const gchar        *filename,
+                                                                     GtkActionGroup     *action_group);
 
-int  mate_panel_applet_factory_setup_in_process (const gchar               *factory_id,
-							  GType                      applet_type,
-							  MatePanelAppletFactoryCallback callback,
-							  gpointer                   data);
+void                    mate_panel_applet_setup_menu_from_resource  (MatePanelApplet    *applet,
+                                                                     const gchar        *resource_path,
+                                                                     GtkActionGroup     *action_group);
+
+int                     mate_panel_applet_factory_main              (const gchar   *factory_id,
+                                                                     gboolean       out_process,
+                                                                     GType          applet_type,
+                                                                     MatePanelAppletFactoryCallback callback,
+                                                                     gpointer       data);
+
+int                     mate_panel_applet_factory_setup_in_process  (const gchar    *factory_id,
+                                                                     GType           applet_type,
+                                                                     MatePanelAppletFactoryCallback callback,
+                                                                     gpointer        data);
 
 
 /*
  * These macros are getting a bit unwieldy.
  *
  * Things to define for these:
- *	+ required if Native Language Support is enabled (ENABLE_NLS):
+ *     + required if Native Language Support is enabled (ENABLE_NLS):
  *                   GETTEXT_PACKAGE and MATELOCALEDIR
  */
 
 #if !defined(ENABLE_NLS)
-	#define _MATE_PANEL_APPLET_SETUP_GETTEXT(call_textdomain) \
-		do { } while (0)
+    #define _MATE_PANEL_APPLET_SETUP_GETTEXT(call_textdomain) \
+        do { } while (0)
 #else /* defined(ENABLE_NLS) */
-	#include <libintl.h>
-	#define _MATE_PANEL_APPLET_SETUP_GETTEXT(call_textdomain) \
-	do { \
-		bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR); \
-		bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8"); \
-		if (call_textdomain) \
-			textdomain (GETTEXT_PACKAGE); \
-	} while (0)
+    #include <libintl.h>
+    #define _MATE_PANEL_APPLET_SETUP_GETTEXT(call_textdomain) \
+    do { \
+        bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR); \
+        bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8"); \
+        if (call_textdomain) \
+            textdomain (GETTEXT_PACKAGE); \
+    } while (0)
 #endif /* !defined(ENABLE_NLS) */
 
 #define MATE_PANEL_APPLET_OUT_PROCESS_FACTORY(factory_id, type, name, callback, data) \
-int main(int argc, char* argv[]) \
+int main(int argc, char *argv[]) \
 { \
-	GOptionContext* context; \
-	GError* error; \
-	int retval; \
-	 \
-	_MATE_PANEL_APPLET_SETUP_GETTEXT (TRUE); \
-	 \
-	context = g_option_context_new(""); \
-	g_option_context_add_group (context, gtk_get_option_group(TRUE)); \
-	 \
-	error = NULL; \
-	if (!g_option_context_parse (context, &argc, &argv, &error)) \
-	{ \
-		if (error) \
-		{ \
-			g_printerr ("Cannot parse arguments: %s.\n", error->message); \
-			g_error_free (error); \
-		} \
-		else \
-		{ \
-			g_printerr ("Cannot parse arguments.\n"); \
-		} \
-		g_option_context_free (context); \
-		return 1; \
-	} \
-	 \
-	gtk_init (&argc, &argv); \
-	 \
-	retval = mate_panel_applet_factory_main (factory_id,TRUE, type, callback, data); \
-	g_option_context_free (context); \
-	 \
-	return retval; \
+    GOptionContext *context; \
+    GError *error; \
+    int retval; \
+     \
+    _MATE_PANEL_APPLET_SETUP_GETTEXT (TRUE); \
+     \
+    context = g_option_context_new(""); \
+    g_option_context_add_group (context, gtk_get_option_group(TRUE)); \
+     \
+    error = NULL; \
+    if (!g_option_context_parse (context, &argc, &argv, &error)) \
+    { \
+        if (error) \
+        { \
+            g_printerr ("Cannot parse arguments: %s.\n", error->message); \
+            g_error_free (error); \
+        } \
+        else \
+        { \
+            g_printerr ("Cannot parse arguments.\n"); \
+        } \
+        g_option_context_free (context); \
+        return 1; \
+    } \
+     \
+    gtk_init (&argc, &argv); \
+     \
+    retval = mate_panel_applet_factory_main (factory_id,TRUE, type, callback, data); \
+    g_option_context_free (context); \
+     \
+    return retval; \
 }
 
 #define MATE_PANEL_APPLET_IN_PROCESS_FACTORY(factory_id, type, descr, callback, data) \
-gboolean _mate_panel_applet_shlib_factory (void);	\
+gboolean _mate_panel_applet_shlib_factory (void);    \
 G_MODULE_EXPORT gint _mate_panel_applet_shlib_factory(void) \
 { \
-	_MATE_PANEL_APPLET_SETUP_GETTEXT(FALSE); \
+    _MATE_PANEL_APPLET_SETUP_GETTEXT(FALSE); \
 return mate_panel_applet_factory_setup_in_process (factory_id, type,                 \
                                                callback, data);  \
 }


### PR DESCRIPTION
This function has an empty body, so removing it should be fine. I tested all affected applets, they work as before for me.

Should not be merged before https://github.com/mate-desktop/mate-media/pull/170 and https://github.com/mate-desktop/mate-applets/pull/555.