### PR TITLE
Register SNI host only if SNI is enabled

### DIFF
--- a/applets/notification_area/na-grid.c
+++ b/applets/notification_area/na-grid.c
@@ -318,6 +318,7 @@ na_grid_realize (GtkWidget *widget)
   GdkScreen *screen;
   GtkOrientation orientation;
   NaHost *tray_host;
+  GSettings *settings = g_settings_new ("org.mate.panel");
 
   GTK_WIDGET_CLASS (na_grid_parent_class)->realize (widget);
 
@@ -330,7 +331,11 @@ na_grid_realize (GtkWidget *widget)
                           G_BINDING_DEFAULT);
 
   add_host (self, tray_host);
-  add_host (self, sn_host_v0_new ());
+
+  if (g_settings_get_boolean (settings, "enable-sni-support"))
+    add_host (self, sn_host_v0_new ());
+
+  g_object_unref (settings);
 }
 
 static void


### PR DESCRIPTION
From time to time, I'm testing some third-party SNI implementations (just for the sake of knowledge) on my favorite DE ( ;) ) and observed that with `enable-sni-support = false`, default applet still registers SNI host and if SNI watcher of other tray implementation accepts registration from that applet, tray icons being duplicated. In practice, I discovered this with the xapp's applet.