### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/libmate-panel-applet/mate-panel-applet-factory.c
+++ b/libmate-panel-applet/mate-panel-applet-factory.c
@@ -273,7 +273,8 @@ static const gchar introspection_xml[] =
 static const GDBusInterfaceVTable interface_vtable = {
 	method_call_cb,
 	NULL,
-	NULL
+	NULL,
+	{ 0 }
 };
 
 static GDBusNodeInfo *introspection_data = NULL;

--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -148,7 +148,8 @@ static const GtkActionEntry menu_entries[] = {
 static const GtkToggleActionEntry menu_toggle_entries[] = {
 	{ "Lock", NULL, N_("Loc_k To Panel"),
 	  NULL, NULL,
-	  G_CALLBACK (mate_panel_applet_menu_cmd_lock) }
+	  G_CALLBACK (mate_panel_applet_menu_cmd_lock),
+	  FALSE }
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (MatePanelApplet, mate_panel_applet, GTK_TYPE_EVENT_BOX)
@@ -2324,7 +2325,8 @@ static const gchar introspection_xml[] =
 static const GDBusInterfaceVTable interface_vtable = {
 	method_call_cb,
 	get_property_cb,
-	set_property_cb
+	set_property_cb,
+	{ 0 }
 };
 
 static GDBusNodeInfo *introspection_data = NULL;

--- a/mate-panel/main.c
+++ b/mate-panel/main.c
@@ -59,7 +59,7 @@ static const GOptionEntry options[] = {
   { "run-dialog", 0, 0, G_OPTION_ARG_NONE, &run_dialog, N_("Execute the run dialog"), NULL },
   /* default panels layout */
   { "layout", 0, 0, G_OPTION_ARG_STRING, &layout, N_("Set the default panel layout"), NULL },
-  { NULL }
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 static void

--- a/mate-panel/mate-desktop-item-edit.c
+++ b/mate-panel/mate-desktop-item-edit.c
@@ -26,7 +26,7 @@ static char **desktops = NULL;
 static GOptionEntry options[] = {
 	{ "create-new", 0, 0, G_OPTION_ARG_NONE, &create_new, N_("Create new file in the given directory"), NULL },
 	{ G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &desktops, NULL, N_("[FILE...]") },
-	{ NULL }
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 static void

--- a/mate-panel/panel-test-applets.c
+++ b/mate-panel/panel-test-applets.c
@@ -41,7 +41,7 @@ static const GOptionEntry options [] = {
 	{ "prefs-path", 0, 0, G_OPTION_ARG_STRING, &cli_prefs_path, N_("Specify a gsettings path in which the applet preferences should be stored"), NULL},
 	{ "size", 0, 0, G_OPTION_ARG_STRING, &cli_size, N_("Specify the initial size of the applet (xx-small, medium, large etc.)"), NULL},
 	{ "orient", 0, 0, G_OPTION_ARG_STRING, &cli_orient, N_("Specify the initial orientation of the applet (top, bottom, left or right)"), NULL},
-	{ NULL}
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 enum {

--- a/mate-panel/xstuff.c
+++ b/mate-panel/xstuff.c
@@ -233,7 +233,7 @@ draw_zoom_animation (GdkScreen *gscreen,
 	int i, j;
 	GC frame_gc;
 	XGCValues gcv;
-	GdkColor color = { 65535, 65535, 65535 };
+	GdkColor color = { .pixel = 0, .red = 65535, .green = 65535, .blue = 65535 };
 	Display *dpy;
 	Window root_win;
 	int screen;


### PR DESCRIPTION
```
gpm-main.c:175:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL}
                      ^
--
gpm-prefs.c:74:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL}
                      ^
--
gpm-statistics.c:1211:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL}
                      ^
--
gpm-backlight-helper.c:174:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL}
                      ^
[robert@fedora builddir]$ grep -A 2 Wmissing-field-initializers] mate-panel.make.log
eggtreemultidnd.c:75:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
        };
        ^
--
eggsmclient.c:261:16: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
--
main.c:62:10: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
  { NULL }
         ^
--
xstuff.c:236:41: warning: missing field 'blue' initializer [-Wmissing-field-initializers]
        GdkColor color = { 65535, 65535, 65535 };
                                               ^
--
mate-desktop-item-edit.c:29:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
--
panel-test-applets.c:44:8: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL}
              ^
--
mate-panel-applet-factory.c:277:1: warning: missing field 'padding' initializer [-Wmissing-field-initializers]
};
^
--
mate-panel-applet.c:151:49: warning: missing field 'is_active' initializer [-Wmissing-field-initializers]
          G_CALLBACK (mate_panel_applet_menu_cmd_lock) }
                                                       ^
--
mate-panel-applet.c:2328:1: warning: missing field 'padding' initializer [-Wmissing-field-initializers]
};
^
```