### PR TITLE
 Variable is reassigned a value before the old one has been used

### DIFF
--- a/mate-panel/libpanel-util/panel-xdg.c
+++ b/mate-panel/libpanel-util/panel-xdg.c
@@ -117,18 +117,12 @@ panel_xdg_icon_name_from_icon_path (const char *path,
 			gboolean  current;
 
 			theme_dir = g_file_get_child (parent, theme_name);
-
-			current = FALSE;
-			if (g_file_has_prefix (file, theme_dir)) {
-				/* it's the current one */
-				current = TRUE;
-			} else {
-				/* it's the default one */
+			if ((current = g_file_has_prefix (file, theme_dir)) == FALSE) {
+				/* fallback icon theme? */
 				g_object_unref (theme_dir);
 				theme_dir = g_file_get_child (parent, DEFAULT_THEME_NAME);
 				current = g_file_has_prefix (file, theme_dir);
 			}
-
 			g_object_unref (theme_dir);
 
 			if (current) {

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -773,7 +773,6 @@ static void panel_toplevel_move_to(PanelToplevel* toplevel, int new_x, int new_y
 	y = new_y - panel_multimonitor_y (new_monitor);
 
 	if (toplevel->priv->orientation & PANEL_HORIZONTAL_MASK) {
-		y_centered = FALSE;
 		if (new_y          <= display_min.y + snap_tolerance ||
 		    new_y + height >= display_max.y - snap_tolerance)
 			x_centered = abs (x - ((monitor_geom.width - width) / 2))
@@ -781,7 +780,6 @@ static void panel_toplevel_move_to(PanelToplevel* toplevel, int new_x, int new_y
 		else
 			x_centered = FALSE;
 	} else {
-		x_centered = FALSE;
 		if (new_x         <= display_min.x + snap_tolerance ||
 		    new_x + width >= display_max.x - snap_tolerance)
 			y_centered = abs (y - ((monitor_geom.height - height) / 2))


### PR DESCRIPTION
reported by cppcheck:
```
mate-panel/libpanel-util/panel-xdg.c:124:13: style: Variable 'current' is reassigned a value before the old one has been used. [redundantAssignment]
    current = TRUE;
            ^
mate-panel/libpanel-util/panel-xdg.c:121:12: note: current is assigned
   current = FALSE;
           ^
mate-panel/libpanel-util/panel-xdg.c:124:13: note: current is overwritten
    current = TRUE;
            ^
```
```
mate-panel/panel-toplevel.c:779:15: style: Variable 'x_centered' is reassigned a value before the old one has been used. [redundantAssignment]
   x_centered = abs (x - ((monitor_geom.width - width) / 2))
              ^
mate-panel/panel-toplevel.c:769:13: note: x_centered is assigned
 x_centered = toplevel->priv->x_centered;
            ^
mate-panel/panel-toplevel.c:779:15: note: x_centered is overwritten
   x_centered = abs (x - ((monitor_geom.width - width) / 2))
              ^
```
```
mate-panel/panel-toplevel.c:776:14: style: Variable 'y_centered' is reassigned a value before the old one has been used. [redundantAssignment]
  y_centered = FALSE;
             ^
mate-panel/panel-toplevel.c:770:13: note: y_centered is assigned
 y_centered = toplevel->priv->y_centered;
            ^
mate-panel/panel-toplevel.c:776:14: note: y_centered is overwritten
  y_centered = FALSE;
             ^
```