### PR TITLE
struts: add support for _GNOME_WM_STRUT_AREA

### DIFF
--- a/mate-panel/panel-struts.c
+++ b/mate-panel/panel-struts.c
@@ -322,7 +322,8 @@ panel_struts_set_window_hint (PanelToplevel *toplevel)
                             strut->orientation,
                             strut_size,
                             strut->allocated_strut_start * scale,
-                            strut->allocated_strut_end * scale);
+                            strut->allocated_strut_end * scale,
+                            &strut->allocated_geometry);
 }
 
 void

--- a/mate-panel/panel-util.c
+++ b/mate-panel/panel-util.c
@@ -1227,3 +1227,18 @@ panel_util_get_file_optional_homedir (const char *location)
 	return file;
 }
 
+int
+panel_util_get_window_scaling_factor (void)
+{
+	GValue value = G_VALUE_INIT;
+
+	g_value_init (&value, G_TYPE_INT);
+
+	if (gdk_screen_get_setting (gdk_screen_get_default (),
+	                            "gdk-window-scaling-factor",
+	                            &value))
+		return g_value_get_int (&value);
+
+	return 1;
+}
+

--- a/mate-panel/panel-util.h
+++ b/mate-panel/panel-util.h
@@ -66,6 +66,8 @@ void panel_util_set_tooltip_text (GtkWidget  *widget,
 
 GFile *panel_util_get_file_optional_homedir (const char *location);
 
+int panel_util_get_window_scaling_factor (void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mate-panel/panel-xutils.c
+++ b/mate-panel/panel-xutils.c
@@ -29,6 +29,7 @@
 #endif
 
 #include "panel-xutils.h"
+#include "panel-util.h"
 
 #include <glib.h>
 #include <gdk/gdk.h>
@@ -65,6 +66,7 @@ panel_xutils_set_strut (GdkWindow        *gdk_window,
  {
     Display *xdisplay;
     Window   window;
+    int window_scale;
     gulong   struts [12] = { 0, };
     gulong area[4] = { 0, };
     GdkDisplay *display;
@@ -81,6 +83,8 @@ panel_xutils_set_strut (GdkWindow        *gdk_window,
         net_wm_strut_partial = XInternAtom (xdisplay, "_NET_WM_STRUT_PARTIAL", False);
     if (gnome_wm_strut_area == None)
         gnome_wm_strut_area = XInternAtom (xdisplay, "_GNOME_WM_STRUT_AREA", False);
+
+    window_scale = panel_util_get_window_scaling_factor ();
 
     switch (orientation) {
     case PANEL_ORIENTATION_LEFT:
@@ -105,10 +109,10 @@ panel_xutils_set_strut (GdkWindow        *gdk_window,
         break;
     }
 
-    area[0] = rect->x;
-    area[1] = rect->y;
-    area[2] = rect->width;
-    area[3] = rect->height;
+    area[0] = rect->x * window_scale;
+    area[1] = rect->y * window_scale;
+    area[2] = rect->width * window_scale;
+    area[3] = rect->height * window_scale;
 
     display = gdk_window_get_display (gdk_window);
     gdk_x11_display_error_trap_push (display);

--- a/mate-panel/panel-xutils.c
+++ b/mate-panel/panel-xutils.c
@@ -38,6 +38,7 @@
 
 static Atom net_wm_strut              = None;
 static Atom net_wm_strut_partial      = None;
+static Atom gnome_wm_strut_area       = None;
 
 enum {
     STRUT_LEFT = 0,
@@ -59,11 +60,13 @@ panel_xutils_set_strut (GdkWindow        *gdk_window,
                         PanelOrientation  orientation,
                         guint32           strut,
                         guint32           strut_start,
-                        guint32           strut_end)
+                        guint32           strut_end,
+                        GdkRectangle     *rect)
  {
     Display *xdisplay;
     Window   window;
     gulong   struts [12] = { 0, };
+    gulong area[4] = { 0, };
     GdkDisplay *display;
 
     g_return_if_fail (GDK_IS_WINDOW (gdk_window));
@@ -76,6 +79,8 @@ panel_xutils_set_strut (GdkWindow        *gdk_window,
         net_wm_strut = XInternAtom (xdisplay, "_NET_WM_STRUT", False);
     if (net_wm_strut_partial == None)
         net_wm_strut_partial = XInternAtom (xdisplay, "_NET_WM_STRUT_PARTIAL", False);
+    if (gnome_wm_strut_area == None)
+        gnome_wm_strut_area = XInternAtom (xdisplay, "_GNOME_WM_STRUT_AREA", False);
 
     switch (orientation) {
     case PANEL_ORIENTATION_LEFT:
@@ -100,14 +105,24 @@ panel_xutils_set_strut (GdkWindow        *gdk_window,
         break;
     }
 
+    area[0] = rect->x;
+    area[1] = rect->y;
+    area[2] = rect->width;
+    area[3] = rect->height;
+
     display = gdk_window_get_display (gdk_window);
     gdk_x11_display_error_trap_push (display);
+
     XChangeProperty (xdisplay, window, net_wm_strut,
                      XA_CARDINAL, 32, PropModeReplace,
                      (guchar *) &struts, 4);
     XChangeProperty (xdisplay, window, net_wm_strut_partial,
                      XA_CARDINAL, 32, PropModeReplace,
                      (guchar *) &struts, 12);
+    XChangeProperty (xdisplay, window, gnome_wm_strut_area,
+                     XA_CARDINAL, 32, PropModeReplace,
+                     (guchar *) &area, 4);
+
     gdk_x11_display_error_trap_pop_ignored (display);
 }
 
@@ -126,11 +141,14 @@ panel_xutils_unset_strut (GdkWindow *gdk_window)
         net_wm_strut = XInternAtom (xdisplay, "_NET_WM_STRUT", False);
     if (net_wm_strut_partial == None)
         net_wm_strut_partial = XInternAtom (xdisplay, "_NET_WM_STRUT_PARTIAL", False);
+    if (gnome_wm_strut_area == None)
+        gnome_wm_strut_area = XInternAtom (xdisplay, "_GNOME_WM_STRUT_AREA", False);
 
     gdk_x11_display_error_trap_push (display);
 
     XDeleteProperty (xdisplay, xwindow, net_wm_strut);
     XDeleteProperty (xdisplay, xwindow, net_wm_strut_partial);
+    XDeleteProperty (xdisplay, xwindow, gnome_wm_strut_area);
 
     gdk_x11_display_error_trap_pop_ignored (display);
 }

--- a/mate-panel/panel-xutils.h
+++ b/mate-panel/panel-xutils.h
@@ -47,7 +47,8 @@ void panel_xutils_set_strut       (GdkWindow             *gdk_window,
                                    PanelOrientation       orientation,
                                    guint32                strut,
                                    guint32                strut_start,
-                                   guint32                strut_end);
+                                   guint32                strut_end,
+                                   GdkRectangle          *rect);
 
 void panel_xutils_unset_strut     (GdkWindow             *gdk_window);
 


### PR DESCRIPTION
Back port from gnome-panel:

In addition to existing properties set also new _GNOME_WM_STRUT_AREA
property that allows creating struts between monitors.

https://mail.gnome.org/archives/wm-spec-list/2018-December/msg00000.html
https://gitlab.freedesktop.org/xdg/xdg-specs/merge_requests/22

origin commit:
https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/b505fde

This works fine with with normal monitor resolutions, But not with HIDIPi.
With HIDPI the window decorations are always under the top panel when using side-tiling or quarter-tiling.
Here i need a bit help.
Maybe there is another commit from gnome-panel missing?

This can be tested together with https://github.com/mate-desktop/marco/pull/678