### PR TITLE
panel-test-applets: fix memory leak

### DIFF
--- a/mate-panel/panel-test-applets.c
+++ b/mate-panel/panel-test-applets.c
@@ -287,8 +287,8 @@ setup_options (void)
 
 		gtk_list_store_append (model, &iter);
 		gtk_list_store_set (model, &iter,
-				    COLUMN_TEXT, g_strdup (mate_panel_applet_info_get_name (info)),
-				    COLUMN_ITEM, g_strdup (mate_panel_applet_info_get_iid (info)),
+				    COLUMN_TEXT, mate_panel_applet_info_get_name (info),
+				    COLUMN_ITEM, mate_panel_applet_info_get_iid (info),
 				    -1);
 	}
 	g_list_free (applet_list);


### PR DESCRIPTION
```
LeakSanitizer: detected memory leaks

Direct leak of 1258 byte(s) in 32 object(s) allocated from:
    #0 0x7ff30fb8c93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7ff30e776b7f in g_malloc ../glib/gmem.c:106
    #2 0x7ff30e776ec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7ff30e7991a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x409787 in setup_options /home/robert/builddir.gcc/mate-panel/mate-panel/panel-test-applets.c:289
    #5 0x409ec1 in main /home/robert/builddir.gcc/mate-panel/mate-panel/panel-test-applets.c:388
    #6 0x7ff30e538b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Direct leak of 512 byte(s) in 32 object(s) allocated from:
    #0 0x7ff30fb8c93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7ff30e776b7f in g_malloc ../glib/gmem.c:106
    #2 0x7ff30e776ec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7ff30e7991a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x4097a1 in setup_options /home/robert/builddir.gcc/mate-panel/mate-panel/panel-test-applets.c:289
    #5 0x409ec1 in main /home/robert/builddir.gcc/mate-panel/mate-panel/panel-test-applets.c:388
    #6 0x7ff30e538b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```