### PR TITLE
travis CI: use base-devel tag for archlinux  docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ after_success:
      fi'
 
 env:
-  - DISTRO="archlinux:latest"
+  - DISTRO="archlinux:base-devel"
   - DISTRO="debian:testing"
   - DISTRO="fedora:latest"
   - DISTRO="ubuntu:rolling"


### PR DESCRIPTION
archlinux:base-devel has the [base-devel group](https://archlinux.org/groups/x86_64/base-devel/) installed
https://hub.docker.com/r/archlinux/archlinux