### PR TITLE
Fix clock applet crash after adding time zone location

### DIFF
--- a/applets/clock/clock-location.c
+++ b/applets/clock/clock-location.c
@@ -92,7 +92,7 @@ clock_location_find_and_ref (GSList       *locations,
         }
 
         if (l != NULL)
-                return g_object_ref (CLOCK_LOCATION (l->data));
+                return CLOCK_LOCATION (l->data);
         else
                 return NULL;
 }

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -2252,7 +2252,7 @@ location_start_element (GMarkupParseContext *context,
         if (current && clock_location_is_current_timezone (loc))
                 clock_location_make_current (loc, NULL, NULL, NULL);
 
-        data->cities = g_slist_append (data->cities, loc);
+        data->cities = g_slist_append (data->cities, g_object_ref (loc));
 }
 
 static GMarkupParser location_parser = {
@@ -2682,7 +2682,7 @@ run_prefs_edit_save (GtkButton *button, ClockData *cd)
                  */
                 clock_location_is_current (loc);
 
-                cd->locations = g_slist_append (cd->locations, loc);
+                cd->locations = g_slist_append (cd->locations, g_object_ref (loc));
         }
         g_free (name);
         g_free (city);


### PR DESCRIPTION
Fix clock applet crash after adding City Location
#1138 
### test
```
... make pr ... make install
pkill -f /usr/libexec/clock-applet
pkill -f mate-panel

clock-applet->edit->location->add
```