### PR TITLE
clock: Add option to show all location's local time in display

### DIFF
--- a/applets/clock/clock.ui
+++ b/applets/clock/clock.ui
@@ -514,6 +514,21 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="all_locations_check">
+                                <property name="label" translatable="yes">Show all loc_ations' local time in clock</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkCheckButton" id="weather_check">
                                 <property name="label" translatable="yes">Show _weather</property>
                                 <property name="visible">True</property>
@@ -525,7 +540,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
@@ -540,7 +555,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                           </object>

--- a/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
+++ b/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
@@ -64,6 +64,11 @@
       <summary>Show week numbers in calendar</summary>
       <description>If true, show week numbers in the calendar.</description>
     </key>
+    <key name="show-all-locations" type="b">
+      <default>false</default>
+      <summary>Show all locations in clock display</summary>
+      <description>If true, display the local time of all locations in the clock.</description>
+    </key>
     <key name="expand-locations" type="b">
       <default>false</default>
       <summary>Expand list of locations</summary>


### PR DESCRIPTION
Hi! Not sure if this is useful to enough people to warrant merging but I figured I'd check.

I have to work with multiple timezones, enough that clicking on the applet to get multiple local times was annoying... So I added an option to the clock applet to display the local time of all locations in the locations tabs of the settings.

![image](https://user-images.githubusercontent.com/5545257/109430533-dee9fd80-79cf-11eb-9bd0-898e001251af.png)

This MR:

* Adds the logic to optionally display all locations' formatted time in the task bar
* Adds a `show-all-locations` boolean in the settings schema
* Add a tickbox to enable the option in the settings
    *    ![image](https://user-images.githubusercontent.com/5545257/109431019-53be3700-79d2-11eb-9164-b2a1291bf41d.png)

I'm not familiar with how translations are supposed to be done however.

## Tests

This was developed tested on mate-panel 1.24 (apt-get source in Ubuntu 20.04) then ported to master. Patch applied almost cleanly, with the exception that the `cd->locations` list was now a singly-linked list (GSList) instead of a double-linked one (GList).

Works fine, only issue is adding locations sometimes crashes the applet, but it also does that without these changes so I think that is #1138 and not me :)