### PR TITLE
Local variable shadows outer variable warning reported by cppcheck

### DIFF
--- a/applets/notification_area/status-notifier/sn-item-v0.c
+++ b/applets/notification_area/status-notifier/sn-item-v0.c
@@ -83,7 +83,7 @@ enum
   LAST_PROP
 };
 
-static GParamSpec *properties[LAST_PROP] = { NULL };
+static GParamSpec *obj_properties[LAST_PROP] = { NULL };
 
 G_DEFINE_TYPE (SnItemV0, sn_item_v0, SN_TYPE_ITEM)
 
@@ -1345,15 +1345,15 @@ sn_item_v0_set_property (GObject      *object,
 static void
 install_properties (GObjectClass *object_class)
 {
-  properties[PROP_ICON_SIZE] =
+  obj_properties[PROP_ICON_SIZE] =
     g_param_spec_int ("icon-size", "Icon size", "Icon size", 0, G_MAXINT, 16,
                       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
-  properties[PROP_ICON_PADDING] =
+  obj_properties[PROP_ICON_PADDING] =
     g_param_spec_int ("icon-padding", "Icon padding", "Icon padding", 0,
                       G_MAXINT, 0, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_properties (object_class, LAST_PROP, properties);
+  g_object_class_install_properties (object_class, LAST_PROP, obj_properties);
 }
 
 static void
@@ -1465,7 +1465,7 @@ sn_item_v0_set_icon_size (SnItemV0 *v0,
   if (v0->icon_size != size)
     {
       v0->icon_size = size;
-      g_object_notify_by_pspec (G_OBJECT (v0), properties[PROP_ICON_SIZE]);
+      g_object_notify_by_pspec (G_OBJECT (v0), obj_properties[PROP_ICON_SIZE]);
 
       if (v0->id != NULL)
         queue_update (v0);

--- a/mate-panel/libpanel-util/panel-icon-chooser.c
+++ b/mate-panel/libpanel-util/panel-icon-chooser.c
@@ -357,7 +357,6 @@ _panel_icon_chooser_clicked (GtkButton *button)
 	GtkWidget        *filechooser;
 	GtkWidget        *toplevel;
 	GtkWindow        *parent;
-	char             *path;
 	gboolean          filechooser_path_set;
 
 	if (chooser->priv->filechooser) {
@@ -382,15 +381,11 @@ _panel_icon_chooser_clicked (GtkButton *button)
 
 	panel_gtk_file_chooser_add_image_preview (GTK_FILE_CHOOSER (filechooser));
 
-	path = g_build_filename (DATADIR, "icons", NULL);
 	gtk_file_chooser_add_shortcut_folder (GTK_FILE_CHOOSER (filechooser),
-					      path, NULL);
-	g_free (path);
+	                                      DATADIR "/icons", NULL);
 
-	path = g_build_filename (DATADIR, "pixmaps", NULL);
 	gtk_file_chooser_add_shortcut_folder (GTK_FILE_CHOOSER (filechooser),
-					      path, NULL);
-	g_free (path);
+	                                      DATADIR "/pixmaps", NULL);
 
 	filechooser_path_set = FALSE;
 
@@ -428,14 +423,11 @@ _panel_icon_chooser_clicked (GtkButton *button)
 	}
 
 	if (!filechooser_path_set) {
-		char *path;
 		/* FIXME? Use current icon theme? But there might not be a lot
 		 * of icons there...
 		 */
-		path = g_build_filename (DATADIR, "icons", NULL);
 		gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (filechooser),
-						     path);
-		g_free (path);
+						     DATADIR "/icons");
 	}
 
 	gtk_window_set_destroy_with_parent (GTK_WINDOW (filechooser), TRUE);

--- a/mate-panel/panel-menu-items.c
+++ b/mate-panel/panel-menu-items.c
@@ -903,19 +903,19 @@ panel_place_menu_item_append_local_gio (PanelPlaceMenuItem *place_item,
 	if (g_slist_length (items) <= g_settings_get_uint (place_item->priv->menubar_settings, PANEL_MENU_BAR_MAX_ITEMS_OR_SUBMENU)) {
 		add_menu = menu;
 	} else {
-		GtkWidget  *item;
+		GtkWidget  *menu_item;
 
-		item = gtk_image_menu_item_new ();
-		setup_menuitem_with_icon (item, panel_menu_icon_get_size (),
-					  NULL,
-					  PANEL_ICON_REMOVABLE_MEDIA,
-					   _("Removable Media"));
+		menu_item = gtk_image_menu_item_new ();
+		setup_menuitem_with_icon (menu_item, panel_menu_icon_get_size (),
+		                          NULL,
+		                          PANEL_ICON_REMOVABLE_MEDIA,
+		                          _("Removable Media"));
 
-		gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
-		gtk_widget_show (item);
+		gtk_menu_shell_append (GTK_MENU_SHELL (menu), menu_item);
+		gtk_widget_show (menu_item);
 
 		add_menu = create_empty_menu ();
-		gtk_menu_item_set_submenu (GTK_MENU_ITEM (item), add_menu);
+		gtk_menu_item_set_submenu (GTK_MENU_ITEM (menu_item), add_menu);
 	}
 
 	for (sl = items; sl; sl = sl->next) {

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -3243,7 +3243,7 @@ panel_toplevel_size_allocate (GtkWidget     *widget,
 	GtkBin          *bin = (GtkBin *) widget;
 	GtkStyleContext *context;
 	GtkStateFlags    state;
-	GtkBorder padding;
+	GtkBorder        padding;
 	GtkWidget       *child;
 	GtkAllocation    challoc;
 	GtkAllocation    child_allocation;
@@ -3299,10 +3299,11 @@ panel_toplevel_size_allocate (GtkWidget     *widget,
 	     challoc.y != child_allocation.y ||
 	     challoc.width  != child_allocation.width ||
 	     challoc.height != child_allocation.height)) {
-		GtkAllocation allocation;
+		GtkAllocation allocation_to_invalidate;
 
-		gtk_widget_get_allocation (widget, &allocation);
-		gdk_window_invalidate_rect (gtk_widget_get_window (widget), &allocation, FALSE);
+		gtk_widget_get_allocation (widget, &allocation_to_invalidate);
+		gdk_window_invalidate_rect (gtk_widget_get_window (widget),
+		                            &allocation_to_invalidate, FALSE);
 	}
 
 	if (child && gtk_widget_get_visible (child))


### PR DESCRIPTION
reported by cppcheck:
```
applets/notification_area/status-notifier/sn-item-v0.c:918:13: style: Local variable 'properties' shadows outer variable [shadowVariable]
mate-panel/libpanel-util/panel-icon-chooser.c:398:9: style: Local variable 'path' shadows outer variable [shadowVariable]
mate-panel/libpanel-util/panel-icon-chooser.c:431:9: style: Local variable 'path' shadows outer variable [shadowVariable]
mate-panel/panel-multimonitor.c:224:16: style: Local variable 'geometries' shadows outer variable [shadowVariable]
mate-panel/panel-multimonitor.c:278:16: style: Local variable 'geometries' shadows outer variable [shadowVariable]
mate-panel/panel-multimonitor.c:107:22: style: Local variable 'geometries' shadows outer variable [shadowVariable]
```
reported by gcc:
```
panel-menu-items.c:906:15: warning: declaration of 'item' shadows a previous local [-Wshadow]
```
```
panel-toplevel.c:3302:17: warning: declaration of 'allocation' shadows a parameter [-Wshadow]
```