### PR TITLE
window-list: use GtkNotebook, improve codebase

### DIFF
--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -43,26 +43,18 @@
 #define WINDOW_LIST_PREVIEW_SCHEMA "org.mate.panel.applet.window-list-previews"
 #endif /* HAVE_WINDOW_PREVIEWS */
 
-typedef enum {
+enum TasklistGroupingType {
   TASKLIST_NEVER_GROUP,
   TASKLIST_AUTO_GROUP,
   TASKLIST_ALWAYS_GROUP
-} TasklistGroupingType;
+};
 
 typedef struct {
 	GtkWidget* applet;
 	GtkWidget* tasklist;
 #ifdef HAVE_WINDOW_PREVIEWS
 	GtkWidget* preview;
-
-	gboolean show_window_thumbnails;
-	gint thumbnail_size;
 #endif
-	gboolean include_all_workspaces;
-
-	TasklistGroupingType grouping;
-	gboolean move_unminimized_windows;
-	gboolean scroll_enable;
 
 	GtkOrientation orientation;
 	int size;
@@ -74,21 +66,19 @@ typedef struct {
 
 	/* Properties: */
 	GtkWidget* properties_dialog;
-	GtkWidget* wayland_info_label;
-	GtkWidget* show_current_radio;
-	GtkWidget* show_all_radio;
+	GtkWidget* display_all_workspaces_radio;
 #ifdef HAVE_WINDOW_PREVIEWS
 	GtkWidget* window_thumbnail_box;
 	GtkWidget* show_thumbnails_check;
 	GtkWidget* thumbnail_size_label;
 	GtkWidget* thumbnail_size_spin;
+	GtkWidget* thumbnail_box;
 #endif
 	GtkWidget* never_group_radio;
 	GtkWidget* auto_group_radio;
 	GtkWidget* always_group_radio;
-	GtkWidget* move_minimized_radio;
+	GtkWidget* restore_to_current_workspace_radio;
 	GtkWidget* mouse_scroll_check;
-	GtkWidget* change_workspace_radio;
 	GtkWidget* minimized_windows_box;
 	GtkWidget* window_grouping_box;
 	GtkWidget* window_list_content_box;
@@ -105,7 +95,7 @@ static void display_help_dialog(GtkAction* action, TasklistData* tasklist);
 static void display_about_dialog(GtkAction* action, TasklistData* tasklist);
 static void destroy_tasklist(GtkWidget* widget, TasklistData* tasklist);
 
-static void tasklist_update(TasklistData* tasklist)
+static void tasklist_set_size_request(TasklistData* tasklist)
 {
 	if (tasklist->orientation == GTK_ORIENTATION_HORIZONTAL)
 	{
@@ -115,33 +105,6 @@ static void tasklist_update(TasklistData* tasklist)
 	{
 		gtk_widget_set_size_request(GTK_WIDGET(tasklist->tasklist), tasklist->size, -1);
 	}
-
-#ifdef HAVE_X11
-	if (WNCK_IS_TASKLIST(tasklist->tasklist))
-	{
-		WnckTasklistGroupingType grouping;
-		switch (tasklist->grouping)
-		{
-			case TASKLIST_NEVER_GROUP:
-				grouping = WNCK_TASKLIST_NEVER_GROUP;
-				break;
-			case TASKLIST_AUTO_GROUP:
-				grouping = WNCK_TASKLIST_AUTO_GROUP;
-				break;
-			case TASKLIST_ALWAYS_GROUP:
-				grouping = WNCK_TASKLIST_ALWAYS_GROUP;
-				break;
-			default:
-				grouping = WNCK_TASKLIST_NEVER_GROUP;
-		}
-		wnck_tasklist_set_grouping(WNCK_TASKLIST(tasklist->tasklist), grouping);
-		wnck_tasklist_set_include_all_workspaces(WNCK_TASKLIST(tasklist->tasklist), tasklist->include_all_workspaces);
-		wnck_tasklist_set_switch_workspace_on_unminimize(WNCK_TASKLIST(tasklist->tasklist), tasklist->move_unminimized_windows);
-		wnck_tasklist_set_scroll_enabled (WNCK_TASKLIST(tasklist->tasklist), tasklist->scroll_enable);
-	}
-#endif /* HAVE_X11 */
-
-	/* Not implemented for Wayland */
 }
 
 static void tasklist_apply_orientation(TasklistData* tasklist)
@@ -190,7 +153,7 @@ static const int* tasklist_get_size_hint_list(TasklistData* tasklist, int* n_ele
 	}
 }
 
-static void response_cb(GtkWidget* widget, int id, TasklistData* tasklist)
+static void on_tasklist_properties_dialog_response(GtkWidget* widget, int id, TasklistData* tasklist)
 {
 	if (id == GTK_RESPONSE_HELP)
 	{
@@ -229,8 +192,7 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 
 	tasklist->orientation = new_orient;
 	tasklist_apply_orientation (tasklist);
-
-	tasklist_update(tasklist);
+	tasklist_set_size_request(tasklist);
 }
 
 static void applet_change_background(MatePanelApplet* applet, MatePanelAppletBackgroundType type, GdkColor* color, cairo_pattern_t* pattern, TasklistData* tasklist)
@@ -285,16 +247,17 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 	height = gdk_window_get_height (window) * scale;
 
 	/* Scale to configured size while maintaining aspect ratio */
+	gint thumbnail_size = g_settings_get_int (tasklist->preview_settings, "thumbnail-window-size");
 	if (width > height)
 	{
-		int max_size = MIN (width, tasklist->thumbnail_size * scale);
+		int max_size = MIN (width, thumbnail_size * scale);
 		ratio = (double) max_size / (double) width;
 		*thumbnail_width = max_size;
 		*thumbnail_height = (int) ((double) height * ratio);
 	}
 	else
 	{
-		int max_size = MIN (height, tasklist->thumbnail_size * scale);
+		int max_size = MIN (height, thumbnail_size * scale);
 		ratio = (double) max_size / (double) height;
 		*thumbnail_height = max_size;
 		*thumbnail_width = (int) ((double) width * ratio);
@@ -383,7 +346,7 @@ static gboolean applet_enter_notify_event (WnckTasklist *tl, GList *wnck_windows
 		tasklist->preview = NULL;
 	}
 
-	if (!tasklist->show_window_thumbnails || wnck_windows == NULL)
+	if (!g_settings_get_boolean (tasklist->preview_settings, "show-window-thumbnails") || wnck_windows == NULL)
 		return FALSE;
 
 	n_windows = g_list_length (wnck_windows);
@@ -444,7 +407,7 @@ static void applet_change_pixel_size(MatePanelApplet* applet, gint size, Tasklis
 
 	tasklist->size = size;
 
-	tasklist_update(tasklist);
+	tasklist_set_size_request(tasklist);
 }
 
 /* TODO: this is sad, should be used a function to retrieve  applications from
@@ -488,165 +451,6 @@ static const GtkActionEntry tasklist_menu_actions[] = {
 		G_CALLBACK(display_about_dialog)
 	}
 };
-
-static void tasklist_properties_update_content_radio(TasklistData* tasklist)
-{
-	GtkWidget* button;
-
-	if (tasklist->show_current_radio == NULL)
-		return;
-
-	if (tasklist->include_all_workspaces)
-	{
-		button = tasklist->show_all_radio;
-	}
-	else
-	{
-		button = tasklist->show_current_radio;
-	}
-
-	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)))
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-
-	gtk_widget_set_sensitive(tasklist->minimized_windows_box, tasklist->include_all_workspaces);
-}
-
-static void display_all_workspaces_changed(GSettings* settings, gchar* key, TasklistData* tasklist)
-{
-	gboolean value;
-
-	value = g_settings_get_boolean(settings, key);
-
-	tasklist->include_all_workspaces = (value != 0);
-	tasklist_update(tasklist);
-
-	tasklist_properties_update_content_radio(tasklist);
-}
-
-#ifdef HAVE_WINDOW_PREVIEWS
-static void tasklist_update_thumbnail_size_spin(TasklistData* tasklist)
-{
-	GtkWidget* button;
-
-	if (!tasklist->thumbnail_size)
-		return;
-
-	button = tasklist->thumbnail_size_spin;
-
-	gtk_spin_button_set_value(GTK_SPIN_BUTTON(button), (gdouble)tasklist->thumbnail_size);
-}
-
-static void thumbnail_size_changed(GSettings *settings, gchar* key, TasklistData* tasklist)
-{
-	tasklist->thumbnail_size = g_settings_get_int(settings, key);
-	tasklist_update_thumbnail_size_spin(tasklist);
-}
-#endif
-
-static GtkWidget* get_grouping_button(TasklistData* tasklist, TasklistGroupingType type)
-{
-	switch (type)
-	{
-		default:
-		case TASKLIST_NEVER_GROUP:
-			return tasklist->never_group_radio;
-			break;
-		case TASKLIST_AUTO_GROUP:
-			return tasklist->auto_group_radio;
-			break;
-		case TASKLIST_ALWAYS_GROUP:
-			return tasklist->always_group_radio;
-			break;
-	}
-}
-
-static void group_windows_changed(GSettings* settings, gchar* key, TasklistData* tasklist)
-{
-	TasklistGroupingType type;
-	GtkWidget* button;
-
-	type = g_settings_get_enum (settings, key);
-
-	tasklist->grouping = type;
-	tasklist_update(tasklist);
-
-	button = get_grouping_button(tasklist, type);
-
-	if (button && !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)))
-	{
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	}
-}
-
-static void tasklist_update_unminimization_radio(TasklistData* tasklist)
-{
-	GtkWidget* button;
-
-	if (tasklist->move_minimized_radio == NULL)
-		return;
-
-	if (tasklist->move_unminimized_windows)
-	{
-		button = tasklist->move_minimized_radio;
-	}
-	else
-	{
-		button = tasklist->change_workspace_radio;
-	}
-
-	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)))
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-}
-
-
-static void move_unminimized_windows_changed(GSettings* settings, gchar* key, TasklistData* tasklist)
-{
-	gboolean value;
-
-	value = g_settings_get_boolean(settings, key);
-
-	tasklist->move_unminimized_windows = (value != 0);
-	tasklist_update(tasklist);
-
-	tasklist_update_unminimization_radio(tasklist);
-}
-
-static void scroll_enabled_changed (GSettings* settings, gchar* key, TasklistData* tasklist)
-{
-	tasklist->scroll_enable = g_settings_get_boolean (settings, key);
-	tasklist_update(tasklist);
-}
-
-static void setup_gsettings(TasklistData* tasklist)
-{
-	tasklist->settings = mate_panel_applet_settings_new (MATE_PANEL_APPLET (tasklist->applet), WINDOW_LIST_SCHEMA);
-
-	g_signal_connect (tasklist->settings,
-					  "changed::display-all-workspaces",
-					  G_CALLBACK (display_all_workspaces_changed),
-					  tasklist);
-
-#ifdef HAVE_WINDOW_PREVIEWS
-	tasklist->preview_settings = mate_panel_applet_settings_new (MATE_PANEL_APPLET (tasklist->applet), WINDOW_LIST_PREVIEW_SCHEMA);
-
-	g_signal_connect (tasklist->preview_settings,
-					  "changed::thumbnail-window-size",
-					  G_CALLBACK (thumbnail_size_changed),
-					  tasklist);
-#endif
-	g_signal_connect (tasklist->settings,
-					  "changed::group-windows",
-					  G_CALLBACK (group_windows_changed),
-					  tasklist);
-	g_signal_connect (tasklist->settings,
-					  "changed::move-unminimized-windows",
-					  G_CALLBACK (move_unminimized_windows_changed),
-					  tasklist);
-	g_signal_connect (tasklist->settings,
-					  "changed::scroll-enabled",
-					  G_CALLBACK (scroll_enabled_changed),
-					  tasklist);
-}
 
 static void applet_size_allocate(GtkWidget *widget, GtkAllocation *allocation, TasklistData *tasklist)
 {
@@ -755,21 +559,11 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 
 	mate_panel_applet_set_flags(MATE_PANEL_APPLET(tasklist->applet), MATE_PANEL_APPLET_EXPAND_MAJOR | MATE_PANEL_APPLET_EXPAND_MINOR | MATE_PANEL_APPLET_HAS_HANDLE);
 
-	setup_gsettings(tasklist);
-
-	tasklist->include_all_workspaces = g_settings_get_boolean (tasklist->settings, "display-all-workspaces");
+	tasklist->settings = mate_panel_applet_settings_new (MATE_PANEL_APPLET (tasklist->applet), WINDOW_LIST_SCHEMA);
 
 #ifdef HAVE_WINDOW_PREVIEWS
-	tasklist->show_window_thumbnails = g_settings_get_boolean (tasklist->preview_settings, "show-window-thumbnails");
-
-	tasklist->thumbnail_size = g_settings_get_int (tasklist->preview_settings, "thumbnail-window-size");
+ 	tasklist->preview_settings = mate_panel_applet_settings_new (MATE_PANEL_APPLET (tasklist->applet), WINDOW_LIST_PREVIEW_SCHEMA);
 #endif
-
-	tasklist->grouping = g_settings_get_enum (tasklist->settings, "group-windows");
-
-	tasklist->move_unminimized_windows = g_settings_get_boolean (tasklist->settings, "move-unminimized-windows");
-
-	tasklist->scroll_enable = g_settings_get_boolean (tasklist->settings, "scroll-enabled");
 
 	tasklist->size = mate_panel_applet_get_size(applet);
 
@@ -875,7 +669,7 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 
 	g_object_unref(action_group);
 
-	tasklist_update(tasklist);
+	tasklist_set_size_request(tasklist);
 	gtk_widget_show(tasklist->tasklist);
 	gtk_widget_show(tasklist->applet);
 
@@ -901,7 +695,6 @@ static void call_system_monitor(GtkAction* action, TasklistData* tasklist)
 		}
 	}
 }
-
 
 static void display_help_dialog(GtkAction* action, TasklistData* tasklist)
 {
@@ -940,169 +733,116 @@ static void display_about_dialog(GtkAction* action, TasklistData* tasklist)
 		NULL);
 }
 
-static void group_windows_toggled(GtkToggleButton* button, TasklistData* tasklist)
+static void mouse_scrolling_callback(GSettings* settings, gchar *key, TasklistData* tasklist)
 {
-	if (gtk_toggle_button_get_active(button))
-	{
-		gchar *value;
-		value = g_object_get_data (G_OBJECT (button), "group_value");
-		g_settings_set_string (tasklist->settings, "group-windows", value);
-	}
+	wnck_tasklist_set_scroll_enabled (WNCK_TASKLIST(tasklist->tasklist), g_settings_get_boolean (settings, "scroll-enabled"));
+}
+
+static void move_unminimized_windows_callback(GSettings* settings, gchar *key, TasklistData* tasklist)
+{
+	wnck_tasklist_set_switch_workspace_on_unminimize(WNCK_TASKLIST(tasklist->tasklist), g_settings_get_boolean (settings, "move-unminimized-windows"));
+}
+
+static void display_all_workspaces_callback(GSettings* settings, gchar *key, TasklistData* tasklist)
+{
+	wnck_tasklist_set_include_all_workspaces(WNCK_TASKLIST(tasklist->tasklist), g_settings_get_boolean (settings, "display-all-workspaces"));
 }
 
 #ifdef HAVE_WINDOW_PREVIEWS
-static void thumbnail_size_spin_changed(GtkSpinButton* button, TasklistData* tasklist)
+static void on_thumbnail_size_spin_value_changed(GtkSpinButton* button, TasklistData* tasklist)
 {
 	g_settings_set_int(tasklist->preview_settings, "thumbnail-window-size", gtk_spin_button_get_value_as_int(button));
 }
 #endif
 
-static void move_minimized_toggled(GtkToggleButton* button, TasklistData* tasklist)
+static void on_never_group_radio_toggled(GtkRadioButton* button, TasklistData* tasklist)
 {
-	g_settings_set_boolean(tasklist->settings, "move-unminimized-windows", gtk_toggle_button_get_active(button));
+	g_settings_set_enum (tasklist->settings, "group-windows", TASKLIST_NEVER_GROUP);
+	wnck_tasklist_set_grouping(WNCK_TASKLIST(tasklist->tasklist), WNCK_TASKLIST_NEVER_GROUP);
 }
 
-static void display_all_workspaces_toggled(GtkToggleButton* button, TasklistData* tasklist)
+static void on_auto_group_radio_toggled(GtkRadioButton* button, TasklistData* tasklist)
 {
-	g_settings_set_boolean(tasklist->settings, "display-all-workspaces", gtk_toggle_button_get_active(button));
+	g_settings_set_enum (tasklist->settings, "group-windows", TASKLIST_AUTO_GROUP);
+	wnck_tasklist_set_grouping(WNCK_TASKLIST(tasklist->tasklist), WNCK_TASKLIST_AUTO_GROUP);
 }
 
-#define WID(s) GTK_WIDGET(gtk_builder_get_object(builder, s))
-
-static void setup_sensitivity(TasklistData* tasklist, GtkBuilder* builder, const char* wid1, const char* wid2, const char* wid3, const char* key)
+static void on_always_group_radio_toggled(GtkRadioButton* button, TasklistData* tasklist)
 {
-	GtkWidget* w;
-
-	if (g_settings_is_writable(tasklist->settings, key))
-	{
-		return;
-	}
-
-	w = WID(wid1);
-	g_assert(w != NULL);
-	gtk_widget_set_sensitive(w, FALSE);
-
-	if (wid2 != NULL)
-	{
-		w = WID(wid2);
-		g_assert(w != NULL);
-		gtk_widget_set_sensitive(w, FALSE);
-	}
-
-	if (wid3 != NULL)
-	{
-		w = WID(wid3);
-		g_assert(w != NULL);
-		gtk_widget_set_sensitive(w, FALSE);
-	}
+	g_settings_set_enum (tasklist->settings, "group-windows", TASKLIST_ALWAYS_GROUP);
+	wnck_tasklist_set_grouping(WNCK_TASKLIST(tasklist->tasklist), WNCK_TASKLIST_ALWAYS_GROUP);
 }
 
-#ifdef HAVE_WAYLAND
-static void setup_dialog_wayland(TasklistData* tasklist)
-{
-	gtk_widget_show(tasklist->wayland_info_label);
-
-	gtk_widget_set_sensitive(tasklist->window_list_content_box, FALSE);
-	gtk_widget_set_sensitive(tasklist->window_grouping_box, FALSE);
-	gtk_widget_set_sensitive(tasklist->minimized_windows_box, FALSE);
-
-#ifdef HAVE_WINDOW_PREVIEWS
-	gtk_widget_set_sensitive(tasklist->window_thumbnail_box, FALSE);
-#endif /* HAVE_WINDOW_PREVIEWS */
-}
-#endif /* HAVE_WAYLAND */
+#define GET_WIDGET(s) GTK_WIDGET(gtk_builder_get_object(builder, s))
 
 static void setup_dialog(GtkBuilder* builder, TasklistData* tasklist)
 {
-	GtkWidget* button;
-#ifdef HAVE_WINDOW_PREVIEWS
-	GtkAdjustment *adjustment;
-#endif /* HAVE_WINDOW_PREVIEWS */
-
-	tasklist->wayland_info_label = WID("wayland_info_label");
-	tasklist->show_current_radio = WID("show_current_radio");
-	tasklist->show_all_radio = WID("show_all_radio");
-
-	setup_sensitivity(tasklist, builder, "show_current_radio", "show_all_radio", NULL, "display-all-workspaces" /* key */);
-
-	tasklist->never_group_radio = WID("never_group_radio");
-	tasklist->auto_group_radio = WID("auto_group_radio");
-	tasklist->always_group_radio = WID("always_group_radio");
-
-	setup_sensitivity(tasklist, builder, "never_group_radio", "auto_group_radio", "always_group_radio", "group-windows" /* key */);
+	tasklist->display_all_workspaces_radio = GET_WIDGET("display_all_workspaces_radio");
+	tasklist->never_group_radio = GET_WIDGET("never_group_radio");
+	tasklist->auto_group_radio = GET_WIDGET("auto_group_radio");
+	tasklist->always_group_radio = GET_WIDGET("always_group_radio");
 
 #ifdef HAVE_WINDOW_PREVIEWS
-	tasklist->window_thumbnail_box = WID("window_thumbnail_box");
-	tasklist->show_thumbnails_check = WID("show_thumbnails_check");
-	tasklist->thumbnail_size_label = WID("thumbnail_size_label");
-	tasklist->thumbnail_size_spin = WID("thumbnail_size_spin");
+	tasklist->window_thumbnail_box = GET_WIDGET("window_thumbnail_box");
+	tasklist->show_thumbnails_check = GET_WIDGET("show_thumbnails_check");
+	tasklist->thumbnail_size_label = GET_WIDGET("thumbnail_size_label");
+	tasklist->thumbnail_size_spin = GET_WIDGET("thumbnail_size_spin");
+	tasklist->thumbnail_box = GET_WIDGET("thumbnail_box");
 
-	g_settings_bind(tasklist->preview_settings, "show-window-thumbnails", tasklist->show_thumbnails_check, "active", G_SETTINGS_BIND_DEFAULT);
-	if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(tasklist->show_thumbnails_check))) {
-		gtk_widget_set_sensitive (tasklist->thumbnail_size_label, TRUE);
-		gtk_widget_set_sensitive (tasklist->thumbnail_size_spin, TRUE);
-	} else {
-		gtk_widget_set_sensitive (tasklist->thumbnail_size_label, FALSE);
-		gtk_widget_set_sensitive (tasklist->thumbnail_size_spin, FALSE);
-	}
-	g_object_bind_property(tasklist->show_thumbnails_check, "active", tasklist->thumbnail_size_label, "sensitive", G_BINDING_DEFAULT);
-	g_object_bind_property(tasklist->show_thumbnails_check, "active", tasklist->thumbnail_size_spin, "sensitive", G_BINDING_DEFAULT);
+	g_settings_bind(tasklist->preview_settings, "show-window-thumbnails",
+					tasklist->show_thumbnails_check, "active",
+					G_SETTINGS_BIND_DEFAULT);
 
-	adjustment = gtk_spin_button_get_adjustment (GTK_SPIN_BUTTON(tasklist->thumbnail_size_spin));
-	gtk_adjustment_set_lower (adjustment, 0);
-	gtk_adjustment_set_upper (adjustment, 999);
-	gtk_adjustment_set_step_increment (adjustment, 1);
+	gtk_widget_set_sensitive (tasklist->thumbnail_box, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(tasklist->show_thumbnails_check)));
+	g_object_bind_property(tasklist->show_thumbnails_check, "active", tasklist->thumbnail_box, "sensitive", G_BINDING_DEFAULT);
+
+	gtk_spin_button_set_value(GTK_SPIN_BUTTON(tasklist->thumbnail_size_spin),
+							  (gdouble) g_settings_get_int (tasklist->preview_settings, "thumbnail-window-size"));
 #else
-	gtk_widget_hide(WID("window_thumbnail_box"));
+	gtk_widget_hide(GET_WIDGET("window_thumbnail_box"));
 #endif
 
-	tasklist->move_minimized_radio = WID("move_minimized_radio");
-	tasklist->change_workspace_radio = WID("change_workspace_radio");
-	tasklist->mouse_scroll_check = WID("mouse_scroll_check");
-	tasklist->minimized_windows_box = WID("minimized_windows_box");
-	tasklist->window_grouping_box = WID("window_grouping_box");
-	tasklist->window_list_content_box = WID("window_list_content_box");
+	tasklist->restore_to_current_workspace_radio = GET_WIDGET("restore_to_current_workspace_radio");
+	tasklist->mouse_scroll_check = GET_WIDGET("mouse_scroll_check");
+	tasklist->minimized_windows_box = GET_WIDGET("minimized_windows_box");
+	tasklist->window_grouping_box = GET_WIDGET("window_grouping_box");
+	tasklist->window_list_content_box = GET_WIDGET("window_list_content_box");
 
-	setup_sensitivity(tasklist, builder, "move_minimized_radio", "change_workspace_radio", NULL, "move-unminimized-windows" /* key */);
+	g_settings_bind (tasklist->settings, "scroll-enabled",
+					 tasklist->mouse_scroll_check, "active",
+					 G_SETTINGS_BIND_DEFAULT);
 
-	/* Window grouping: */
-	button = get_grouping_button(tasklist, tasklist->grouping);
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	g_object_set_data(G_OBJECT(tasklist->never_group_radio), "group_value", "never");
-	g_object_set_data(G_OBJECT(tasklist->auto_group_radio), "group_value", "auto");
-	g_object_set_data(G_OBJECT(tasklist->always_group_radio), "group_value", "always");
+	g_signal_connect (tasklist->settings,
+					  "changed::scroll-enabled",
+					  G_CALLBACK (mouse_scrolling_callback),
+					  tasklist);
 
-	g_signal_connect(G_OBJECT(tasklist->never_group_radio), "toggled", (GCallback) group_windows_toggled, tasklist);
-	g_signal_connect(G_OBJECT(tasklist->auto_group_radio), "toggled", (GCallback) group_windows_toggled, tasklist);
-	g_signal_connect(G_OBJECT(tasklist->always_group_radio), "toggled", (GCallback) group_windows_toggled, tasklist);
+	g_settings_bind (tasklist->settings, "move-unminimized-windows",
+					 tasklist->restore_to_current_workspace_radio, "active",
+					 G_SETTINGS_BIND_DEFAULT);
+	g_signal_connect (tasklist->settings, "changed::move-unminimized-windows",
+					  G_CALLBACK (move_unminimized_windows_callback),
+					  tasklist);
 
-	/* Mouse Scroll: */
-	g_settings_bind (tasklist->settings,
-                    "scroll-enabled",
-                     tasklist->mouse_scroll_check,
-                    "active",
-                     G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind(tasklist->settings, "display-all-workspaces",
+					tasklist->display_all_workspaces_radio, "active",
+					G_SETTINGS_BIND_DEFAULT);
+	g_signal_connect (tasklist->settings, "changed::display-all-workspaces",
+					  G_CALLBACK (display_all_workspaces_callback),
+					  tasklist);
 
-#ifdef HAVE_WINDOW_PREVIEWS
-	/* change thumbnail size: */
-	tasklist_update_thumbnail_size_spin(tasklist);
-	g_signal_connect(G_OBJECT(tasklist->thumbnail_size_spin), "value-changed", (GCallback) thumbnail_size_spin_changed, tasklist);
-#endif
-
-	/* move window when unminimizing: */
-	tasklist_update_unminimization_radio(tasklist);
-	g_signal_connect(G_OBJECT(tasklist->move_minimized_radio), "toggled", (GCallback) move_minimized_toggled, tasklist);
-
-	/* Tasklist content: */
-	tasklist_properties_update_content_radio (tasklist);
-	g_signal_connect(G_OBJECT(tasklist->show_all_radio), "toggled", (GCallback) display_all_workspaces_toggled, tasklist);
-
-	g_signal_connect_swapped(WID("done_button"), "clicked", (GCallback) gtk_widget_hide, tasklist->properties_dialog);
-	g_signal_connect(tasklist->properties_dialog, "response", G_CALLBACK(response_cb), tasklist);
+	gtk_widget_set_sensitive (tasklist->minimized_windows_box, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(tasklist->display_all_workspaces_radio)));
+	g_object_bind_property(tasklist->display_all_workspaces_radio, "active", tasklist->minimized_windows_box, "sensitive", G_BINDING_DEFAULT);
 
 #ifdef HAVE_WAYLAND
 	if (GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default())) {
-		setup_dialog_wayland(tasklist);
+		gtk_widget_set_sensitive(tasklist->window_list_content_box, FALSE);
+		gtk_widget_set_sensitive(tasklist->window_grouping_box, FALSE);
+		gtk_widget_set_sensitive(tasklist->minimized_windows_box, FALSE);
+		gtk_widget_set_sensitive(tasklist->mouse_scroll_check, FALSE);
+	#ifdef HAVE_WINDOW_PREVIEWS
+		gtk_widget_set_sensitive(tasklist->window_thumbnail_box, FALSE);
+	#endif
 	}
 #endif /* HAVE_WAYLAND */
 }
@@ -1117,18 +857,27 @@ static void display_properties_dialog(GtkAction* action, TasklistData* tasklist)
 		gtk_builder_set_translation_domain(builder, GETTEXT_PACKAGE);
 		gtk_builder_add_from_resource (builder, WNCKLET_RESOURCE_PATH "window-list.ui", NULL);
 
-		tasklist->properties_dialog = WID("tasklist_properties_dialog");
+		tasklist->properties_dialog = GET_WIDGET("tasklist_properties_dialog");
 
 		g_object_add_weak_pointer(G_OBJECT(tasklist->properties_dialog), (void**) &tasklist->properties_dialog);
 
 		setup_dialog(builder, tasklist);
 
+	gtk_builder_add_callback_symbols (builder,
+#ifdef HAVE_WINDOW_PREVIEWS
+		                              "on_thumbnail_size_spin_value_changed", G_CALLBACK (on_thumbnail_size_spin_value_changed),
+#endif
+		                              "on_never_group_radio_toggled", G_CALLBACK (on_never_group_radio_toggled),
+		                              "on_auto_group_radio_toggled", G_CALLBACK (on_auto_group_radio_toggled),
+		                              "on_always_group_radio_toggled", G_CALLBACK (on_always_group_radio_toggled),
+		                              "on_tasklist_properties_dialog_response", G_CALLBACK (on_tasklist_properties_dialog_response),
+		                              NULL);
+
+		gtk_builder_connect_signals(builder, tasklist);
+
 		g_object_unref(builder);
 	}
 
-	gtk_window_set_icon_name(GTK_WINDOW(tasklist->properties_dialog), WINDOW_LIST_ICON);
-
-	gtk_window_set_resizable(GTK_WINDOW(tasklist->properties_dialog), FALSE);
 	gtk_window_set_screen(GTK_WINDOW(tasklist->properties_dialog), gtk_widget_get_screen(tasklist->applet));
 	gtk_window_present(GTK_WINDOW(tasklist->properties_dialog));
 }

--- a/applets/wncklet/window-list.ui
+++ b/applets/wncklet/window-list.ui
@@ -1,41 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.22"/>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">999</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">help-browser</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">help-browser</property>
   </object>
   <object class="GtkImage" id="image2">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">window-close</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">window-close</property>
   </object>
   <object class="GtkDialog" id="tasklist_properties_dialog">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
     <property name="title" translatable="yes">Window List Preferences</property>
-    <property name="type_hint">normal</property>
+    <property name="resizable">False</property>
+    <property name="icon-name">mate-panel-window-list</property>
+    <property name="type-hint">normal</property>
+    <signal name="response" handler="on_tasklist_properties_dialog_response" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox2">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkButton" id="help_button">
                 <property name="label" translatable="yes">_Help</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
                 <property name="image">image1</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -47,12 +53,12 @@
               <object class="GtkButton" id="done_button">
                 <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">False</property>
                 <property name="image">image2</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -64,157 +70,103 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="vbox1">
+          <object class="GtkNotebook">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-            <property name="border_width">5</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">18</property>
+            <property name="can-focus">True</property>
             <child>
-              <object class="GtkLabel" id="wayland_info_label">
-                <property name="visible">False</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Some options not available on Wayland</property>
-                <property name="xalign">0</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="window_list_content_box">
+              <object class="GtkBox" id="behaviour_vbox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
+                <property name="spacing">18</property>
                 <child>
-                  <object class="GtkLabel" id="label1">
+                  <object class="GtkBox" id="window_thumbnail_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Window List Content</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment" id="alignment1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="vbox9">
+                      <object class="GtkLabel" id="thumbnails_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkRadioButton" id="show_current_radio">
-                            <property name="label" translatable="yes">Sh_ow windows from current workspace</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="show_all_radio">
-                            <property name="label" translatable="yes">Show windows from a_ll workspaces</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">show_current_radio</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Window Thumbnails</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
                     </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="window_thumbnail_box">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkLabel" id="label4">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Window Thumbnails</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment" id="alignment4">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
                     <child>
                       <object class="GtkBox" id="vbox16">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="show_thumbnails_check">
                             <property name="label" translatable="yes">Show _thumbnails on hover</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="thumbnail_box">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkLabel" id="thumbnail_size_label">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="tooltip-text" translatable="yes">Thumbnail width in pixels. Window aspect ratio will be maintained.</property>
+                                <property name="label" translatable="yes">Thumbnail width:</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="thumbnail_size_spin">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="max-length">3</property>
+                                <property name="text" translatable="yes">0</property>
+                                <property name="caps-lock-warning">False</property>
+                                <property name="placeholder-text" translatable="yes">px</property>
+                                <property name="input-purpose">number</property>
+                                <property name="adjustment">adjustment1</property>
+                                <property name="climb-rate">1</property>
+                                <property name="numeric">True</property>
+                                <signal name="value-changed" handler="on_thumbnail_size_spin_value_changed" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -223,114 +175,58 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment" id="alignment5">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
-                    <child>
-                      <object class="GtkBox" id="hbox1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="thumbnail_size_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">Thumbnail width in pixels. Window aspect ratio will be maintained.</property>
-                            <property name="label" translatable="yes">Thumbnail width:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSpinButton" id="thumbnail_size_spin">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="max_length">3</property>
-                            <property name="caps_lock_warning">False</property>
-                            <property name="placeholder_text" translatable="yes">px</property>
-                            <property name="input_purpose">number</property>
-                            <property name="climb_rate">1</property>
-                            <property name="numeric">True</property>
-                            <property name="value">200</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="window_grouping_box">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkLabel" id="label3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Window Grouping</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment2">
+                  <object class="GtkBox" id="window_grouping_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label3">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Window Grouping</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
                     <child>
                       <object class="GtkBox" id="vbox12">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkRadioButton" id="never_group_radio">
                             <property name="label" translatable="yes">_Never group windows</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw-indicator">True</property>
+                            <signal name="toggled" handler="on_never_group_radio_toggled" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -342,11 +238,12 @@
                           <object class="GtkRadioButton" id="auto_group_radio">
                             <property name="label" translatable="yes">Group windows when _space is limited</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                             <property name="group">never_group_radio</property>
+                            <signal name="toggled" handler="on_auto_group_radio_toggled" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -358,11 +255,12 @@
                           <object class="GtkRadioButton" id="always_group_radio">
                             <property name="label" translatable="yes">_Always group windows</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                             <property name="group">never_group_radio</property>
+                            <signal name="toggled" handler="on_always_group_radio_toggled" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -371,6 +269,11 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -379,55 +282,43 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="mouse_scroll_box">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkBox" id="mouse_scroll_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Mouse Scrolling</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox">
+                      <object class="GtkLabel" id="mouse_scrolling_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Mouse Scrolling</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="mouse_scrolling_vbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="mouse_scroll_check">
                             <property name="label" translatable="yes">_Enable mouse scrolling</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -436,63 +327,151 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="behaviour_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Behaviour</property>
+              </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="minimized_windows_box">
+              <object class="GtkBox" id="workspaces_vbox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
+                <property name="spacing">18</property>
                 <child>
-                  <object class="GtkLabel" id="minimized_windows_label">
+                  <object class="GtkBox" id="window_list_content_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Restoring Minimized Windows</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label1">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Window List Content</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="vbox9">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkRadioButton" id="show_current_radio">
+                            <property name="label" translatable="yes">Sh_ow windows from current workspace</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="display_all_workspaces_radio">
+                            <property name="label" translatable="yes">Show windows from a_ll workspaces</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                            <property name="group">show_current_radio</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment3">
+                  <object class="GtkBox" id="minimized_windows_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="minimized_windows_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Restoring Minimized Windows</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
                     <child>
                       <object class="GtkBox" id="vbox14">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkRadioButton" id="move_minimized_radio">
+                          <object class="GtkRadioButton" id="restore_to_current_workspace_radio">
                             <property name="label" translatable="yes">Restore to current _workspace</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -504,11 +483,11 @@
                           <object class="GtkRadioButton" id="change_workspace_radio">
                             <property name="label" translatable="yes">Restore to na_tive workspace</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">move_minimized_radio</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                            <property name="group">restore_to_current_workspace_radio</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -517,6 +496,11 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -527,9 +511,18 @@
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">4</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="workspaces_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Workspaces</property>
+              </object>
+              <packing>
+                <property name="position">1</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>
@@ -543,10 +536,7 @@
     </child>
     <action-widgets>
       <action-widget response="-11">help_button</action-widget>
-      <action-widget response="0">done_button</action-widget>
+      <action-widget response="-7">done_button</action-widget>
     </action-widgets>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
   </object>
 </interface>


### PR DESCRIPTION
Similar to #1221 

window-list.ui: use GtkNotebook
Set some callback functions in the ui file.

window-list.c: use g_settings_* functions directly instead of using stored values
use g_settings_bind when possible

For tabs to spaces I can do another PR, when this one is merged.

![Screenshot at 2021-05-01 17-35-33](https://user-images.githubusercontent.com/39454100/116787331-b0f26980-aaa3-11eb-9039-159cf467ed4b.png)
![Screenshot at 2021-05-01 17-35-45](https://user-images.githubusercontent.com/39454100/116787332-b354c380-aaa3-11eb-9dd0-9ed3ae586886.png)
