### PR TITLE
remove deprecated gtk_container_set_focus_chain

### DIFF
--- a/mate-panel/panel-ditem-editor.c
+++ b/mate-panel/panel-ditem-editor.c
@@ -582,6 +582,7 @@ panel_ditem_editor_make_ui (PanelDItemEditor *dialog)
 {
 	PanelDItemEditorPrivate *priv;
 	GtkWidget *dialog_vbox;
+	GtkWidget *box;
 
 	priv = dialog->priv;
 
@@ -590,11 +591,23 @@ panel_ditem_editor_make_ui (PanelDItemEditor *dialog)
 	dialog_vbox = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
 	gtk_box_set_spacing (GTK_BOX (dialog_vbox), 2);
 
+	box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
+	gtk_box_pack_start (GTK_BOX (dialog_vbox), box, TRUE, TRUE, 0);
+	gtk_widget_show (box);
+
+	/* Icon */
+	priv->icon_chooser = panel_icon_chooser_new (NULL);
+	panel_icon_chooser_set_fallback_icon_name (PANEL_ICON_CHOOSER (priv->icon_chooser),
+	                       PANEL_ICON_LAUNCHER);
+	gtk_box_pack_start (GTK_BOX (box), priv->icon_chooser, FALSE, FALSE, 0);
+	gtk_widget_set_valign (priv->icon_chooser, GTK_ALIGN_START);
+	gtk_widget_show (priv->icon_chooser);
+
 	priv->grid = gtk_grid_new ();
 	gtk_container_set_border_width (GTK_CONTAINER (priv->grid), 5);
 	gtk_grid_set_row_spacing (GTK_GRID (priv->grid), 6);
 	gtk_grid_set_column_spacing (GTK_GRID (priv->grid), 12);
-	gtk_box_pack_start (GTK_BOX (dialog_vbox), priv->grid, TRUE, TRUE, 0);
+	gtk_box_pack_start (GTK_BOX (box), priv->grid, TRUE, TRUE, 0);
 	gtk_widget_show (priv->grid);
 
 	/* Type */
@@ -610,13 +623,6 @@ panel_ditem_editor_make_ui (PanelDItemEditor *dialog)
 	gtk_widget_show (priv->name_entry);
 	gtk_label_set_mnemonic_widget (GTK_LABEL (priv->name_label),
 				       priv->name_entry);
-
-	/* Icon */
-	priv->icon_chooser = panel_icon_chooser_new (NULL);
-	panel_icon_chooser_set_fallback_icon_name (PANEL_ICON_CHOOSER (priv->icon_chooser),
-						   PANEL_ICON_LAUNCHER);
-	gtk_grid_attach (GTK_GRID (priv->grid), priv->icon_chooser, 0, 0, 1, 2);
-	gtk_widget_show (priv->icon_chooser);
 
 	/* Command */
 	priv->command_label = label_new_with_mnemonic ("");
@@ -676,7 +682,6 @@ panel_ditem_editor_setup_ui (PanelDItemEditor *dialog)
 	PanelDItemEditorPrivate *priv;
 	PanelDItemEditorType     type;
 	gboolean                 show_combo;
-	GList                   *focus_chain;
 
 	priv = dialog->priv;
 	type = panel_ditem_editor_get_item_type (dialog);
@@ -717,17 +722,17 @@ panel_ditem_editor_setup_ui (PanelDItemEditor *dialog)
 		GtkTreeModel         *model;
 		PanelDItemEditorType  buf_type;
 
-		grid_attach_label (GTK_GRID (priv->grid), priv->type_label, 1, 0, 1, 1);
-		grid_attach_entry (GTK_GRID (priv->grid), priv->type_combo, 2, 0, 1, 1);
+		grid_attach_label (GTK_GRID (priv->grid), priv->type_label, 0, 0, 1, 1);
+		grid_attach_entry (GTK_GRID (priv->grid), priv->type_combo, 1, 0, 1, 1);
 
-		grid_attach_label (GTK_GRID (priv->grid), priv->name_label, 1, 1, 1, 1);
-		grid_attach_entry (GTK_GRID (priv->grid), priv->name_entry, 2, 1, 1, 1);
+		grid_attach_label (GTK_GRID (priv->grid), priv->name_label, 0, 1, 1, 1);
+		grid_attach_entry (GTK_GRID (priv->grid), priv->name_entry, 1, 1, 1, 1);
 
-		grid_attach_label (GTK_GRID (priv->grid), priv->command_label, 1, 2, 1, 1);
-		grid_attach_entry (GTK_GRID (priv->grid), priv->command_hbox, 2, 2, 1, 1);
+		grid_attach_label (GTK_GRID (priv->grid), priv->command_label, 0, 2, 1, 1);
+		grid_attach_entry (GTK_GRID (priv->grid), priv->command_hbox, 1, 2, 1, 1);
 
-		grid_attach_label (GTK_GRID (priv->grid), priv->comment_label, 1, 3, 1, 1);
-		grid_attach_entry (GTK_GRID (priv->grid), priv->comment_entry, 2, 3, 1, 1);
+		grid_attach_label (GTK_GRID (priv->grid), priv->comment_label, 0, 3, 1, 1);
+		grid_attach_entry (GTK_GRID (priv->grid), priv->comment_entry, 1, 3, 1, 1);
 
 		/* FIXME: hack hack hack */
 		model = gtk_combo_box_get_model (GTK_COMBO_BOX (priv->type_combo));
@@ -743,35 +748,23 @@ panel_ditem_editor_setup_ui (PanelDItemEditor *dialog)
 			}
 		} while (gtk_tree_model_iter_next (model, &iter));
 	} else if (type == PANEL_DITEM_EDITOR_TYPE_DIRECTORY) {
-		grid_attach_label (GTK_GRID (priv->grid), priv->name_label, 1, 0, 1, 1);
-		grid_attach_entry (GTK_GRID (priv->grid), priv->name_entry, 2, 0, 1, 1);
+		grid_attach_label (GTK_GRID (priv->grid), priv->name_label, 0, 0, 1, 1);
+		grid_attach_entry (GTK_GRID (priv->grid), priv->name_entry, 1, 0, 1, 1);
 
-		grid_attach_label (GTK_GRID (priv->grid), priv->comment_label, 1, 1, 1, 1);
-		grid_attach_entry (GTK_GRID (priv->grid), priv->comment_entry, 2, 1, 1, 1);
+		grid_attach_label (GTK_GRID (priv->grid), priv->comment_label, 0, 1, 1, 1);
+		grid_attach_entry (GTK_GRID (priv->grid), priv->comment_entry, 1, 1, 1, 1);
 	} else {
-		grid_attach_label (GTK_GRID (priv->grid), priv->name_label, 1, 0, 1, 1);
-		grid_attach_entry (GTK_GRID (priv->grid), priv->name_entry, 2, 0, 1, 1);
+		grid_attach_label (GTK_GRID (priv->grid), priv->name_label, 0, 0, 1, 1);
+		grid_attach_entry (GTK_GRID (priv->grid), priv->name_entry, 1, 0, 1, 1);
 
-		grid_attach_label (GTK_GRID (priv->grid), priv->command_label, 1, 1, 1, 1);
-		grid_attach_entry (GTK_GRID (priv->grid), priv->command_hbox, 2, 1, 1, 1);
+		grid_attach_label (GTK_GRID (priv->grid), priv->command_label, 0, 1, 1, 1);
+		grid_attach_entry (GTK_GRID (priv->grid), priv->command_hbox, 1, 1, 1, 1);
 
-		grid_attach_label (GTK_GRID (priv->grid), priv->comment_label, 1, 2, 1, 1);
-		grid_attach_entry (GTK_GRID (priv->grid), priv->comment_entry, 2, 2, 1, 1);
+		grid_attach_label (GTK_GRID (priv->grid), priv->comment_label, 0, 2, 1, 1);
+		grid_attach_entry (GTK_GRID (priv->grid), priv->comment_entry, 1, 2, 1, 1);
 	}
 
 	type_combo_changed (dialog);
-
-	/* set a focus chain since GTK+ doesn't want to put the icon entry
-	 * as the first widget in the chain */
-	focus_chain = NULL;
-	focus_chain = g_list_prepend (focus_chain, priv->icon_chooser);
-	focus_chain = g_list_prepend (focus_chain, priv->type_combo);
-	focus_chain = g_list_prepend (focus_chain, priv->name_entry);
-	focus_chain = g_list_prepend (focus_chain, priv->command_hbox);
-	focus_chain = g_list_prepend (focus_chain, priv->comment_entry);
-	focus_chain = g_list_reverse (focus_chain);
-	gtk_container_set_focus_chain (GTK_CONTAINER (priv->grid), focus_chain);
-	g_list_free (focus_chain);
 
 	gtk_widget_grab_focus (priv->name_entry);
 }


### PR DESCRIPTION
This function can be removed directly. This function has no effect and brings compilation warning