### PR TITLE
fix mate-desktop-item-edit executable

### DIFF
--- a/mate-panel/Makefile.am
+++ b/mate-panel/Makefile.am
@@ -170,6 +170,8 @@ mate_panel_LDFLAGS = -export-dynamic
 mate_desktop_item_edit_SOURCES = \
 	mate-desktop-item-edit.c \
 	panel-ditem-editor.c \
+	panel-resources.c		\
+	panel-resources.h		\
 	panel-marshal.c \
 	panel-util.c
 
@@ -187,6 +189,8 @@ if ENABLE_X11
 mate_desktop_item_edit_LDADD += \
 	-lX11
 endif
+
+mate_desktop_item_edit_LDFLAGS = -export-dynamic
 
 mate_panel_test_applets_SOURCES = \
 	$(panel_test_applets_BUILT_SOURCES)	\


### PR DESCRIPTION
This should fix https://github.com/mate-desktop/mozo/issues/81.
Maybe a new soon point release for mate-panel would be good, because without this mozo is more or less broken.