### PR TITLE
Fix clock applet add location crash

### DIFF
--- a/applets/clock/clock-location.c
+++ b/applets/clock/clock-location.c
@@ -92,7 +92,7 @@ clock_location_find_and_ref (GSList       *locations,
         }
 
         if (l != NULL)
-                return g_object_ref (CLOCK_LOCATION (l->data));
+                return CLOCK_LOCATION (l->data);
         else
                 return NULL;
 }

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -2252,7 +2252,7 @@ location_start_element (GMarkupParseContext *context,
         if (current && clock_location_is_current_timezone (loc))
                 clock_location_make_current (loc, NULL, NULL, NULL);
 
-        data->cities = g_slist_append (data->cities, loc);
+        data->cities = g_slist_append (data->cities, g_object_ref (loc));
 }
 
 static GMarkupParser location_parser = {
@@ -2682,7 +2682,7 @@ run_prefs_edit_save (GtkButton *button, ClockData *cd)
                  */
                 clock_location_is_current (loc);
 
-                cd->locations = g_slist_append (cd->locations, loc);
+                cd->locations = g_slist_append (cd->locations, g_object_ref (loc));
         }
         g_free (name);
         g_free (city);


### PR DESCRIPTION
Fix clock applet add location crash
This PR needs to be tested with  [libmateweathe#100](https://github.com/mate-desktop/libmateweather/pull/100)
### test

1. make  [libmateweathe#100](https://github.com/mate-desktop/libmateweather/pull/100) and install
2. make this pr and install
3. restart clock-applet and  mate-panel
4. clock-applet->edit->location->add