### PR TITLE
Fix solid color controls after disabling compositor

### DIFF
--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -158,8 +158,7 @@ mate_panel_LDADD = \
 	$(DCONF_LIBS) \
 	$(XRANDR_LIBS) \
 	$(X_LIBS) \
-	$(WAYLAND_LIBS) \
-	-lm
+	$(WAYLAND_LIBS)
 
 if ENABLE_WAYLAND
 mate_panel_LDADD += \

--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -1,5 +1,4 @@
 #include <config.h>
-#include <math.h>
 #include <string.h>
 
 #include <glib/gi18n.h>

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -23,7 +23,6 @@
  */
 
 #include <config.h>
-#include <math.h>
 
 #include "panel-profile.h"
 #include "panel-layout.h"
@@ -267,20 +266,20 @@ panel_profile_get_background_color (PanelToplevel *toplevel,
 
 void
 panel_profile_set_background_opacity (PanelToplevel *toplevel,
-				      guint16        opacity)
+                                      gdouble        percentage)
 {
 	GdkRGBA color;
 	panel_profile_get_background_color (toplevel, &color);
-	color.alpha = opacity / 65535.0;
+	color.alpha = percentage / 100.0;
 	panel_profile_set_background_color (toplevel, &color);
 }
 
-guint16
+gdouble
 panel_profile_get_background_opacity (PanelToplevel *toplevel)
 {
 	GdkRGBA color;
 	panel_profile_get_background_color (toplevel, &color);
-	return (guint16) round (color.alpha * 65535);
+	return color.alpha * 100.0;
 }
 
 void

--- a/mate-panel/panel-profile.h
+++ b/mate-panel/panel-profile.h
@@ -115,8 +115,8 @@ void        panel_profile_get_background_color        (PanelToplevel       *topl
 						       GdkRGBA             *color);
 
 void        panel_profile_set_background_opacity      (PanelToplevel       *toplevel,
-						       guint16              opacity);
-guint16     panel_profile_get_background_opacity      (PanelToplevel       *toplevel);
+                                                       gdouble              percentage);
+gdouble     panel_profile_get_background_opacity      (PanelToplevel       *toplevel);
 
 void        panel_profile_set_background_image        (PanelToplevel       *toplevel,
 						       const char          *image);


### PR DESCRIPTION
- Enable the compositor
- Open panel properties dialog
- Set the panel background to solid color and enable color transparency.
- Close panel properties dialog
- Disable the compositor
- Open panel properties dialog

![Screenshot at 2020-12-04 23-14-41](https://user-images.githubusercontent.com/10171411/101223880-5b996400-368d-11eb-8836-07432ecb8119.png)
