### PR TITLE
Window list properties dialog: use GtkNotebook

### DIFF
--- a/applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in
+++ b/applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in
@@ -20,9 +20,9 @@
       <summary>Move windows to current workspace when unminimized</summary>
       <description>If true, then when unminimizing a window, move it to the current workspace. Otherwise, switch to the workspace of the window.</description>
     </key>
-    <key name="scroll-enabled" type="b">
+    <key name="mouse-scrolling" type="b">
       <default>true</default>
-      <summary>Whether to enable mouse scrolling in the switch window list</summary>
+      <summary>Whether to enable mouse scrolling in the window list</summary>
       <description>If true, enable mouse scrolling in window list, otherwise disable mouse scrolling in window list.</description>
     </key>
   </schema>

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -50,42 +50,42 @@ enum {
 };
 
 typedef struct {
-	GtkWidget* applet;
-	GtkWidget* tasklist;
+    GtkWidget* applet;
+    GtkWidget* tasklist;
 #ifdef HAVE_WINDOW_PREVIEWS
-	GtkWidget* preview;
+    GtkWidget* preview;
 #endif
 
-	GtkOrientation orientation;
-	int size;
+    GtkOrientation orientation;
+    int size;
 #if !defined(WNCKLET_INPROCESS) && !GTK_CHECK_VERSION (3, 23, 0)
-	gboolean needs_hints;
+    gboolean needs_hints;
 #endif
 
-	GtkIconTheme* icon_theme;
+    GtkIconTheme* icon_theme;
 
-	/* Properties: */
-	GtkWidget* properties_dialog;
-	GtkWidget* display_all_workspaces_radio;
+    /* Properties: */
+    GtkWidget* properties_dialog;
+    GtkWidget* display_all_workspaces_radio;
 #ifdef HAVE_WINDOW_PREVIEWS
-	GtkWidget* window_thumbnail_box;
-	GtkWidget* show_thumbnails_check;
-	GtkWidget* thumbnail_size_label;
-	GtkWidget* thumbnail_size_spin;
-	GtkWidget* thumbnail_box;
+    GtkWidget* window_thumbnail_box;
+    GtkWidget* show_thumbnails_check;
+    GtkWidget* thumbnail_size_label;
+    GtkWidget* thumbnail_size_spin;
+    GtkWidget* thumbnail_box;
 #endif
-	GtkWidget* never_group_radio;
-	GtkWidget* auto_group_radio;
-	GtkWidget* always_group_radio;
-	GtkWidget* restore_to_current_workspace_radio;
-	GtkWidget* mouse_scroll_check;
-	GtkWidget* minimized_windows_box;
-	GtkWidget* window_grouping_box;
-	GtkWidget* window_list_content_box;
+    GtkWidget* never_group_radio;
+    GtkWidget* auto_group_radio;
+    GtkWidget* always_group_radio;
+    GtkWidget* restore_to_current_workspace_radio;
+    GtkWidget* mouse_scroll_check;
+    GtkWidget* minimized_windows_box;
+    GtkWidget* window_grouping_box;
+    GtkWidget* window_list_content_box;
 
-	GSettings* settings;
+    GSettings* settings;
 #ifdef HAVE_WINDOW_PREVIEWS
-	GSettings* preview_settings;
+    GSettings* preview_settings;
 #endif
 } TasklistData;
 
@@ -97,77 +97,77 @@ static void destroy_tasklist(GtkWidget* widget, TasklistData* tasklist);
 
 static void tasklist_set_size_request(TasklistData* tasklist)
 {
-	if (tasklist->orientation == GTK_ORIENTATION_HORIZONTAL)
-	{
-		gtk_widget_set_size_request(GTK_WIDGET(tasklist->tasklist), -1, tasklist->size);
-	}
-	else
-	{
-		gtk_widget_set_size_request(GTK_WIDGET(tasklist->tasklist), tasklist->size, -1);
-	}
+    if (tasklist->orientation == GTK_ORIENTATION_HORIZONTAL)
+    {
+        gtk_widget_set_size_request(GTK_WIDGET(tasklist->tasklist), -1, tasklist->size);
+    }
+    else
+    {
+        gtk_widget_set_size_request(GTK_WIDGET(tasklist->tasklist), tasklist->size, -1);
+    }
 }
 
 static void tasklist_apply_orientation(TasklistData* tasklist)
 {
 #ifdef HAVE_X11
-	if (WNCK_IS_TASKLIST(tasklist->tasklist))
-	{
-		wnck_tasklist_set_orientation(WNCK_TASKLIST(tasklist->tasklist), tasklist->orientation);
-	}
+    if (WNCK_IS_TASKLIST(tasklist->tasklist))
+    {
+        wnck_tasklist_set_orientation(WNCK_TASKLIST(tasklist->tasklist), tasklist->orientation);
+    }
 #endif /* HAVE_X11 */
 
 #ifdef HAVE_WAYLAND
-	if (GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default()))
-	{
-		wayland_tasklist_set_orientation(tasklist->tasklist, tasklist->orientation);
-	}
+    if (GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default()))
+    {
+        wayland_tasklist_set_orientation(tasklist->tasklist, tasklist->orientation);
+    }
 #endif
 }
 
 static void tasklist_set_button_relief(TasklistData* tasklist, GtkReliefStyle relief)
 {
 #ifdef HAVE_X11
-	if (WNCK_IS_TASKLIST(tasklist->tasklist))
-	{
-		wnck_tasklist_set_button_relief(WNCK_TASKLIST(tasklist->tasklist), relief);
-	}
+    if (WNCK_IS_TASKLIST(tasklist->tasklist))
+    {
+        wnck_tasklist_set_button_relief(WNCK_TASKLIST(tasklist->tasklist), relief);
+    }
 #endif /* HAVE_X11 */
 
-	/* Not implemented for Wayland */
+    /* Not implemented for Wayland */
 }
 
 static const int* tasklist_get_size_hint_list(TasklistData* tasklist, int* n_elements)
 {
 #ifdef HAVE_X11
-	if (WNCK_IS_TASKLIST(tasklist->tasklist))
-	{
-		return wnck_tasklist_get_size_hint_list(WNCK_TASKLIST(tasklist->tasklist), n_elements);
-	}
-	else
+    if (WNCK_IS_TASKLIST(tasklist->tasklist))
+    {
+        return wnck_tasklist_get_size_hint_list(WNCK_TASKLIST(tasklist->tasklist), n_elements);
+    }
+    else
 #endif /* HAVE_X11 */
 
-	{
-		/* Not implemented for Wayland */
-		*n_elements = 0;
-		return NULL;
-	}
+    {
+        /* Not implemented for Wayland */
+        *n_elements = 0;
+        return NULL;
+    }
 }
 
 static void on_tasklist_properties_dialog_response(GtkWidget* widget, int id, TasklistData* tasklist)
 {
-	if (id == GTK_RESPONSE_HELP)
-	{
-		wncklet_display_help(widget, "mate-user-guide", "windowlist-prefs", WINDOW_LIST_ICON);
-	}
-	else
-	{
-		gtk_widget_hide(widget);
-	}
+    if (id == GTK_RESPONSE_HELP)
+    {
+        wncklet_display_help(widget, "mate-user-guide", "windowlist-prefs", WINDOW_LIST_ICON);
+    }
+    else
+    {
+        gtk_widget_hide(widget);
+    }
 }
 
 static void applet_realized(MatePanelApplet* applet, TasklistData* tasklist)
 {
-	tasklist->icon_theme = gtk_icon_theme_get_for_screen(gtk_widget_get_screen(tasklist->applet));
+    tasklist->icon_theme = gtk_icon_theme_get_for_screen(gtk_widget_get_screen(tasklist->applet));
 }
 
 static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient orient, TasklistData* tasklist)
@@ -197,14 +197,14 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 
 static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, cairo_pattern_t* pattern, TasklistData* tasklist)
 {
-	switch (type)
-	{
-		case PANEL_NO_BACKGROUND:
-		case PANEL_COLOR_BACKGROUND:
-		case PANEL_PIXMAP_BACKGROUND:
-			tasklist_set_button_relief(tasklist, GTK_RELIEF_NONE);
-			break;
-	}
+    switch (type)
+    {
+        case PANEL_NO_BACKGROUND:
+        case PANEL_COLOR_BACKGROUND:
+        case PANEL_PIXMAP_BACKGROUND:
+            tasklist_set_button_relief(tasklist, GTK_RELIEF_NONE);
+            break;
+    }
 }
 
 #ifdef HAVE_X11
@@ -216,69 +216,69 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
                           int          *thumbnail_height,
                           int          *thumbnail_scale)
 {
-	GdkWindow *window;
-	GdkWindow *window_wrapper = NULL;
-	Window win;
-	cairo_surface_t *thumbnail;
-	cairo_t *cr;
-	double ratio;
-	int width, height, scale;
+    GdkWindow *window;
+    GdkWindow *window_wrapper = NULL;
+    Window win;
+    cairo_surface_t *thumbnail;
+    cairo_t *cr;
+    double ratio;
+    int width, height, scale;
 
-	win = wnck_window_get_xid (wnck_window);
+    win = wnck_window_get_xid (wnck_window);
 
-	if ((window = gdk_x11_window_lookup_for_display (gdk_display_get_default (), win)) == NULL)
-	{
-		if ((window = gdk_x11_window_foreign_new_for_display (gdk_display_get_default (), win)) == NULL)
-		{
-			return NULL;
-		}
-		else
-		{
-			window_wrapper = window;
-		}
-	}
-	else
-	{
-		g_object_ref (window);
-	}
+    if ((window = gdk_x11_window_lookup_for_display (gdk_display_get_default (), win)) == NULL)
+    {
+        if ((window = gdk_x11_window_foreign_new_for_display (gdk_display_get_default (), win)) == NULL)
+        {
+            return NULL;
+        }
+        else
+        {
+            window_wrapper = window;
+        }
+    }
+    else
+    {
+        g_object_ref (window);
+    }
 
-	*thumbnail_scale = scale = gdk_window_get_scale_factor (window);
-	width = gdk_window_get_width (window) * scale;
-	height = gdk_window_get_height (window) * scale;
+    *thumbnail_scale = scale = gdk_window_get_scale_factor (window);
+    width = gdk_window_get_width (window) * scale;
+    height = gdk_window_get_height (window) * scale;
 
-	int thumbnail_size = g_settings_get_int (tasklist->preview_settings, "thumbnail-window-size");
+    int thumbnail_size = g_settings_get_int (tasklist->preview_settings, "thumbnail-window-size");
 
-	/* Scale to configured size while maintaining aspect ratio */
-	if (width > height)
-	{
-		int max_size = MIN (width, thumbnail_size * scale);
-		ratio = (double) max_size / (double) width;
-		*thumbnail_width = max_size;
-		*thumbnail_height = (int) ((double) height * ratio);
-	}
-	else
-	{
-		int max_size = MIN (height, thumbnail_size * scale);
-		ratio = (double) max_size / (double) height;
-		*thumbnail_height = max_size;
-		*thumbnail_width = (int) ((double) width * ratio);
-	}
+    /* Scale to configured size while maintaining aspect ratio */
+    if (width > height)
+    {
+        int max_size = MIN (width, thumbnail_size * scale);
+        ratio = (double) max_size / (double) width;
+        *thumbnail_width = max_size;
+        *thumbnail_height = (int) ((double) height * ratio);
+    }
+    else
+    {
+        int max_size = MIN (height, thumbnail_size * scale);
+        ratio = (double) max_size / (double) height;
+        *thumbnail_height = max_size;
+        *thumbnail_width = (int) ((double) width * ratio);
+    }
 
-	thumbnail = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
-	                                        *thumbnail_width,
-	                                        *thumbnail_height);
-	cairo_surface_set_device_scale (thumbnail, scale, scale);
-	cr = cairo_create (thumbnail);
-	cairo_scale (cr, ratio, ratio);
-	gdk_cairo_set_source_window (cr, window, 0, 0);
-	cairo_paint (cr);
-	cairo_destroy (cr);
+    thumbnail = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
+                                            *thumbnail_width,
+                                            *thumbnail_height);
+    cairo_surface_set_device_scale (thumbnail, scale, scale);
+    cr = cairo_create (thumbnail);
+    cairo_scale (cr, ratio, ratio);
+    gdk_cairo_set_source_window (cr, window, 0, 0);
+    cairo_paint (cr);
+    cairo_destroy (cr);
 
-	if (window_wrapper)
-		g_object_unref (window_wrapper);
-	g_object_unref (window);
+    if (window_wrapper)
+        g_object_unref (window_wrapper);
+    g_object_unref (window);
 
-	return thumbnail;
+    return thumbnail;
 }
 
 #define PREVIEW_PADDING 5
@@ -289,448 +289,448 @@ preview_window_reposition (TasklistData    *tasklist,
                            int              height,
                            int              scale)
 {
-	GdkMonitor *monitor;
-	GdkRectangle monitor_geom;
-	int x_pos, y_pos;
+    GdkMonitor *monitor;
+    GdkRectangle monitor_geom;
+    int x_pos, y_pos;
 
-	/* Set position at pointer, then re-adjust from there to just outside of the pointer */
-	gtk_window_set_position (GTK_WINDOW (tasklist->preview), GTK_WIN_POS_MOUSE);
-	gtk_window_get_position (GTK_WINDOW (tasklist->preview), &x_pos, &y_pos);
+    /* Set position at pointer, then re-adjust from there to just outside of the pointer */
+    gtk_window_set_position (GTK_WINDOW (tasklist->preview), GTK_WIN_POS_MOUSE);
+    gtk_window_get_position (GTK_WINDOW (tasklist->preview), &x_pos, &y_pos);
 
-	/* Get geometry of monitor where tasklist is located to calculate correct position of preview */
-	monitor = gdk_display_get_monitor_at_point (gdk_display_get_default (), x_pos, y_pos);
-	gdk_monitor_get_geometry (monitor, &monitor_geom);
+    /* Get geometry of monitor where tasklist is located to calculate correct position of preview */
+    monitor = gdk_display_get_monitor_at_point (gdk_display_get_default (), x_pos, y_pos);
+    gdk_monitor_get_geometry (monitor, &monitor_geom);
 
-	/* Add padding to clear the panel */
-	switch (mate_panel_applet_get_orient (MATE_PANEL_APPLET (tasklist->applet)))
-	{
-		case MATE_PANEL_APPLET_ORIENT_LEFT:
-			x_pos = monitor_geom.width + monitor_geom.x - (width/scale + tasklist->size) - PREVIEW_PADDING;
-			break;
-		case MATE_PANEL_APPLET_ORIENT_RIGHT:
-			x_pos = tasklist->size + PREVIEW_PADDING;
-			break;
-		case MATE_PANEL_APPLET_ORIENT_UP:
-			y_pos = monitor_geom.height + monitor_geom.y - (height/scale + tasklist->size) - PREVIEW_PADDING;
-			break;
-		case MATE_PANEL_APPLET_ORIENT_DOWN:
-		default:
-			y_pos = tasklist->size + PREVIEW_PADDING;
-			break;
-	}
+    /* Add padding to clear the panel */
+    switch (mate_panel_applet_get_orient (MATE_PANEL_APPLET (tasklist->applet)))
+    {
+        case MATE_PANEL_APPLET_ORIENT_LEFT:
+            x_pos = monitor_geom.width + monitor_geom.x - (width/scale + tasklist->size) - PREVIEW_PADDING;
+            break;
+        case MATE_PANEL_APPLET_ORIENT_RIGHT:
+            x_pos = tasklist->size + PREVIEW_PADDING;
+            break;
+        case MATE_PANEL_APPLET_ORIENT_UP:
+            y_pos = monitor_geom.height + monitor_geom.y - (height/scale + tasklist->size) - PREVIEW_PADDING;
+            break;
+        case MATE_PANEL_APPLET_ORIENT_DOWN:
+        default:
+            y_pos = tasklist->size + PREVIEW_PADDING;
+            break;
+    }
 
-	gtk_window_move (GTK_WINDOW (tasklist->preview), x_pos, y_pos);
+    gtk_window_move (GTK_WINDOW (tasklist->preview), x_pos, y_pos);
 }
 
 static gboolean preview_window_draw (GtkWidget *widget, cairo_t *cr, cairo_surface_t *thumbnail)
 {
-	GtkStyleContext *context;
+    GtkStyleContext *context;
 
-	context = gtk_widget_get_style_context (widget);
-	gtk_render_icon_surface (context, cr, thumbnail, 0, 0);
+    context = gtk_widget_get_style_context (widget);
+    gtk_render_icon_surface (context, cr, thumbnail, 0, 0);
 
-	return FALSE;
+    return FALSE;
 }
 
 static gboolean applet_enter_notify_event (WnckTasklist *tl, GList *wnck_windows, TasklistData *tasklist)
 {
-	cairo_surface_t *thumbnail;
-	WnckWindow *wnck_window = NULL;
-	int n_windows;
-	int thumbnail_width;
-	int thumbnail_height;
-	int thumbnail_scale;
+    cairo_surface_t *thumbnail;
+    WnckWindow *wnck_window = NULL;
+    int n_windows;
+    int thumbnail_width;
+    int thumbnail_height;
+    int thumbnail_scale;
 
-	if (tasklist->preview != NULL)
-	{
-		gtk_widget_destroy (tasklist->preview);
-		tasklist->preview = NULL;
-	}
+    if (tasklist->preview != NULL)
+    {
+        gtk_widget_destroy (tasklist->preview);
+        tasklist->preview = NULL;
+    }
 
-	if (!g_settings_get_boolean (tasklist->preview_settings, "show-window-thumbnails") || wnck_windows == NULL)
-		return FALSE;
+    if (!g_settings_get_boolean (tasklist->preview_settings, "show-window-thumbnails") || wnck_windows == NULL)
+        return FALSE;
 
-	n_windows = g_list_length (wnck_windows);
-	/* TODO: Display a list of stacked thumbnails for grouped windows. */
-	if (n_windows == 1)
-	{
-		GList* l = wnck_windows;
-		if (l != NULL)
-			wnck_window = (WnckWindow*)l->data;
-	}
+    n_windows = g_list_length (wnck_windows);
+    /* TODO: Display a list of stacked thumbnails for grouped windows. */
+    if (n_windows == 1)
+    {
+        GList* l = wnck_windows;
+        if (l != NULL)
+            wnck_window = (WnckWindow*)l->data;
+    }
 
-	if (wnck_window == NULL)
-		return FALSE;
+    if (wnck_window == NULL)
+        return FALSE;
 
-	/* Do not show preview if window is not visible nor in current workspace */
-	if (!wnck_window_is_visible_on_workspace (wnck_window,
-						  wnck_screen_get_active_workspace (wnck_screen_get_default ())))
-		return FALSE;
+    /* Do not show preview if window is not visible nor in current workspace */
+    if (!wnck_window_is_visible_on_workspace (wnck_window,
+                          wnck_screen_get_active_workspace (wnck_screen_get_default ())))
+        return FALSE;
 
-	thumbnail = preview_window_thumbnail (wnck_window, tasklist, &thumbnail_width, &thumbnail_height, &thumbnail_scale);
+    thumbnail = preview_window_thumbnail (wnck_window, tasklist, &thumbnail_width, &thumbnail_height, &thumbnail_scale);
 
-	if (thumbnail == NULL)
-		return FALSE;
+    if (thumbnail == NULL)
+        return FALSE;
 
-	/* Create window to display preview */
-	tasklist->preview = gtk_window_new (GTK_WINDOW_POPUP);
+    /* Create window to display preview */
+    tasklist->preview = gtk_window_new (GTK_WINDOW_POPUP);
 
-	gtk_widget_set_app_paintable (tasklist->preview, TRUE);
-	gtk_window_set_default_size (GTK_WINDOW (tasklist->preview), thumbnail_width/thumbnail_scale, thumbnail_height/thumbnail_scale);
-	gtk_window_set_resizable (GTK_WINDOW (tasklist->preview), TRUE);
+    gtk_widget_set_app_paintable (tasklist->preview, TRUE);
+    gtk_window_set_default_size (GTK_WINDOW (tasklist->preview), thumbnail_width/thumbnail_scale, thumbnail_height/thumbnail_scale);
+    gtk_window_set_resizable (GTK_WINDOW (tasklist->preview), TRUE);
 
-	preview_window_reposition (tasklist, thumbnail, thumbnail_width, thumbnail_height, thumbnail_scale);
+    preview_window_reposition (tasklist, thumbnail, thumbnail_width, thumbnail_height, thumbnail_scale);
 
-	gtk_widget_show (tasklist->preview);
+    gtk_widget_show (tasklist->preview);
 
-	g_signal_connect_data (G_OBJECT (tasklist->preview), "draw", G_CALLBACK (preview_window_draw), thumbnail, (GClosureNotify) G_CALLBACK (cairo_surface_destroy), 0);
+    g_signal_connect_data (G_OBJECT (tasklist->preview), "draw", G_CALLBACK (preview_window_draw), thumbnail, (GClosureNotify) G_CALLBACK (cairo_surface_destroy), 0);
 
-	return FALSE;
+    return FALSE;
 }
 
 static gboolean applet_leave_notify_event (WnckTasklist *tl, GList *wnck_windows, TasklistData *tasklist)
 {
-	if (tasklist->preview != NULL)
-	{
-		gtk_widget_destroy (tasklist->preview);
-		tasklist->preview = NULL;
-	}
+    if (tasklist->preview != NULL)
+    {
+        gtk_widget_destroy (tasklist->preview);
+        tasklist->preview = NULL;
+    }
 
-	return FALSE;
+    return FALSE;
 }
 #endif /* HAVE_WINDOW_PREVIEWS */
 #endif /* HAVE_X11 */
 
 static void applet_change_pixel_size(MatePanelApplet* applet, gint size, TasklistData* tasklist)
 {
-	if (tasklist->size == size)
-		return;
+    if (tasklist->size == size)
+        return;
 
-	tasklist->size = size;
+    tasklist->size = size;
 
-	tasklist_set_size_request(tasklist);
+    tasklist_set_size_request(tasklist);
 }
 
 /* TODO: this is sad, should be used a function to retrieve  applications from
  *  .desktop or some like that. */
 static const char* system_monitors[] = {
-	"mate-system-monitor",
-	"gnome-system-monitor",
+    "mate-system-monitor",
+    "gnome-system-monitor",
 };
 
 static const GtkActionEntry tasklist_menu_actions[] = {
-	{
-		"TasklistSystemMonitor",
-		"utilities-system-monitor",
-		N_("_System Monitor"),
-		NULL,
-		NULL,
-		G_CALLBACK(call_system_monitor)
-	},
-	{
-		"TasklistPreferences",
-		"document-properties",
-		N_("_Preferences"),
-		NULL,
-		NULL,
-		G_CALLBACK(display_properties_dialog)
-	},
-	{
-		"TasklistHelp",
-		"help-browser",
-		N_("_Help"),
-		NULL,
-		NULL,
-		G_CALLBACK(display_help_dialog)
-	},
-	{
-		"TasklistAbout",
-		"help-about",
-		N_("_About"),
-		NULL,
-		NULL,
-		G_CALLBACK(display_about_dialog)
-	}
+    {
+        "TasklistSystemMonitor",
+        "utilities-system-monitor",
+        N_("_System Monitor"),
+        NULL,
+        NULL,
+        G_CALLBACK(call_system_monitor)
+    },
+    {
+        "TasklistPreferences",
+        "document-properties",
+        N_("_Preferences"),
+        NULL,
+        NULL,
+        G_CALLBACK(display_properties_dialog)
+    },
+    {
+        "TasklistHelp",
+        "help-browser",
+        N_("_Help"),
+        NULL,
+        NULL,
+        G_CALLBACK(display_help_dialog)
+    },
+    {
+        "TasklistAbout",
+        "help-about",
+        N_("_About"),
+        NULL,
+        NULL,
+        G_CALLBACK(display_about_dialog)
+    }
 };
 
 static void applet_size_allocate(GtkWidget *widget, GtkAllocation *allocation, TasklistData *tasklist)
 {
-	int len;
-	const int* size_hints;
+    int len;
+    const int* size_hints;
 
-	size_hints = tasklist_get_size_hint_list (tasklist, &len);
+    size_hints = tasklist_get_size_hint_list (tasklist, &len);
 
-	g_assert(len % 2 == 0);
+    g_assert(len % 2 == 0);
 
 #if !defined(WNCKLET_INPROCESS) && !GTK_CHECK_VERSION (3, 23, 0)
-	/* HACK: When loading the WnckTasklist initially, it reports size hints as though there were
-	 * no elements in the Tasklist. This causes a rendering issue when built out-of-process in
-	 * HiDPI displays. We keep a flag to skip size hinting until WnckTasklist has something to
-	 * show. */
-	if (!tasklist->needs_hints)
-	{
-		int i;
-		for (i = 0; i < len; i++)
-		{
-			if (size_hints[i])
-			{
-				tasklist->needs_hints = TRUE;
-				break;
-			}
-		}
-	}
+    /* HACK: When loading the WnckTasklist initially, it reports size hints as though there were
+     * no elements in the Tasklist. This causes a rendering issue when built out-of-process in
+     * HiDPI displays. We keep a flag to skip size hinting until WnckTasklist has something to
+     * show. */
+    if (!tasklist->needs_hints)
+    {
+        int i;
+        for (i = 0; i < len; i++)
+        {
+            if (size_hints[i])
+            {
+                tasklist->needs_hints = TRUE;
+                break;
+            }
+        }
+    }
 
-	if (tasklist->needs_hints)
+    if (tasklist->needs_hints)
 #endif
-		mate_panel_applet_set_size_hints(MATE_PANEL_APPLET(tasklist->applet), size_hints, len, 0);
+        mate_panel_applet_set_size_hints(MATE_PANEL_APPLET(tasklist->applet), size_hints, len, 0);
 }
 
 #ifdef HAVE_X11
 /* Currently only used on X11, but should work on Wayland as well when needed */
 static GdkPixbuf* icon_loader_func(const char* icon, int size, unsigned int flags, void* data)
 {
-	TasklistData* tasklist;
-	GdkPixbuf* retval;
-	char* icon_no_extension;
-	char* p;
+    TasklistData* tasklist;
+    GdkPixbuf* retval;
+    char* icon_no_extension;
+    char* p;
 
-	tasklist = data;
+    tasklist = data;
 
-	if (icon == NULL || strcmp(icon, "") == 0)
-		return NULL;
+    if (icon == NULL || strcmp(icon, "") == 0)
+        return NULL;
 
-	if (g_path_is_absolute(icon))
-	{
-		if (g_file_test(icon, G_FILE_TEST_EXISTS))
-		{
-			return gdk_pixbuf_new_from_file_at_size(icon, size, size, NULL);
-		}
-		else
-		{
-			char* basename;
+    if (g_path_is_absolute(icon))
+    {
+        if (g_file_test(icon, G_FILE_TEST_EXISTS))
+        {
+            return gdk_pixbuf_new_from_file_at_size(icon, size, size, NULL);
+        }
+        else
+        {
+            char* basename;
 
-			basename = g_path_get_basename(icon);
-			retval = icon_loader_func(basename, size, flags, data);
-			g_free(basename);
+            basename = g_path_get_basename(icon);
+            retval = icon_loader_func(basename, size, flags, data);
+            g_free(basename);
 
-			return retval;
-		}
-	}
+            return retval;
+        }
+    }
 
-	/* This is needed because some .desktop files have an icon name *and*
-	* an extension as icon */
-	icon_no_extension = g_strdup(icon);
-	p = strrchr(icon_no_extension, '.');
+    /* This is needed because some .desktop files have an icon name *and*
+    * an extension as icon */
+    icon_no_extension = g_strdup(icon);
+    p = strrchr(icon_no_extension, '.');
 
-	if (p && (strcmp(p, ".png") == 0 || strcmp(p, ".xpm") == 0 || strcmp(p, ".svg") == 0))
-	{
-		*p = 0;
-	}
+    if (p && (strcmp(p, ".png") == 0 || strcmp(p, ".xpm") == 0 || strcmp(p, ".svg") == 0))
+    {
+        *p = 0;
+    }
 
-	retval = gtk_icon_theme_load_icon(tasklist->icon_theme, icon_no_extension, size, 0, NULL);
-	g_free(icon_no_extension);
+    retval = gtk_icon_theme_load_icon(tasklist->icon_theme, icon_no_extension, size, 0, NULL);
+    g_free(icon_no_extension);
 
-	return retval;
+    return retval;
 }
 #endif /* HAVE_X11 */
 
 gboolean window_list_applet_fill(MatePanelApplet* applet)
 {
-	TasklistData* tasklist;
-	GtkActionGroup* action_group;
-	GtkCssProvider  *provider;
-	GdkScreen *screen;
+    TasklistData* tasklist;
+    GtkActionGroup* action_group;
+    GtkCssProvider  *provider;
+    GdkScreen *screen;
 
-	tasklist = g_new0(TasklistData, 1);
+    tasklist = g_new0(TasklistData, 1);
 
-	tasklist->applet = GTK_WIDGET(applet);
+    tasklist->applet = GTK_WIDGET(applet);
 
-	provider = gtk_css_provider_new ();
-	screen = gdk_screen_get_default ();
-	gtk_css_provider_load_from_data (provider,
-										".mate-panel-menu-bar button,\n"
-										" #tasklist-button {\n"
-										" padding: 0px;\n"
-										" margin: 0px;\n }",
-										-1, NULL);
-	gtk_style_context_add_provider_for_screen (screen,
-										GTK_STYLE_PROVIDER (provider),
-										GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-	g_object_unref (provider);
+    provider = gtk_css_provider_new ();
+    screen = gdk_screen_get_default ();
+    gtk_css_provider_load_from_data (provider,
+                                     ".mate-panel-menu-bar button,\n"
+                                     " #tasklist-button {\n"
+                                     " padding: 0px;\n"
+                                     " margin: 0px;\n }",
+                                     -1, NULL);
+    gtk_style_context_add_provider_for_screen (screen,
+                                               GTK_STYLE_PROVIDER (provider),
+                                               GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    g_object_unref (provider);
 
-	mate_panel_applet_set_flags(MATE_PANEL_APPLET(tasklist->applet), MATE_PANEL_APPLET_EXPAND_MAJOR | MATE_PANEL_APPLET_EXPAND_MINOR | MATE_PANEL_APPLET_HAS_HANDLE);
+    mate_panel_applet_set_flags(MATE_PANEL_APPLET(tasklist->applet), MATE_PANEL_APPLET_EXPAND_MAJOR | MATE_PANEL_APPLET_EXPAND_MINOR | MATE_PANEL_APPLET_HAS_HANDLE);
 
-	tasklist->settings = mate_panel_applet_settings_new (MATE_PANEL_APPLET (tasklist->applet), WINDOW_LIST_SCHEMA);
+    tasklist->settings = mate_panel_applet_settings_new (MATE_PANEL_APPLET (tasklist->applet), WINDOW_LIST_SCHEMA);
 #ifdef HAVE_WINDOW_PREVIEWS
-	tasklist->preview_settings = mate_panel_applet_settings_new (MATE_PANEL_APPLET (tasklist->applet), WINDOW_LIST_PREVIEW_SCHEMA);
+    tasklist->preview_settings = mate_panel_applet_settings_new (MATE_PANEL_APPLET (tasklist->applet), WINDOW_LIST_PREVIEW_SCHEMA);
 #endif
 
-	tasklist->size = mate_panel_applet_get_size(applet);
+    tasklist->size = mate_panel_applet_get_size(applet);
 
 #if !defined(WNCKLET_INPROCESS) && !GTK_CHECK_VERSION (3, 23, 0)
-	tasklist->needs_hints = FALSE;
+    tasklist->needs_hints = FALSE;
 #endif
 
-	switch (mate_panel_applet_get_orient(applet))
-	{
-		case MATE_PANEL_APPLET_ORIENT_LEFT:
-		case MATE_PANEL_APPLET_ORIENT_RIGHT:
-			tasklist->orientation = GTK_ORIENTATION_VERTICAL;
-			break;
-		case MATE_PANEL_APPLET_ORIENT_UP:
-		case MATE_PANEL_APPLET_ORIENT_DOWN:
-		default:
-			tasklist->orientation = GTK_ORIENTATION_HORIZONTAL;
-			break;
-	}
+    switch (mate_panel_applet_get_orient(applet))
+    {
+        case MATE_PANEL_APPLET_ORIENT_LEFT:
+        case MATE_PANEL_APPLET_ORIENT_RIGHT:
+            tasklist->orientation = GTK_ORIENTATION_VERTICAL;
+            break;
+        case MATE_PANEL_APPLET_ORIENT_UP:
+        case MATE_PANEL_APPLET_ORIENT_DOWN:
+        default:
+            tasklist->orientation = GTK_ORIENTATION_HORIZONTAL;
+            break;
+    }
 
 #ifdef HAVE_X11
-	if (GDK_IS_X11_DISPLAY (gdk_display_get_default ()))
-	{
-		tasklist->tasklist = wnck_tasklist_new();
+    if (GDK_IS_X11_DISPLAY (gdk_display_get_default ()))
+    {
+        tasklist->tasklist = wnck_tasklist_new();
 
-		wnck_tasklist_set_middle_click_close (WNCK_TASKLIST (tasklist->tasklist), TRUE);
-		wnck_tasklist_set_icon_loader(WNCK_TASKLIST(tasklist->tasklist), icon_loader_func, tasklist, NULL);
+        wnck_tasklist_set_middle_click_close (WNCK_TASKLIST (tasklist->tasklist), TRUE);
+        wnck_tasklist_set_icon_loader(WNCK_TASKLIST(tasklist->tasklist), icon_loader_func, tasklist, NULL);
 
 #ifdef HAVE_WINDOW_PREVIEWS
-		g_signal_connect(G_OBJECT(tasklist->tasklist), "task_enter_notify", G_CALLBACK(applet_enter_notify_event), tasklist);
-		g_signal_connect(G_OBJECT(tasklist->tasklist), "task_leave_notify", G_CALLBACK(applet_leave_notify_event), tasklist);
+        g_signal_connect(G_OBJECT(tasklist->tasklist), "task_enter_notify", G_CALLBACK(applet_enter_notify_event), tasklist);
+        g_signal_connect(G_OBJECT(tasklist->tasklist), "task_leave_notify", G_CALLBACK(applet_leave_notify_event), tasklist);
 #endif /* HAVE_WINDOW_PREVIEWS */
-	}
-	else
+    }
+    else
 #endif /* HAVE_X11 */
 
 #ifdef HAVE_WAYLAND
-	if (GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default ()))
-	{
-		tasklist->tasklist = wayland_tasklist_new();
-	}
-	else
+    if (GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default ()))
+    {
+        tasklist->tasklist = wayland_tasklist_new();
+    }
+    else
 #endif /* HAVE_WAYLAND */
 
-	{
-		tasklist->tasklist = gtk_label_new ("[Tasklist not supported on this platform]");
-	}
+    {
+        tasklist->tasklist = gtk_label_new ("[Tasklist not supported on this platform]");
+    }
 
-	tasklist_apply_orientation(tasklist);
+    tasklist_apply_orientation(tasklist);
 
-	g_signal_connect(G_OBJECT(tasklist->tasklist), "destroy", G_CALLBACK(destroy_tasklist), tasklist);
-	g_signal_connect(G_OBJECT(tasklist->applet), "size_allocate", G_CALLBACK(applet_size_allocate), tasklist);
+    g_signal_connect(G_OBJECT(tasklist->tasklist), "destroy", G_CALLBACK(destroy_tasklist), tasklist);
+    g_signal_connect(G_OBJECT(tasklist->applet), "size_allocate", G_CALLBACK(applet_size_allocate), tasklist);
 
-	gtk_container_add(GTK_CONTAINER(tasklist->applet), tasklist->tasklist);
+    gtk_container_add(GTK_CONTAINER(tasklist->applet), tasklist->tasklist);
 
-	g_signal_connect(G_OBJECT(tasklist->applet), "realize", G_CALLBACK(applet_realized), tasklist);
-	g_signal_connect(G_OBJECT(tasklist->applet), "change_orient", G_CALLBACK(applet_change_orient), tasklist);
-	g_signal_connect(G_OBJECT(tasklist->applet), "change_size", G_CALLBACK(applet_change_pixel_size), tasklist);
-	g_signal_connect(G_OBJECT(tasklist->applet), "change_background", G_CALLBACK(applet_change_background), tasklist);
+    g_signal_connect(G_OBJECT(tasklist->applet), "realize", G_CALLBACK(applet_realized), tasklist);
+    g_signal_connect(G_OBJECT(tasklist->applet), "change_orient", G_CALLBACK(applet_change_orient), tasklist);
+    g_signal_connect(G_OBJECT(tasklist->applet), "change_size", G_CALLBACK(applet_change_pixel_size), tasklist);
+    g_signal_connect(G_OBJECT(tasklist->applet), "change_background", G_CALLBACK(applet_change_background), tasklist);
 
-	action_group = gtk_action_group_new("Tasklist Applet Actions");
-	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);
-	gtk_action_group_add_actions(action_group, tasklist_menu_actions, G_N_ELEMENTS(tasklist_menu_actions), tasklist);
-
-
-	/* disable the item of system monitor, if not exists.
-	 * example, mate-system-monitor, o gnome-system-monitor */
-	char* programpath;
-	int i;
-
-	for (i = 0; i < G_N_ELEMENTS(system_monitors); i += 1)
-	{
-		programpath = g_find_program_in_path(system_monitors[i]);
-
-		if (programpath != NULL)
-		{
-			g_free(programpath);
-			/* we give up */
-			goto _system_monitor_found;
-		}
-
-		/* search another */
-	}
-
-	/* system monitor not found */
-	gtk_action_set_visible(gtk_action_group_get_action(action_group, "TasklistSystemMonitor"), FALSE);
-
-	_system_monitor_found:;
-	/* end of system monitor item */
+    action_group = gtk_action_group_new("Tasklist Applet Actions");
+    gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);
+    gtk_action_group_add_actions(action_group, tasklist_menu_actions, G_N_ELEMENTS(tasklist_menu_actions), tasklist);
 
 
-	mate_panel_applet_setup_menu_from_resource (MATE_PANEL_APPLET (tasklist->applet),
-	                                            WNCKLET_RESOURCE_PATH "window-list-menu.xml",
-	                                            action_group);
+    /* disable the item of system monitor, if not exists.
+     * example, mate-system-monitor, o gnome-system-monitor */
+    char* programpath;
+    int i;
 
-	if (mate_panel_applet_get_locked_down(MATE_PANEL_APPLET(tasklist->applet)))
-	{
-		GtkAction* action;
+    for (i = 0; i < G_N_ELEMENTS(system_monitors); i += 1)
+    {
+        programpath = g_find_program_in_path(system_monitors[i]);
 
-		action = gtk_action_group_get_action(action_group, "TasklistPreferences");
-		gtk_action_set_visible(action, FALSE);
-	}
+        if (programpath != NULL)
+        {
+            g_free(programpath);
+            /* we give up */
+            goto _system_monitor_found;
+        }
 
-	g_object_unref(action_group);
+        /* search another */
+    }
 
-	tasklist_set_size_request(tasklist);
-	gtk_widget_show(tasklist->tasklist);
-	gtk_widget_show(tasklist->applet);
+    /* system monitor not found */
+    gtk_action_set_visible(gtk_action_group_get_action(action_group, "TasklistSystemMonitor"), FALSE);
 
-	return TRUE;
+    _system_monitor_found:;
+    /* end of system monitor item */
+
+
+    mate_panel_applet_setup_menu_from_resource (MATE_PANEL_APPLET (tasklist->applet),
+                                                WNCKLET_RESOURCE_PATH "window-list-menu.xml",
+                                                action_group);
+
+    if (mate_panel_applet_get_locked_down(MATE_PANEL_APPLET(tasklist->applet)))
+    {
+        GtkAction* action;
+
+        action = gtk_action_group_get_action(action_group, "TasklistPreferences");
+        gtk_action_set_visible(action, FALSE);
+    }
+
+    g_object_unref(action_group);
+
+    tasklist_set_size_request(tasklist);
+    gtk_widget_show(tasklist->tasklist);
+    gtk_widget_show(tasklist->applet);
+
+    return TRUE;
 }
 
 static void call_system_monitor(GtkAction* action, TasklistData* tasklist)
 {
-	int i;
+    int i;
 
-	for (i = 0; i < G_N_ELEMENTS(system_monitors); i += 1)
-	{
-		char *programpath = g_find_program_in_path(system_monitors[i]);
+    for (i = 0; i < G_N_ELEMENTS(system_monitors); i += 1)
+    {
+        char *programpath = g_find_program_in_path(system_monitors[i]);
 
-		if (programpath != NULL)
-		{
-			g_free(programpath);
+        if (programpath != NULL)
+        {
+            g_free(programpath);
 
-			mate_gdk_spawn_command_line_on_screen(gtk_widget_get_screen(tasklist->applet),
-				      system_monitors[i],
-				      NULL);
-			return;
-		}
-	}
+            mate_gdk_spawn_command_line_on_screen(gtk_widget_get_screen(tasklist->applet),
+                                                  system_monitors[i],
+                                                  NULL);
+            return;
+        }
+    }
 }
 
 static void display_help_dialog(GtkAction* action, TasklistData* tasklist)
 {
-	wncklet_display_help(tasklist->applet, "mate-user-guide", "windowlist", WINDOW_LIST_ICON);
+    wncklet_display_help(tasklist->applet, "mate-user-guide", "windowlist", WINDOW_LIST_ICON);
 }
 
 static void display_about_dialog(GtkAction* action, TasklistData* tasklist)
 {
-	static const gchar* authors[] = {
-		"Perberos <perberos@gmail.com>",
-		"Steve Zesch <stevezesch2@gmail.com>",
-		"Stefano Karapetsas <stefano@karapetsas.com>",
-		"Alexander Larsson <alla@lysator.liu.se>",
-		NULL
-	};
+    static const gchar* authors[] = {
+        "Perberos <perberos@gmail.com>",
+        "Steve Zesch <stevezesch2@gmail.com>",
+        "Stefano Karapetsas <stefano@karapetsas.com>",
+        "Alexander Larsson <alla@lysator.liu.se>",
+        NULL
+    };
 
-	const char* documenters [] = {
-		"Sun GNOME Documentation Team <gdocteam@sun.com>",
-		NULL
-	};
+    const char* documenters [] = {
+        "Sun GNOME Documentation Team <gdocteam@sun.com>",
+        NULL
+    };
 
-	gtk_show_about_dialog(GTK_WINDOW(tasklist->applet),
-		"program-name", _("Window List"),
-		"title", _("About Window List"),
-		"authors", authors,
-		"comments", _("The Window List shows a list of all windows in a set of buttons and lets you browse them."),
-		"copyright", _("Copyright \xc2\xa9 2002 Red Hat, Inc.\n"
-		               "Copyright \xc2\xa9 2011 Perberos\n"
-		               "Copyright \xc2\xa9 2012-2021 MATE developers"),
-		"documenters", documenters,
-		"icon-name", WINDOW_LIST_ICON,
-		"logo-icon-name", WINDOW_LIST_ICON,
-		"translator-credits", _("translator-credits"),
-		"version", VERSION,
-		"website", PACKAGE_URL,
-		NULL);
+    gtk_show_about_dialog(GTK_WINDOW(tasklist->applet),
+        "program-name", _("Window List"),
+        "title", _("About Window List"),
+        "authors", authors,
+        "comments", _("The Window List shows a list of all windows in a set of buttons and lets you browse them."),
+        "copyright", _("Copyright \xc2\xa9 2002 Red Hat, Inc.\n"
+                       "Copyright \xc2\xa9 2011 Perberos\n"
+                       "Copyright \xc2\xa9 2012-2021 MATE developers"),
+        "documenters", documenters,
+        "icon-name", WINDOW_LIST_ICON,
+        "logo-icon-name", WINDOW_LIST_ICON,
+        "translator-credits", _("translator-credits"),
+        "version", VERSION,
+        "website", PACKAGE_URL,
+        NULL);
 }
 
 static void mouse_scrolling_callback(GSettings* settings, gchar *key, TasklistData* tasklist)
@@ -751,7 +751,7 @@ static void display_all_workspaces_callback(GSettings* settings, gchar *key, Tas
 #ifdef HAVE_WINDOW_PREVIEWS
 static void on_thumbnail_size_spin_value_changed(GtkSpinButton* button, TasklistData* tasklist)
 {
-	g_settings_set_int(tasklist->preview_settings, "thumbnail-window-size", gtk_spin_button_get_value_as_int(button));
+    g_settings_set_int(tasklist->preview_settings, "thumbnail-window-size", gtk_spin_button_get_value_as_int(button));
 }
 #endif
 
@@ -769,6 +769,7 @@ static void on_auto_group_radio_toggled(GtkRadioButton* button, TasklistData* ta
 
 static void on_always_group_radio_toggled(GtkRadioButton* button, TasklistData* tasklist)
 {
+
     g_settings_set_enum (tasklist->settings, "group-windows", TASKLIST_ALWAYS_GROUP);
     wnck_tasklist_set_grouping(WNCK_TASKLIST(tasklist->tasklist), WNCK_TASKLIST_ALWAYS_GROUP);
 }
@@ -777,70 +778,65 @@ static void on_always_group_radio_toggled(GtkRadioButton* button, TasklistData* 
 
 static void setup_dialog(GtkBuilder* builder, TasklistData* tasklist)
 {
-	tasklist->display_all_workspaces_radio = GET_WIDGET("display_all_workspaces_radio");
-	tasklist->never_group_radio = GET_WIDGET("never_group_radio");
-	tasklist->auto_group_radio = GET_WIDGET("auto_group_radio");
-	tasklist->always_group_radio = GET_WIDGET("always_group_radio");
+    tasklist->display_all_workspaces_radio = GET_WIDGET("display_all_workspaces_radio");
+    tasklist->never_group_radio = GET_WIDGET("never_group_radio");
+    tasklist->auto_group_radio = GET_WIDGET("auto_group_radio");
+    tasklist->always_group_radio = GET_WIDGET("always_group_radio");
 
 #ifdef HAVE_WINDOW_PREVIEWS
-	tasklist->window_thumbnail_box = GET_WIDGET("window_thumbnail_box");
-	tasklist->show_thumbnails_check = GET_WIDGET("show_thumbnails_check");
-	tasklist->thumbnail_size_spin = GET_WIDGET("thumbnail_size_spin");
-	tasklist->thumbnail_box = GET_WIDGET("thumbnail_box");
+    tasklist->window_thumbnail_box = GET_WIDGET("window_thumbnail_box");
+    tasklist->show_thumbnails_check = GET_WIDGET("show_thumbnails_check");
+    tasklist->thumbnail_size_spin = GET_WIDGET("thumbnail_size_spin");
+    tasklist->thumbnail_box = GET_WIDGET("thumbnail_box");
 
-	g_settings_bind(tasklist->preview_settings,
-                    "show-window-thumbnails",
-                    tasklist->show_thumbnails_check,
-                    "active",
+    g_settings_bind(tasklist->preview_settings, "show-window-thumbnails",
+                    tasklist->show_thumbnails_check, "active",
                     G_SETTINGS_BIND_DEFAULT);
 
-	gtk_widget_set_sensitive (tasklist->thumbnail_box, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(tasklist->show_thumbnails_check)));
-	g_object_bind_property(tasklist->show_thumbnails_check, "active", tasklist->thumbnail_box, "sensitive", G_BINDING_DEFAULT);
+    gtk_widget_set_sensitive (tasklist->thumbnail_box,
+                              gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(tasklist->show_thumbnails_check)));
+    g_object_bind_property(tasklist->show_thumbnails_check, "active",
+                           tasklist->thumbnail_box, "sensitive",
+                           G_BINDING_DEFAULT);
 
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(tasklist->thumbnail_size_spin),
                               (gdouble) g_settings_get_int (tasklist->preview_settings, "thumbnail-window-size"));
 #else
-	gtk_widget_hide(GET_WIDGET("window_thumbnail_box"));
+    gtk_widget_hide(GET_WIDGET("window_thumbnail_box"));
 #endif
 
-	tasklist->restore_to_current_workspace_radio = GET_WIDGET("restore_to_current_workspace_radio");
-	tasklist->mouse_scroll_check = GET_WIDGET("mouse_scroll_check");
-	tasklist->minimized_windows_box = GET_WIDGET("minimized_windows_box");
-	tasklist->window_grouping_box = GET_WIDGET("window_grouping_box");
-	tasklist->window_list_content_box = GET_WIDGET("window_list_content_box");
+    tasklist->restore_to_current_workspace_radio = GET_WIDGET("restore_to_current_workspace_radio");
+    tasklist->mouse_scroll_check = GET_WIDGET("mouse_scroll_check");
+    tasklist->minimized_windows_box = GET_WIDGET("minimized_windows_box");
+    tasklist->window_grouping_box = GET_WIDGET("window_grouping_box");
+    tasklist->window_list_content_box = GET_WIDGET("window_list_content_box");
 
-	g_settings_bind (tasklist->settings,
-                     "move-unminimized-windows",
-                      tasklist->restore_to_current_workspace_radio,
-                     "active",
-                      G_SETTINGS_BIND_DEFAULT);
-	g_signal_connect (tasklist->settings,
-					  "changed::move-unminimized-windows",
-					  G_CALLBACK (move_unminimized_windows_callback),
-					  tasklist);
+    g_settings_bind (tasklist->settings, "move-unminimized-windows",
+                     tasklist->restore_to_current_workspace_radio, "active",
+                     G_SETTINGS_BIND_DEFAULT);
+    g_signal_connect (tasklist->settings, "changed::move-unminimized-windows",
+                      G_CALLBACK (move_unminimized_windows_callback),
+                      tasklist);
 
-	g_settings_bind (tasklist->settings,
-                     "mouse-scrolling",
-                      tasklist->mouse_scroll_check,
-                     "active",
-                      G_SETTINGS_BIND_DEFAULT);
-	g_signal_connect (tasklist->settings,
-					  "changed::mouse-scrolling",
-					  G_CALLBACK (mouse_scrolling_callback),
-					  tasklist);
+    g_settings_bind (tasklist->settings, "mouse-scrolling",
+                     tasklist->mouse_scroll_check, "active",
+                     G_SETTINGS_BIND_DEFAULT);
+    g_signal_connect (tasklist->settings, "changed::mouse-scrolling",
+                      G_CALLBACK (mouse_scrolling_callback),
+                      tasklist);
 
-	g_settings_bind(tasklist->settings,
-                    "display-all-workspaces",
-                    tasklist->display_all_workspaces_radio,
-                    "active",
+    g_settings_bind(tasklist->settings, "display-all-workspaces",
+                    tasklist->display_all_workspaces_radio, "active",
                     G_SETTINGS_BIND_DEFAULT);
-	g_signal_connect (tasklist->settings,
-					  "changed::display-all-workspaces",
-					  G_CALLBACK (display_all_workspaces_callback),
-					  tasklist);
+    g_signal_connect (tasklist->settings, "changed::display-all-workspaces",
+                      G_CALLBACK (display_all_workspaces_callback),
+                      tasklist);
 
-	gtk_widget_set_sensitive (tasklist->minimized_windows_box, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(tasklist->display_all_workspaces_radio)));
-	g_object_bind_property(tasklist->display_all_workspaces_radio, "active", tasklist->minimized_windows_box, "sensitive", G_BINDING_DEFAULT);
+    gtk_widget_set_sensitive (tasklist->minimized_windows_box,
+                              gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(tasklist->display_all_workspaces_radio)));
+    g_object_bind_property(tasklist->display_all_workspaces_radio, "active",
+                           tasklist->minimized_windows_box, "sensitive",
+                           G_BINDING_DEFAULT);
 
 #ifdef HAVE_WAYLAND
     if (GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default())) {
@@ -857,58 +853,58 @@ static void setup_dialog(GtkBuilder* builder, TasklistData* tasklist)
 
 static void display_properties_dialog(GtkAction* action, TasklistData* tasklist)
 {
-	if (tasklist->properties_dialog == NULL)
-	{
-		GtkBuilder* builder = gtk_builder_new_from_resource(WNCKLET_RESOURCE_PATH "window-list.ui");
+    if (tasklist->properties_dialog == NULL)
+    {
+        GtkBuilder* builder = gtk_builder_new_from_resource(WNCKLET_RESOURCE_PATH "window-list.ui");
 
-		gtk_builder_set_translation_domain(builder, GETTEXT_PACKAGE);
+        gtk_builder_set_translation_domain(builder, GETTEXT_PACKAGE);
 
-		tasklist->properties_dialog = GET_WIDGET("tasklist_properties_dialog");
+        tasklist->properties_dialog = GET_WIDGET("tasklist_properties_dialog");
 
-		g_object_add_weak_pointer(G_OBJECT(tasklist->properties_dialog), (void**) &tasklist->properties_dialog);
+        g_object_add_weak_pointer(G_OBJECT(tasklist->properties_dialog), (void**) &tasklist->properties_dialog);
 
-		setup_dialog(builder, tasklist);
+        setup_dialog(builder, tasklist);
 
-		gtk_builder_add_callback_symbols (builder,
+        gtk_builder_add_callback_symbols (builder,
 #ifdef HAVE_WINDOW_PREVIEWS
-		                                  "on_thumbnail_size_spin_value_changed", G_CALLBACK (on_thumbnail_size_spin_value_changed),
+                                          "on_thumbnail_size_spin_value_changed", G_CALLBACK (on_thumbnail_size_spin_value_changed),
 #endif
-		                                  "on_never_group_radio_toggled", G_CALLBACK (on_never_group_radio_toggled),
-		                                  "on_auto_group_radio_toggled", G_CALLBACK (on_auto_group_radio_toggled),
-		                                  "on_always_group_radio_toggled", G_CALLBACK (on_always_group_radio_toggled),
-		                                  "on_tasklist_properties_dialog_response", G_CALLBACK (on_tasklist_properties_dialog_response),
-		                                  NULL);
+                                          "on_never_group_radio_toggled", G_CALLBACK (on_never_group_radio_toggled),
+                                          "on_auto_group_radio_toggled", G_CALLBACK (on_auto_group_radio_toggled),
+                                          "on_always_group_radio_toggled", G_CALLBACK (on_always_group_radio_toggled),
+                                          "on_tasklist_properties_dialog_response", G_CALLBACK (on_tasklist_properties_dialog_response),
+                                          NULL);
 
-		gtk_builder_connect_signals(builder, tasklist);
+        gtk_builder_connect_signals(builder, tasklist);
 
-		g_object_unref(builder);
-	}
+        g_object_unref(builder);
+    }
 
-	gtk_window_set_screen(GTK_WINDOW(tasklist->properties_dialog), gtk_widget_get_screen(tasklist->applet));
-	gtk_window_present(GTK_WINDOW(tasklist->properties_dialog));
+    gtk_window_set_screen(GTK_WINDOW(tasklist->properties_dialog), gtk_widget_get_screen(tasklist->applet));
+    gtk_window_present(GTK_WINDOW(tasklist->properties_dialog));
 }
 
 static void destroy_tasklist(GtkWidget* widget, TasklistData* tasklist)
 {
-	g_signal_handlers_disconnect_by_data (G_OBJECT (tasklist->applet), tasklist);
+    g_signal_handlers_disconnect_by_data (G_OBJECT (tasklist->applet), tasklist);
 
 #ifdef HAVE_WINDOW_PREVIEWS
-	g_signal_handlers_disconnect_by_data (G_OBJECT (tasklist->tasklist), tasklist);
-	g_signal_handlers_disconnect_by_data (tasklist->preview_settings, tasklist);
-	g_object_unref(tasklist->preview_settings);
+    g_signal_handlers_disconnect_by_data (G_OBJECT (tasklist->tasklist), tasklist);
+    g_signal_handlers_disconnect_by_data (tasklist->preview_settings, tasklist);
+    g_object_unref(tasklist->preview_settings);
 #endif
 
-	g_signal_handlers_disconnect_by_data (tasklist->settings, tasklist);
+    g_signal_handlers_disconnect_by_data (tasklist->settings, tasklist);
 
-	g_object_unref(tasklist->settings);
+    g_object_unref(tasklist->settings);
 
-	if (tasklist->properties_dialog)
-		gtk_widget_destroy(tasklist->properties_dialog);
+    if (tasklist->properties_dialog)
+        gtk_widget_destroy(tasklist->properties_dialog);
 
 #ifdef HAVE_WINDOW_PREVIEWS
-	if (tasklist->preview)
-		gtk_widget_destroy(tasklist->preview);
+    if (tasklist->preview)
+        gtk_widget_destroy(tasklist->preview);
 #endif
 
-	g_free(tasklist);
+    g_free(tasklist);
 }

--- a/applets/wncklet/window-list.ui
+++ b/applets/wncklet/window-list.ui
@@ -1,41 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.22"/>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">999</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">help-browser</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">help-browser</property>
   </object>
   <object class="GtkImage" id="image2">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">window-close</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">window-close</property>
   </object>
   <object class="GtkDialog" id="tasklist_properties_dialog">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
     <property name="title" translatable="yes">Window List Preferences</property>
-    <property name="type_hint">normal</property>
+    <property name="resizable">False</property>
+    <property name="icon-name">mate-panel-window-list</property>
+    <property name="type-hint">normal</property>
+    <signal name="response" handler="on_tasklist_properties_dialog_response" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox2">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkButton" id="help_button">
                 <property name="label" translatable="yes">_Help</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
                 <property name="image">image1</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -47,12 +53,12 @@
               <object class="GtkButton" id="done_button">
                 <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">False</property>
                 <property name="image">image2</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -64,157 +70,103 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="vbox1">
+          <object class="GtkNotebook">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-            <property name="border_width">5</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">18</property>
+            <property name="can-focus">True</property>
             <child>
-              <object class="GtkLabel" id="wayland_info_label">
-                <property name="visible">False</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Some options not available on Wayland</property>
-                <property name="xalign">0</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="window_list_content_box">
+              <object class="GtkBox" id="behaviour_vbox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
+                <property name="spacing">18</property>
                 <child>
-                  <object class="GtkLabel" id="label1">
+                  <object class="GtkBox" id="window_thumbnail_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Window List Content</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment" id="alignment1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="vbox9">
+                      <object class="GtkLabel" id="thumbnails_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkRadioButton" id="show_current_radio">
-                            <property name="label" translatable="yes">Sh_ow windows from current workspace</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="show_all_radio">
-                            <property name="label" translatable="yes">Show windows from a_ll workspaces</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">show_current_radio</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Window Thumbnails</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
                     </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="window_thumbnail_box">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkLabel" id="label4">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Window Thumbnails</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment" id="alignment4">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
                     <child>
                       <object class="GtkBox" id="vbox16">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="show_thumbnails_check">
                             <property name="label" translatable="yes">Show _thumbnails on hover</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="thumbnail_box">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkLabel" id="thumbnail_size_label">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="tooltip-text" translatable="yes">Thumbnail width in pixels. Window aspect ratio will be maintained.</property>
+                                <property name="label" translatable="yes">Thumbnail width:</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="thumbnail_size_spin">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="max-length">3</property>
+                                <property name="text" translatable="yes">0</property>
+                                <property name="caps-lock-warning">False</property>
+                                <property name="placeholder-text" translatable="yes">px</property>
+                                <property name="input-purpose">number</property>
+                                <property name="adjustment">adjustment1</property>
+                                <property name="climb-rate">1</property>
+                                <property name="numeric">True</property>
+                                <signal name="value-changed" handler="on_thumbnail_size_spin_value_changed" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -223,114 +175,58 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment" id="alignment5">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
-                    <child>
-                      <object class="GtkBox" id="hbox1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="thumbnail_size_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">Thumbnail width in pixels. Window aspect ratio will be maintained.</property>
-                            <property name="label" translatable="yes">Thumbnail width:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSpinButton" id="thumbnail_size_spin">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="max_length">3</property>
-                            <property name="caps_lock_warning">False</property>
-                            <property name="placeholder_text" translatable="yes">px</property>
-                            <property name="input_purpose">number</property>
-                            <property name="climb_rate">1</property>
-                            <property name="numeric">True</property>
-                            <property name="value">200</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="window_grouping_box">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkLabel" id="label3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Window Grouping</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment2">
+                  <object class="GtkBox" id="window_grouping_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label3">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Window Grouping</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
                     <child>
                       <object class="GtkBox" id="vbox12">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkRadioButton" id="never_group_radio">
                             <property name="label" translatable="yes">_Never group windows</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw-indicator">True</property>
+                            <signal name="toggled" handler="on_never_group_radio_toggled" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -342,11 +238,12 @@
                           <object class="GtkRadioButton" id="auto_group_radio">
                             <property name="label" translatable="yes">Group windows when _space is limited</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                             <property name="group">never_group_radio</property>
+                            <signal name="toggled" handler="on_auto_group_radio_toggled" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -358,11 +255,12 @@
                           <object class="GtkRadioButton" id="always_group_radio">
                             <property name="label" translatable="yes">_Always group windows</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                             <property name="group">never_group_radio</property>
+                            <signal name="toggled" handler="on_always_group_radio_toggled" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -371,6 +269,11 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -379,55 +282,43 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="mouse_scroll_box">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkBox" id="mouse_scroll_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Mouse Scrolling</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox">
+                      <object class="GtkLabel" id="mouse_scrolling_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Mouse Scrolling</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="mouse_scrolling_vbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="mouse_scroll_check">
                             <property name="label" translatable="yes">_Enable mouse scrolling</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -436,63 +327,151 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="behaviour_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Behaviour</property>
+              </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="minimized_windows_box">
+              <object class="GtkBox" id="workspaces_vbox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
+                <property name="spacing">18</property>
                 <child>
-                  <object class="GtkLabel" id="minimized_windows_label">
+                  <object class="GtkBox" id="window_list_content_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Restoring Minimized Windows</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label1">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Window List Content</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="vbox9">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkRadioButton" id="show_current_radio">
+                            <property name="label" translatable="yes">Sh_ow windows from current workspace</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="display_all_workspaces_radio">
+                            <property name="label" translatable="yes">Show windows from a_ll workspaces</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                            <property name="group">show_current_radio</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment3">
+                  <object class="GtkBox" id="minimized_windows_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="minimized_windows_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Restoring Minimized Windows</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
                     <child>
                       <object class="GtkBox" id="vbox14">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkRadioButton" id="move_minimized_radio">
+                          <object class="GtkRadioButton" id="restore_to_current_workspace_radio">
                             <property name="label" translatable="yes">Restore to current _workspace</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -504,11 +483,11 @@
                           <object class="GtkRadioButton" id="change_workspace_radio">
                             <property name="label" translatable="yes">Restore to na_tive workspace</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">move_minimized_radio</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                            <property name="group">restore_to_current_workspace_radio</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -517,6 +496,11 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -527,9 +511,18 @@
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">4</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="workspaces_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Workspaces</property>
+              </object>
+              <packing>
+                <property name="position">1</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>
@@ -543,10 +536,7 @@
     </child>
     <action-widgets>
       <action-widget response="-11">help_button</action-widget>
-      <action-widget response="0">done_button</action-widget>
+      <action-widget response="-7">done_button</action-widget>
     </action-widgets>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
   </object>
 </interface>


### PR DESCRIPTION
 Also some code cleanup:
 - use g_settings_* functions directly instead of using stored values
 - use g_settings_bind when possible
 - set callback functions in glade when possible
 - remove other unneeded code complexity

The second commit is code formatting and tabs to spaces only. So for indentation please review the second commit.

Test: open the window-list properties dialog and see if all options work as before. Btw in current master, disable window thumbnails does not work for me. This PR fixes that issue.
