### PR TITLE
Updated installation instructions ; added missing build dependency

### DIFF
--- a/README
+++ b/README
@@ -26,13 +26,18 @@ Installation
 
 See the file 'INSTALL'. If you are not using a released version of
 mate-panel (for example, if you checked out the code from git), you
-first need to run './autogen.sh'.
+first need to run :
+
+git submodule init
+git submodule update
+./autogen.sh
 
 Build dependencies
 ==================
 
 On Ubuntu MATE 18.04 (daily 2018-01-30)
 build-essential
+autopoint
 mate-common
 libglib2.0-dev
 yelp-tools


### PR DESCRIPTION
While trying to build mate-panel, I noticed two small errors in the README : the git submodule needs to be updated before autogen is called, and there was one package missing in the list of build dependencies.