### PR TITLE
Make Recent Documents list in Places menu of configurable length

### DIFF
--- a/data/org.mate.panel.menubar.gschema.xml.in
+++ b/data/org.mate.panel.menubar.gschema.xml.in
@@ -50,5 +50,11 @@
       <summary>Threshold of menu items before submenu is created</summary>
       <description>Maximum number of menu items (i.e. bookmarks) that are displayed without being put in a submenu.</description>
     </key>
+    <key name="max-recent-items" type="i">
+      <range min="-1"/>
+      <default>10</default>
+      <summary>Maximum number of recent documents displayed in the Places menu</summary>
+      <description>Maximum number of recent documents that are displayed in the Places menu at a time. If this is set to -1, all known recent documents will be displayed.</description>
+    </key>
   </schema>
 </schemalist>

--- a/mate-panel/panel-menu-items.c
+++ b/mate-panel/panel-menu-items.c
@@ -1025,6 +1025,7 @@ panel_place_menu_item_create_menu (PanelPlaceMenuItem *place_item)
 	char      *name;
 	char      *uri;
 	GFile     *file;
+	int        recent_items_limit;
 
 	places_menu = panel_create_menu ();
 
@@ -1120,8 +1121,12 @@ panel_place_menu_item_create_menu (PanelPlaceMenuItem *place_item)
 						      NULL,
 						      FALSE);
 
+	recent_items_limit = g_settings_get_int (place_item->priv->menubar_settings,
+						 PANEL_MENU_BAR_MAX_RECENT_ITEMS);
+
 	panel_recent_append_documents_menu (places_menu,
-					    place_item->priv->recent_manager);
+					    place_item->priv->recent_manager,
+					    recent_items_limit);
 /* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
 	GtkWidget *toplevel = gtk_widget_get_toplevel (places_menu);
 	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
@@ -1378,6 +1383,10 @@ panel_place_menu_item_init (PanelPlaceMenuItem *menuitem)
 	menuitem->priv->menubar_settings = g_settings_new (PANEL_MENU_BAR_SCHEMA);
 	g_signal_connect (menuitem->priv->menubar_settings,
 			"changed::" PANEL_MENU_BAR_MAX_ITEMS_OR_SUBMENU,
+			G_CALLBACK (panel_place_menu_item_key_changed),
+			G_OBJECT (menuitem));
+	g_signal_connect (menuitem->priv->menubar_settings,
+			"changed::" PANEL_MENU_BAR_MAX_RECENT_ITEMS,
 			G_CALLBACK (panel_place_menu_item_key_changed),
 			G_OBJECT (menuitem));
 

--- a/mate-panel/panel-recent.c
+++ b/mate-panel/panel-recent.c
@@ -185,7 +185,8 @@ recent_documents_clear_cb (GtkMenuItem      *menuitem,
 
 void
 panel_recent_append_documents_menu (GtkWidget        *top_menu,
-				    GtkRecentManager *manager)
+				    GtkRecentManager *manager,
+				    int               recent_items_limit)
 {
 	GtkWidget      *recent_menu;
 	GtkWidget      *menu_item;
@@ -199,6 +200,9 @@ panel_recent_append_documents_menu (GtkWidget        *top_menu,
 				  _("Recent Documents"));
 	recent_menu = gtk_recent_chooser_menu_new_for_manager (manager);
 	gtk_menu_item_set_submenu (GTK_MENU_ITEM (menu_item), recent_menu);
+	
+	gtk_recent_chooser_set_limit (GTK_RECENT_CHOOSER (recent_menu),
+				      recent_items_limit);
 
 	g_signal_connect (G_OBJECT (recent_menu), "button_press_event",
 			  G_CALLBACK (menu_dummy_button_press_event), NULL);

--- a/mate-panel/panel-recent.h
+++ b/mate-panel/panel-recent.h
@@ -32,7 +32,8 @@ extern "C" {
 #endif
 
 void panel_recent_append_documents_menu (GtkWidget        *menu,
-					 GtkRecentManager *manager);
+					 GtkRecentManager *manager,
+					 int               recent_items_limit);
 
 #ifdef __cplusplus
 }

--- a/mate-panel/panel-schemas.h
+++ b/mate-panel/panel-schemas.h
@@ -66,6 +66,7 @@
 #define PANEL_MENU_BAR_SHOW_ICON_KEY          "show-icon"
 #define PANEL_MENU_BAR_ICON_NAME_KEY          "icon-name"
 #define PANEL_MENU_BAR_MAX_ITEMS_OR_SUBMENU   "max-items-or-submenu"
+#define PANEL_MENU_BAR_MAX_RECENT_ITEMS       "max-recent-items"
 
 /* external schemas */
 


### PR DESCRIPTION
As requested by a fellow user on the Ubuntu MATE forum at https://ubuntu-mate.community/t/number-of-recent-documents/23802, the Recent Documents list in the Places menu on a panel should be of configurable length, since not all users want to see as few or as many as 10 recent documents in the menu.  This pull request resolves the issue.  The number of recently used documents displayed is determined by the value of the setting `org.mate.panel.menubar.max-recent-items` (default 10, like has been the default for years).