### PR TITLE
Signal name is 'value-changed' for GtkSpinButton

### DIFF
--- a/applets/fish/fish.c
+++ b/applets/fish/fish.c
@@ -467,7 +467,7 @@ static void display_preferences_dialog(GtkAction* action, FishApplet* fish)
 	gtk_spin_button_set_value (GTK_SPIN_BUTTON (fish->frames_spin),
 				   fish->n_frames);
 
-	g_signal_connect (fish->frames_spin, "value_changed",
+	g_signal_connect (fish->frames_spin, "value-changed",
 			  G_CALLBACK (n_frames_value_changed), fish);
 
 	setup_sensitivity (fish, builder,
@@ -479,7 +479,7 @@ static void display_preferences_dialog(GtkAction* action, FishApplet* fish)
 	fish->speed_spin = GTK_WIDGET (gtk_builder_get_object (builder, "speed_spin"));
 	gtk_spin_button_set_value (GTK_SPIN_BUTTON (fish->speed_spin), fish->speed);
 
-	g_signal_connect (fish->speed_spin, "value_changed",
+	g_signal_connect (fish->speed_spin, "value-changed",
 			  G_CALLBACK (speed_value_changed), fish);
 
 	setup_sensitivity (fish, builder,

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -194,7 +194,7 @@ ensure_prefs_window_is_created (NaTrayApplet *applet)
   gtk_spin_button_set_range (GTK_SPIN_BUTTON (applet->priv->dialog->min_icon_size_spin), 7, 130);
   gtk_spin_button_set_value (GTK_SPIN_BUTTON (applet->priv->dialog->min_icon_size_spin), applet->priv->min_icon_size);
 
-  g_signal_connect_swapped (applet->priv->dialog->min_icon_size_spin, "value_changed",
+  g_signal_connect_swapped (applet->priv->dialog->min_icon_size_spin, "value-changed",
                             G_CALLBACK (na_preferences_dialog_min_icon_size_changed),
                             applet);
 

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -794,12 +794,14 @@ static void workspace_destroyed(WnckScreen* screen, WnckWorkspace* space, PagerD
 }
 #endif /* HAVE_X11 */
 
-static void num_workspaces_value_changed(GtkSpinButton* button, PagerData* pager)
+static void
+on_num_workspaces_value_changed (GtkSpinButton *button,
+                                 PagerData     *pager)
 {
 #ifdef HAVE_X11
 	if (pager->screen)
 	{
-		int workspace_count = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(pager->num_workspaces_spin));
+		int workspace_count = gtk_spin_button_get_value_as_int (button);
 		wnck_screen_change_workspace_count(pager->screen, workspace_count);
 	}
 #endif /* HAVE_X11 */
@@ -1013,7 +1015,7 @@ static void setup_dialog(GtkBuilder* builder, PagerData* pager)
 	}
 
 	/* Num rows: */
-	g_signal_connect(G_OBJECT(pager->num_rows_spin), "value_changed", (GCallback) num_rows_value_changed, pager);
+	g_signal_connect (pager->num_rows_spin, "value-changed", G_CALLBACK (num_rows_value_changed), pager);
 
 	gtk_spin_button_set_value(GTK_SPIN_BUTTON(pager->num_rows_spin), pager->n_rows);
 	gtk_label_set_text(GTK_LABEL(pager->label_row_col), pager->orientation == GTK_ORIENTATION_HORIZONTAL ? _("rows") : _("columns"));
@@ -1041,7 +1043,7 @@ static void setup_dialog(GtkBuilder* builder, PagerData* pager)
 	}
 #endif /* HAVE_X11 */
 
-	g_signal_connect(G_OBJECT(pager->num_workspaces_spin), "value_changed", (GCallback) num_workspaces_value_changed, pager);
+	g_signal_connect (pager->num_workspaces_spin, "value-changed", G_CALLBACK (on_num_workspaces_value_changed), pager);
 
 	g_signal_connect(G_OBJECT(pager->workspaces_tree), "focus_out_event", (GCallback) workspaces_tree_focused_out, pager);
 

--- a/mate-panel/panel-properties-dialog.c
+++ b/mate-panel/panel-properties-dialog.c
@@ -238,7 +238,7 @@ panel_properties_dialog_setup_size_spin (PanelPropertiesDialog *dialog,
 	gtk_spin_button_set_value (GTK_SPIN_BUTTON (dialog->size_spin),
 				   panel_profile_get_toplevel_size (dialog->toplevel));
 
-	g_signal_connect_swapped (dialog->size_spin, "value_changed",
+	g_signal_connect_swapped (dialog->size_spin, "value-changed",
 				  G_CALLBACK (panel_properties_dialog_size_changed),
 				  dialog);
 
@@ -465,7 +465,7 @@ panel_properties_dialog_setup_opacity_scale (PanelPropertiesDialog *dialog,
 		gtk_widget_set_sensitive (dialog->opacity_legend, FALSE);
 	}
 
-	g_signal_connect_swapped (dialog->opacity_scale, "value_changed",
+	g_signal_connect_swapped (dialog->opacity_scale, "value-changed",
 				  G_CALLBACK (panel_properties_dialog_opacity_changed),
 				  dialog);
 }


### PR DESCRIPTION
```C
  /**
   * GtkSpinButton::value-changed:
   * @spin_button: the object on which the signal was emitted
   *
   * The ::value-changed signal is emitted when the value represented by
   * @spinbutton changes. Also see the #GtkSpinButton::output signal.
   */
  spinbutton_signals[VALUE_CHANGED] =
    g_signal_new (I_("value-changed"),
                  G_TYPE_FROM_CLASS (gobject_class),
                  G_SIGNAL_RUN_LAST,
                  G_STRUCT_OFFSET (GtkSpinButtonClass, value_changed),
                  NULL, NULL,
                  NULL,
                  G_TYPE_NONE, 0);
```
https://github.com/GNOME/gtk/blob/daa5d5aeadbebd2d1e764e953b8b6f0d21fbfacf/gtk/gtkspinbutton.c#L493-L507