### PR TITLE
wncklet: unread variable warning reported by cppcheck

### DIFF
--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -321,11 +321,13 @@ static void applet_style_updated (MatePanelApplet *applet, GtkStyleContext *cont
  */
 static gboolean applet_scroll(MatePanelApplet* applet, GdkEventScroll* event, PagerData* pager)
 {
+#ifdef HAVE_X11
 	GdkScrollDirection absolute_direction;
 	int index;
 	int n_workspaces;
 	int n_columns;
 	int in_last_row;
+#endif /* HAVE_X11 */
 
 	if (event->type != GDK_SCROLL)
 		return FALSE;
@@ -340,7 +342,6 @@ static gboolean applet_scroll(MatePanelApplet* applet, GdkEventScroll* event, Pa
 		n_workspaces = wnck_screen_get_workspace_count(pager->screen);
 	}
 	else
-#endif /* HAVE_X11 */
 	{
 		index = 0;
 		n_workspaces = 1;
@@ -431,7 +432,6 @@ static gboolean applet_scroll(MatePanelApplet* applet, GdkEventScroll* event, Pa
 			break;
 	}
 
-#ifdef HAVE_X11
 	if (pager->screen)
 	{
 		wnck_workspace_activate(wnck_screen_get_workspace(pager->screen, index), event->time);


### PR DESCRIPTION
```
applets/wncklet/workspace-switcher.c:378:11: style: Variable 'index' is assigned a value that is never used. [unreadVariable]
    index += n_columns;
          ^
applets/wncklet/workspace-switcher.c:382:11: style: Variable 'index' is assigned a value that is never used. [unreadVariable]
    index = 0;
          ^
applets/wncklet/workspace-switcher.c:386:11: style: Variable 'index' is assigned a value that is never used. [unreadVariable]
    index = (index % n_columns) + 1;
          ^
applets/wncklet/workspace-switcher.c:393:10: style: Variable 'index' is assigned a value that is never used. [unreadVariable]
    index++;
         ^
applets/wncklet/workspace-switcher.c:397:18: style: Variable 'index' is assigned a value that is never used. [unreadVariable]
           index = 0;
                 ^
applets/wncklet/workspace-switcher.c:416:11: style: Variable 'index' is assigned a value that is never used. [unreadVariable]
    index -= n_columns;
          ^
applets/wncklet/workspace-switcher.c:422:10: style: Variable 'index' is assigned a value that is never used. [unreadVariable]
    index--;
         ^
applets/wncklet/workspace-switcher.c:426:11: style: Variable 'index' is assigned a value that is never used. [unreadVariable]
    index = n_workspaces - 1;
          ^
```