### PR TITLE
Add the function of monitor panel launcher files

### DIFF
--- a/mate-panel/launcher.h
+++ b/mate-panel/launcher.h
@@ -26,6 +26,7 @@ typedef struct {
 	char              *location;
 	GKeyFile          *key_file;
 
+	GFileMonitor      *monitor;
 	GtkWidget         *prop_dialog;
 	GSList            *error_dialogs;
 


### PR DESCRIPTION
Add the function of monitor  panel launcher ```xxxxx.desktop``` files
When the launcher ```.desktop``` file changes, change the panel launcher synchronously

Fix #1235