### PR TITLE
Remove unnecessary cast in g_signal_connect* call

### DIFF
--- a/applets/clock/clock-location-tile.c
+++ b/applets/clock/clock-location-tile.c
@@ -82,7 +82,7 @@ clock_location_tile_new (ClockLocation *loc,
 
         g_signal_connect (priv->weather_icon, "query-tooltip",
                           G_CALLBACK (weather_tooltip), this);
-        priv->location_weather_updated_id = g_signal_connect (G_OBJECT (loc), "weather-updated",
+        priv->location_weather_updated_id = g_signal_connect (loc, "weather-updated",
                                                               G_CALLBACK (update_weather_icon), this);
 
         return this;

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1414,7 +1414,7 @@ create_clock_widget (ClockData *cd)
                           G_CALLBACK (do_not_eat_button_press), NULL);
         g_signal_connect (cd->panel_button, "toggled",
                           G_CALLBACK (toggle_calendar), cd);
-        g_signal_connect (G_OBJECT (cd->panel_button), "destroy",
+        g_signal_connect (cd->panel_button, "destroy",
                           G_CALLBACK (destroy_clock),
                           cd);
         gtk_widget_show (cd->panel_button);
@@ -2510,13 +2510,11 @@ fill_clock_applet (MatePanelApplet *applet)
         /* we have to bind change_orient before we do applet_widget_add
            since we need to get an initial change_orient signal to set our
            initial oriantation, and we get that during the _add call */
-        g_signal_connect (G_OBJECT (cd->applet),
-                          "change-orient",
+        g_signal_connect (cd->applet, "change-orient",
                           G_CALLBACK (applet_change_orient),
                           cd);
 
-        g_signal_connect (G_OBJECT (cd->panel_button),
-                          "size-allocate",
+        g_signal_connect (cd->panel_button, "size-allocate",
                           G_CALLBACK (panel_button_change_pixel_size),
                           cd);
 
@@ -3191,31 +3189,31 @@ ensure_prefs_window_is_created (ClockData *cd)
                 gtk_widget_hide (clock_options);
 
         selection = gtk_tree_view_get_selection (cd->prefs_locations);
-        g_signal_connect (G_OBJECT (selection), "changed",
+        g_signal_connect (selection, "changed",
                           G_CALLBACK (prefs_locations_changed), cd);
 
-        g_signal_connect (G_OBJECT (cd->prefs_window), "delete-event",
+        g_signal_connect (cd->prefs_window, "delete-event",
                           G_CALLBACK (prefs_hide_event), cd);
 
-        g_signal_connect (G_OBJECT (prefs_close_button), "clicked",
+        g_signal_connect (prefs_close_button, "clicked",
                           G_CALLBACK (prefs_hide), cd);
 
-        g_signal_connect (G_OBJECT (prefs_help_button), "clicked",
+        g_signal_connect (prefs_help_button, "clicked",
                           G_CALLBACK (prefs_help), cd);
 
         cd->prefs_location_remove_button = _clock_get_widget (cd, "prefs-locations-remove-button");
 
-        g_signal_connect (G_OBJECT (cd->prefs_location_remove_button), "clicked",
+        g_signal_connect (cd->prefs_location_remove_button, "clicked",
                           G_CALLBACK (run_prefs_locations_remove), cd);
 
         cd->prefs_location_add_button = _clock_get_widget (cd, "prefs-locations-add-button");
 
-        g_signal_connect (G_OBJECT (cd->prefs_location_add_button), "clicked",
+        g_signal_connect (cd->prefs_location_add_button, "clicked",
                           G_CALLBACK (run_prefs_locations_add), cd);
 
         cd->prefs_location_edit_button = _clock_get_widget (cd, "prefs-locations-edit-button");
 
-        g_signal_connect (G_OBJECT (cd->prefs_location_edit_button), "clicked",
+        g_signal_connect (cd->prefs_location_edit_button, "clicked",
                           G_CALLBACK (run_prefs_locations_edit), cd);
 
         edit_window = _clock_get_widget (cd, "edit-location-window");
@@ -3223,7 +3221,7 @@ ensure_prefs_window_is_created (ClockData *cd)
         gtk_window_set_transient_for (GTK_WINDOW (edit_window),
                                       GTK_WINDOW (cd->prefs_window));
 
-        g_signal_connect (G_OBJECT (edit_window), "delete-event",
+        g_signal_connect (edit_window, "delete-event",
                           G_CALLBACK (edit_hide_event), cd);
 
         edit_cancel_button = _clock_get_widget (cd, "edit-location-cancel-button");
@@ -3239,9 +3237,9 @@ ensure_prefs_window_is_created (ClockData *cd)
         gtk_label_set_mnemonic_widget (GTK_LABEL (location_name_label),
                                        GTK_WIDGET (cd->location_entry));
 
-        g_signal_connect (G_OBJECT (cd->location_entry), "notify::location",
+        g_signal_connect (cd->location_entry, "notify::location",
                           G_CALLBACK (location_changed), cd);
-        g_signal_connect (G_OBJECT (cd->location_entry), "changed",
+        g_signal_connect (cd->location_entry, "changed",
                           G_CALLBACK (location_name_changed), cd);
 
         zone_box = _clock_get_widget (cd, "edit-location-timezone-box");
@@ -3251,15 +3249,15 @@ ensure_prefs_window_is_created (ClockData *cd)
         gtk_label_set_mnemonic_widget (GTK_LABEL (timezone_label),
                                        GTK_WIDGET (cd->zone_combo));
 
-        g_signal_connect (G_OBJECT (cd->zone_combo), "notify::tzid",
+        g_signal_connect (cd->zone_combo, "notify::tzid",
                           G_CALLBACK (location_timezone_changed), cd);
 
         mateweather_location_unref (world);
 
-        g_signal_connect (G_OBJECT (edit_cancel_button), "clicked",
+        g_signal_connect (edit_cancel_button, "clicked",
                           G_CALLBACK (edit_hide), cd);
 
-        g_signal_connect (G_OBJECT (edit_ok_button), "clicked",
+        g_signal_connect (edit_ok_button, "clicked",
                           G_CALLBACK (run_prefs_edit_save), cd);
 
         /* Set up the time setting section */
@@ -3337,8 +3335,7 @@ display_properties_dialog (ClockData *cd, gboolean start_in_locations_page)
 
         GtkWidget *notebook = _clock_get_widget (cd, "notebook");
         gtk_widget_add_events (notebook, GDK_SCROLL_MASK);
-        g_signal_connect (GTK_NOTEBOOK (notebook),
-                          "scroll-event",
+        g_signal_connect (notebook, "scroll-event",
                           G_CALLBACK (on_notebook_scroll_event),
                           NULL);
 

--- a/applets/clock/system-timezone.c
+++ b/applets/clock/system-timezone.c
@@ -213,8 +213,7 @@ system_timezone_constructor (GType                  type,
                 g_object_unref (file);
 
                 if (priv->monitors[i])
-                        g_signal_connect (G_OBJECT (priv->monitors[i]),
-                                          "changed",
+                        g_signal_connect (priv->monitors [i], "changed",
                                           G_CALLBACK (system_timezone_monitor_changed),
                                           obj);
         }

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -199,7 +199,7 @@ ensure_prefs_window_is_created (NaTrayApplet *applet)
   g_signal_connect_swapped (applet->priv->dialog->preferences_dialog, "response",
                             G_CALLBACK (na_preferences_dialog_response), applet);
 
-  g_signal_connect (G_OBJECT (applet->priv->dialog->preferences_dialog), "delete-event",
+  g_signal_connect (applet->priv->dialog->preferences_dialog, "delete-event",
                     G_CALLBACK (na_preferences_dialog_hide_event), applet);
 }
 

--- a/applets/wncklet/showdesktop.c
+++ b/applets/wncklet/showdesktop.c
@@ -421,7 +421,9 @@ gboolean show_desktop_applet_fill(MatePanelApplet* applet)
 
 	sdd->size = mate_panel_applet_get_size(MATE_PANEL_APPLET(sdd->applet));
 
-	g_signal_connect(G_OBJECT(sdd->applet), "realize", G_CALLBACK(show_desktop_applet_realized), sdd);
+	g_signal_connect (sdd->applet, "realize",
+	                  G_CALLBACK (show_desktop_applet_realized),
+	                  sdd);
 
 	sdd->button = gtk_toggle_button_new ();
 
@@ -441,21 +443,29 @@ gboolean show_desktop_applet_fill(MatePanelApplet* applet)
 
 	atk_obj = gtk_widget_get_accessible(sdd->button);
 	atk_object_set_name (atk_obj, _("Show Desktop Button"));
-	g_signal_connect(G_OBJECT(sdd->button), "button-press-event", G_CALLBACK(do_not_eat_button_press), NULL);
+	g_signal_connect (sdd->button, "button-press-event",
+	                  G_CALLBACK(do_not_eat_button_press),
+	                  NULL);
 
-	g_signal_connect(G_OBJECT(sdd->button), "toggled", G_CALLBACK(button_toggled_callback), sdd);
+	g_signal_connect (sdd->button, "toggled",
+	                  G_CALLBACK (button_toggled_callback),
+	                  sdd);
 
 	gtk_container_set_border_width(GTK_CONTAINER(sdd->button), 0);
 	gtk_container_add(GTK_CONTAINER(sdd->button), sdd->image);
 	gtk_container_add(GTK_CONTAINER(sdd->applet), sdd->button);
 
-	g_signal_connect (G_OBJECT(sdd->button), "size-allocate", G_CALLBACK(button_size_allocated), sdd);
+	g_signal_connect (sdd->button, "size-allocate",
+	                  G_CALLBACK (button_size_allocated),
+	                  sdd);
 
 	/* FIXME: Update this comment. */
 	/* we have to bind change_orient before we do applet_widget_add
 	   since we need to get an initial change_orient signal to set our
 	   initial oriantation, and we get that during the _add call */
-	g_signal_connect(G_OBJECT (sdd->applet), "change-orient", G_CALLBACK (applet_change_orient), sdd);
+	g_signal_connect (sdd->applet, "change-orient",
+	                  G_CALLBACK (applet_change_orient),
+	                  sdd);
 
 	action_group = gtk_action_group_new("ShowDesktop Applet Actions");
 	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);
@@ -465,12 +475,18 @@ gboolean show_desktop_applet_fill(MatePanelApplet* applet)
 	                                            action_group);
 	g_object_unref(action_group);
 
-	g_signal_connect(G_OBJECT(sdd->applet), "destroy", G_CALLBACK(applet_destroyed), sdd);
+	g_signal_connect (sdd->applet, "destroy",
+	                  G_CALLBACK (applet_destroyed),
+	                  sdd);
 
 	gtk_drag_dest_set(GTK_WIDGET(sdd->button), 0, NULL, 0, 0);
 
-	g_signal_connect(G_OBJECT(sdd->button), "drag-motion", G_CALLBACK (button_drag_motion), sdd);
-	g_signal_connect(G_OBJECT(sdd->button), "drag-leave", G_CALLBACK (button_drag_leave), sdd);
+	g_signal_connect (sdd->button, "drag-motion",
+	                  G_CALLBACK (button_drag_motion),
+	                  sdd);
+	g_signal_connect (sdd->button, "drag-leave",
+	                  G_CALLBACK (button_drag_leave),
+	                  sdd);
 
 	gtk_widget_show_all(sdd->applet);
 
@@ -551,7 +567,9 @@ static void button_toggled_callback(GtkWidget* button, ShowDesktopData* sdd)
 
 		g_object_add_weak_pointer(G_OBJECT(dialog), (gpointer) &dialog);
 
-		g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(gtk_widget_destroy), NULL);
+		g_signal_connect (dialog, "response",
+		                  G_CALLBACK(gtk_widget_destroy),
+		                  NULL);
 
 		gtk_window_set_resizable(GTK_WINDOW(dialog), FALSE);
 		gtk_window_set_screen(GTK_WINDOW(dialog), gtk_widget_get_screen(button));

--- a/applets/wncklet/wayland-backend.c
+++ b/applets/wncklet/wayland-backend.c
@@ -352,8 +352,7 @@ toplevel_task_new (TasklistManager *tasklist, struct zwlr_foreign_toplevel_handl
 				task,
 				(GDestroyNotify)toplevel_task_disconnected_from_widget);
 
-	g_signal_connect (G_OBJECT (task->button),
-			  "button-press-event",
+	g_signal_connect (task->button, "button-press-event",
 			  G_CALLBACK (on_toplevel_button_press),
 			  task);
 

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -419,7 +419,10 @@ static gboolean applet_enter_notify_event (WnckTasklist *tl, GList *wnck_windows
 
 	gtk_widget_show (tasklist->preview);
 
-	g_signal_connect_data (G_OBJECT (tasklist->preview), "draw", G_CALLBACK (preview_window_draw), thumbnail, (GClosureNotify) G_CALLBACK (cairo_surface_destroy), 0);
+	g_signal_connect_data (tasklist->preview, "draw",
+	                       G_CALLBACK (preview_window_draw), thumbnail,
+	                       (GClosureNotify) G_CALLBACK (cairo_surface_destroy),
+	                       0);
 
 	return FALSE;
 }
@@ -808,8 +811,12 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 		wnck_tasklist_set_icon_loader(WNCK_TASKLIST(tasklist->tasklist), icon_loader_func, tasklist, NULL);
 
 #ifdef HAVE_WINDOW_PREVIEWS
-		g_signal_connect(G_OBJECT(tasklist->tasklist), "task-enter-notify", G_CALLBACK(applet_enter_notify_event), tasklist);
-		g_signal_connect(G_OBJECT(tasklist->tasklist), "task-leave-notify", G_CALLBACK(applet_leave_notify_event), tasklist);
+		g_signal_connect (tasklist->tasklist, "task-enter-notify",
+		                  G_CALLBACK (applet_enter_notify_event),
+		                  tasklist);
+		g_signal_connect (tasklist->tasklist, "task-leave-notify",
+		                  G_CALLBACK (applet_leave_notify_event),
+		                  tasklist);
 #endif /* HAVE_WINDOW_PREVIEWS */
 	}
 	else
@@ -829,15 +836,27 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 
 	tasklist_apply_orientation(tasklist);
 
-	g_signal_connect(G_OBJECT(tasklist->tasklist), "destroy", G_CALLBACK(destroy_tasklist), tasklist);
-	g_signal_connect(G_OBJECT(tasklist->applet), "size-allocate", G_CALLBACK(applet_size_allocate), tasklist);
+	g_signal_connect (tasklist->tasklist, "destroy",
+	                  G_CALLBACK (destroy_tasklist),
+	                  tasklist);
+	g_signal_connect (tasklist->applet, "size-allocate",
+	                  G_CALLBACK (applet_size_allocate),
+	                  tasklist);
 
 	gtk_container_add(GTK_CONTAINER(tasklist->applet), tasklist->tasklist);
 
-	g_signal_connect(G_OBJECT(tasklist->applet), "realize", G_CALLBACK(applet_realized), tasklist);
-	g_signal_connect(G_OBJECT(tasklist->applet), "change-orient", G_CALLBACK(applet_change_orient), tasklist);
-	g_signal_connect(G_OBJECT(tasklist->applet), "change-size", G_CALLBACK(applet_change_pixel_size), tasklist);
-	g_signal_connect(G_OBJECT(tasklist->applet), "change-background", G_CALLBACK(applet_change_background), tasklist);
+	g_signal_connect (tasklist->applet, "realize",
+	                  G_CALLBACK (applet_realized),
+	                  tasklist);
+	g_signal_connect (tasklist->applet, "change-orient",
+	                  G_CALLBACK (applet_change_orient),
+	                  tasklist);
+	g_signal_connect (tasklist->applet, "change-size",
+	                  G_CALLBACK (applet_change_pixel_size),
+	                  tasklist);
+	g_signal_connect (tasklist->applet, "change-background",
+	                  G_CALLBACK(applet_change_background),
+	                  tasklist);
 
 	action_group = gtk_action_group_new("Tasklist Applet Actions");
 	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);
@@ -1071,9 +1090,15 @@ static void setup_dialog(GtkBuilder* builder, TasklistData* tasklist)
 	g_object_set_data(G_OBJECT(tasklist->auto_group_radio), "group_value", "auto");
 	g_object_set_data(G_OBJECT(tasklist->always_group_radio), "group_value", "always");
 
-	g_signal_connect(G_OBJECT(tasklist->never_group_radio), "toggled", (GCallback) group_windows_toggled, tasklist);
-	g_signal_connect(G_OBJECT(tasklist->auto_group_radio), "toggled", (GCallback) group_windows_toggled, tasklist);
-	g_signal_connect(G_OBJECT(tasklist->always_group_radio), "toggled", (GCallback) group_windows_toggled, tasklist);
+	g_signal_connect (tasklist->never_group_radio, "toggled",
+	                  (GCallback) group_windows_toggled,
+	                  tasklist);
+	g_signal_connect (tasklist->auto_group_radio, "toggled",
+	                  (GCallback) group_windows_toggled,
+	                  tasklist);
+	g_signal_connect (tasklist->always_group_radio, "toggled",
+	                  (GCallback) group_windows_toggled,
+	                  tasklist);
 
 	/* Mouse Scroll: */
 	g_settings_bind (tasklist->settings,
@@ -1085,19 +1110,29 @@ static void setup_dialog(GtkBuilder* builder, TasklistData* tasklist)
 #ifdef HAVE_WINDOW_PREVIEWS
 	/* change thumbnail size: */
 	tasklist_update_thumbnail_size_spin(tasklist);
-	g_signal_connect(G_OBJECT(tasklist->thumbnail_size_spin), "value-changed", (GCallback) thumbnail_size_spin_changed, tasklist);
+	g_signal_connect (tasklist->thumbnail_size_spin, "value-changed",
+	                  (GCallback) thumbnail_size_spin_changed,
+	                  tasklist);
 #endif
 
 	/* move window when unminimizing: */
 	tasklist_update_unminimization_radio(tasklist);
-	g_signal_connect(G_OBJECT(tasklist->move_minimized_radio), "toggled", (GCallback) move_minimized_toggled, tasklist);
+	g_signal_connect (tasklist->move_minimized_radio, "toggled",
+	                  (GCallback) move_minimized_toggled,
+	                  tasklist);
 
 	/* Tasklist content: */
 	tasklist_properties_update_content_radio (tasklist);
-	g_signal_connect(G_OBJECT(tasklist->show_all_radio), "toggled", (GCallback) display_all_workspaces_toggled, tasklist);
+	g_signal_connect (tasklist->show_all_radio, "toggled",
+	                  (GCallback) display_all_workspaces_toggled,
+	                  tasklist);
 
-	g_signal_connect_swapped(WID("done_button"), "clicked", (GCallback) gtk_widget_hide, tasklist->properties_dialog);
-	g_signal_connect(tasklist->properties_dialog, "response", G_CALLBACK(response_cb), tasklist);
+	g_signal_connect_swapped (WID ("done_button"), "clicked",
+	                          (GCallback) gtk_widget_hide,
+	                          tasklist->properties_dialog);
+	g_signal_connect (tasklist->properties_dialog, "response",
+	                  G_CALLBACK (response_cb),
+	                  tasklist);
 
 #ifdef HAVE_WAYLAND
 	if (GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default())) {

--- a/applets/wncklet/window-menu.c
+++ b/applets/wncklet/window-menu.c
@@ -271,13 +271,23 @@ gboolean window_menu_applet_fill(MatePanelApplet* applet)
 
 	gtk_container_add(GTK_CONTAINER(window_menu->applet), window_menu->selector);
 
-	g_signal_connect(window_menu->applet, "size-allocate", G_CALLBACK(window_menu_size_allocate), window_menu);
+	g_signal_connect (window_menu->applet, "size-allocate",
+	                  G_CALLBACK(window_menu_size_allocate),
+	                  window_menu);
 
-	g_signal_connect_after(G_OBJECT(window_menu->applet), "focus-in-event", G_CALLBACK(gtk_widget_queue_draw), window_menu);
-	g_signal_connect_after(G_OBJECT(window_menu->applet), "focus-out-event", G_CALLBACK(gtk_widget_queue_draw), window_menu);
-	g_signal_connect_after(G_OBJECT(window_menu->selector), "draw", G_CALLBACK(window_menu_on_draw), window_menu);
+	g_signal_connect_after (window_menu->applet, "focus-in-event",
+	                        G_CALLBACK (gtk_widget_queue_draw),
+	                        window_menu);
+	g_signal_connect_after (window_menu->applet, "focus-out-event",
+	                        G_CALLBACK (gtk_widget_queue_draw),
+	                        window_menu);
+	g_signal_connect_after (window_menu->selector, "draw",
+	                        G_CALLBACK (window_menu_on_draw),
+	                        window_menu);
 
-	g_signal_connect(G_OBJECT(window_menu->selector), "button-press-event", G_CALLBACK(filter_button_press), window_menu);
+	g_signal_connect (window_menu->selector, "button_press_event",
+	                  G_CALLBACK (filter_button_press),
+	                  window_menu);
 
 	gtk_widget_show_all(GTK_WIDGET(window_menu->applet));
 

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -649,21 +649,35 @@ gboolean workspace_switcher_applet_fill(MatePanelApplet* applet)
 	context = gtk_widget_get_style_context (pager->pager);
 	gtk_style_context_add_class (context, "wnck-pager");
 
-	g_signal_connect(G_OBJECT(pager->pager), "destroy", G_CALLBACK(destroy_pager), pager);
+	g_signal_connect (pager->pager, "destroy",
+	                  G_CALLBACK (destroy_pager),
+	                  pager);
 
 	/* overwrite default WnckPager widget scroll-event */
-	g_signal_connect(G_OBJECT(pager->pager), "scroll-event", G_CALLBACK(applet_scroll), pager);
+	g_signal_connect (pager->pager, "scroll-event",
+	                  G_CALLBACK (applet_scroll),
+	                  pager);
 
 	gtk_container_add(GTK_CONTAINER(pager->applet), pager->pager);
 
-	g_signal_connect(G_OBJECT(pager->applet), "realize", G_CALLBACK(applet_realized), pager);
-	g_signal_connect(G_OBJECT(pager->applet), "unrealize", G_CALLBACK(applet_unrealized), pager);
-	g_signal_connect(G_OBJECT(pager->applet), "change-orient", G_CALLBACK(applet_change_orient), pager);
-	g_signal_connect(G_OBJECT(pager->applet), "change-background", G_CALLBACK(applet_change_background), pager);
-	g_signal_connect(G_OBJECT(pager->applet), "style-updated", G_CALLBACK(applet_style_updated), context);
+	g_signal_connect (pager->applet, "realize",
+	                  G_CALLBACK (applet_realized),
+	                  pager);
+	g_signal_connect (pager->applet, "unrealize",
+	                  G_CALLBACK (applet_unrealized),
+	                  pager);
+	g_signal_connect (pager->applet, "change-orient",
+	                  G_CALLBACK (applet_change_orient),
+	                  pager);
+	g_signal_connect (pager->applet, "change-background",
+	                  G_CALLBACK (applet_change_background),
+	                  pager);
+	g_signal_connect (pager->applet, "style-updated",
+	                  G_CALLBACK (applet_style_updated),
+	                  context);
 
-	gtk_widget_show(pager->pager);
-	gtk_widget_show(pager->applet);
+	gtk_widget_show (pager->pager);
+	gtk_widget_show (pager->applet);
 
 	action_group = gtk_action_group_new("WorkspaceSwitcher Applet Actions");
 	gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);
@@ -1003,18 +1017,24 @@ static void setup_dialog(GtkBuilder* builder, PagerData* pager)
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(pager->wrap_workspaces_toggle), pager->wrap_workspaces);
 	}
 
-	g_signal_connect(G_OBJECT(pager->wrap_workspaces_toggle), "toggled", (GCallback) wrap_workspaces_toggled, pager);
+	g_signal_connect (pager->wrap_workspaces_toggle, "toggled",
+	                  (GCallback) wrap_workspaces_toggled,
+	                  pager);
 
 	/* Display workspace names: */
 
-	g_signal_connect(G_OBJECT(pager->display_workspaces_toggle), "toggled", (GCallback) display_workspace_names_toggled, pager);
+	g_signal_connect (pager->display_workspaces_toggle, "toggled",
+	                  (GCallback) display_workspace_names_toggled,
+	                  pager);
 
 	value = pager->display_names;
 
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(pager->display_workspaces_toggle), value);
 
 	/* Display all workspaces: */
-	g_signal_connect(G_OBJECT(pager->all_workspaces_radio), "toggled", (GCallback) all_workspaces_toggled, pager);
+	g_signal_connect (pager->all_workspaces_radio, "toggled",
+	                  (GCallback) all_workspaces_toggled,
+	                  pager);
 
 	if (pager->display_all)
 	{
@@ -1060,9 +1080,13 @@ static void setup_dialog(GtkBuilder* builder, PagerData* pager)
 	}
 #endif /* HAVE_X11 */
 
-	g_signal_connect (pager->num_workspaces_spin, "value-changed", G_CALLBACK (on_num_workspaces_value_changed), pager);
+	g_signal_connect (pager->num_workspaces_spin, "value-changed",
+	                  G_CALLBACK (on_num_workspaces_value_changed),
+	                  pager);
 
-	g_signal_connect(G_OBJECT(pager->workspaces_tree), "focus-out-event", (GCallback) workspaces_tree_focused_out, pager);
+	g_signal_connect (pager->workspaces_tree, "focus-out-event",
+	                  (GCallback) workspaces_tree_focused_out,
+	                  pager);
 
 	pager->workspaces_store = gtk_list_store_new(1, G_TYPE_STRING, NULL);
 	update_workspaces_model(pager);

--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1942,7 +1942,7 @@ mate_panel_applet_constructor (GType                  type,
 		gtk_widget_set_name (widget, "PanelPlug");
 		_mate_panel_applet_prepare_css (context);
 
-		g_signal_connect_swapped (G_OBJECT (priv->plug), "embedded",
+		g_signal_connect_swapped (priv->plug, "embedded",
 		                          G_CALLBACK (mate_panel_applet_setup),
 		                          applet);
 

--- a/libmate-panel-applet/test-dbus-applet.c
+++ b/libmate-panel-applet/test-dbus-applet.c
@@ -171,18 +171,15 @@ test_applet_fill (TestApplet *applet)
 
 	mate_panel_applet_set_flags (MATE_PANEL_APPLET (applet), MATE_PANEL_APPLET_HAS_HANDLE);
 
-	g_signal_connect (G_OBJECT (applet),
-			  "change-orient",
+	g_signal_connect (applet, "change-orient",
 			  G_CALLBACK (test_applet_handle_orient_change),
 			  NULL);
 
-	g_signal_connect (G_OBJECT (applet),
-			  "change-size",
+	g_signal_connect (applet, "change-size",
 			  G_CALLBACK (test_applet_handle_size_change),
 			  NULL);
 
-	g_signal_connect (G_OBJECT (applet),
-			  "change-background",
+	g_signal_connect (applet, "change-background",
 			  G_CALLBACK (test_applet_handle_background_change),
 			  NULL);
 

--- a/mate-panel/applet.c
+++ b/mate-panel/applet.c
@@ -395,9 +395,9 @@ setup_an_item (AppletUserMenu *menu,
 
 	gtk_widget_show (menu->menuitem);
 
-	g_signal_connect (G_OBJECT (menu->menuitem), "destroy",
-			  G_CALLBACK (gtk_widget_destroyed),
-			  &menu->menuitem);
+	g_signal_connect (menu->menuitem, "destroy",
+	                  G_CALLBACK (gtk_widget_destroyed),
+	                  &menu->menuitem);
 
 	if(submenu)
 		gtk_menu_shell_append (GTK_MENU_SHELL (submenu), menu->menuitem);
@@ -405,11 +405,11 @@ setup_an_item (AppletUserMenu *menu,
 	/*if an item not a submenu*/
 	if (!is_submenu) {
 		g_signal_connect (menu->menuitem, "activate",
-				  G_CALLBACK (applet_callback_callback),
-				  menu);
+		                  G_CALLBACK (applet_callback_callback),
+		                  menu);
 		g_signal_connect (submenu, "destroy",
-				  G_CALLBACK (gtk_widget_destroyed),
-				  &menu->submenu);
+		                  G_CALLBACK (gtk_widget_destroyed),
+		                  &menu->submenu);
 	/* if the item is a submenu and doesn't have it's menu
 	   created yet*/
 	} else if (!menu->submenu) {
@@ -419,9 +419,9 @@ setup_an_item (AppletUserMenu *menu,
 	if(menu->submenu) {
 		gtk_menu_item_set_submenu(GTK_MENU_ITEM(menu->menuitem),
 					  menu->submenu);
-		g_signal_connect (G_OBJECT (menu->submenu), "destroy",
-				    G_CALLBACK (gtk_widget_destroyed),
-				    &menu->submenu);
+		g_signal_connect (menu->submenu, "destroy",
+		                  G_CALLBACK (gtk_widget_destroyed),
+		                  &menu->submenu);
 	}
 
 	gtk_widget_set_sensitive(menu->menuitem,menu->sensitive);

--- a/mate-panel/launcher.c
+++ b/mate-panel/launcher.c
@@ -1011,11 +1011,13 @@ ask_about_launcher (const char  *file,
 					    launcher_save_uri,
 					    NULL);
 
-	g_signal_connect (G_OBJECT (dialog), "saved",
-			  G_CALLBACK (launcher_new_saved), NULL);
+	g_signal_connect (dialog, "saved",
+	                  G_CALLBACK (launcher_new_saved),
+	                  NULL);
 
-	g_signal_connect (G_OBJECT (dialog), "error-reported",
-			  G_CALLBACK (launcher_error_reported), NULL);
+	g_signal_connect (dialog, "error-reported",
+	                  G_CALLBACK (launcher_error_reported),
+	                  NULL);
 
 	gtk_window_set_screen (GTK_WINDOW (dialog),
 			       gtk_widget_get_screen (GTK_WIDGET (panel)));

--- a/mate-panel/libpanel-util/panel-error.c
+++ b/mate-panel/libpanel-util/panel-error.c
@@ -80,9 +80,9 @@ panel_error_dialog (GtkWindow  *parent,
 	gtk_widget_show_all (dialog);
 
 	if (auto_destroy)
-		g_signal_connect_swapped (G_OBJECT (dialog), "response",
-					  G_CALLBACK (gtk_widget_destroy),
-					  G_OBJECT (dialog));
+		g_signal_connect_swapped (dialog, "response",
+		                          G_CALLBACK (gtk_widget_destroy),
+		                          dialog);
 
 	if (freeme)
 		g_free (freeme);

--- a/mate-panel/libpanel-util/panel-icon-chooser.c
+++ b/mate-panel/libpanel-util/panel-icon-chooser.c
@@ -431,9 +431,9 @@ _panel_icon_chooser_clicked (GtkButton *button)
 
 	chooser->priv->filechooser = filechooser;
 
-	g_signal_connect (G_OBJECT (filechooser), "destroy",
-			  G_CALLBACK (gtk_widget_destroyed),
-			  &chooser->priv->filechooser);
+	g_signal_connect (filechooser, "destroy",
+	                  G_CALLBACK (gtk_widget_destroyed),
+	                  &chooser->priv->filechooser);
 
 	gtk_widget_show (filechooser);
 }

--- a/mate-panel/mate-desktop-item-edit.c
+++ b/mate-panel/mate-desktop-item-edit.c
@@ -205,10 +205,12 @@ main (int argc, char * argv[])
 
 		if (dlg != NULL) {
 			dialogs ++;
-			g_signal_connect (G_OBJECT (dlg), "destroy",
-					  G_CALLBACK (dialog_destroyed), NULL);
-			g_signal_connect (G_OBJECT (dlg), "error-reported",
-					  G_CALLBACK (error_reported), NULL);
+			g_signal_connect (dlg, "destroy",
+			                  G_CALLBACK (dialog_destroyed),
+			                  NULL);
+			g_signal_connect (dlg, "error-reported",
+			                  G_CALLBACK (error_reported),
+			                  NULL);
 			gtk_widget_show (dlg);
 		}
 

--- a/mate-panel/menu.c
+++ b/mate-panel/menu.c
@@ -807,15 +807,17 @@ setup_uri_drag (GtkWidget  *menuitem,
 	if (icon != NULL)
 		gtk_drag_source_set_icon_name (menuitem, icon);
 
-	g_signal_connect (G_OBJECT (menuitem), "drag-begin",
-			  G_CALLBACK (drag_begin_menu_cb), NULL);
-	g_signal_connect_data (G_OBJECT (menuitem), "drag-data-get",
-			       G_CALLBACK (drag_data_get_string_cb),
-			       g_strdup (uri),
-			       (GClosureNotify) G_CALLBACK (g_free),
-			       0 /* connect_flags */);
-	g_signal_connect (G_OBJECT (menuitem), "drag-end",
-			  G_CALLBACK (drag_end_menu_cb), NULL);
+	g_signal_connect (menuitem, "drag-begin",
+	                  G_CALLBACK (drag_begin_menu_cb),
+	                  NULL);
+	g_signal_connect_data (menuitem, "drag-data-get",
+	                       G_CALLBACK (drag_data_get_string_cb),
+	                       g_strdup (uri),
+	                       (GClosureNotify) G_CALLBACK (g_free),
+	                       0 /* connect_flags */);
+	g_signal_connect (menuitem, "drag-end",
+	                  G_CALLBACK (drag_end_menu_cb),
+	                  NULL);
 }
 
 void
@@ -838,15 +840,17 @@ setup_internal_applet_drag (GtkWidget             *menuitem,
 		gtk_drag_source_set_icon_name (menuitem,
 					       panel_action_get_icon_name (type));
 
-	g_signal_connect (G_OBJECT (menuitem), "drag-begin",
-			  G_CALLBACK (drag_begin_menu_cb), NULL);
-	g_signal_connect_data (G_OBJECT (menuitem), "drag-data-get",
-			       G_CALLBACK (drag_data_get_string_cb),
-			       g_strdup (panel_action_get_drag_id (type)),
-			       (GClosureNotify) G_CALLBACK (g_free),
-			       0 /* connect_flags */);
-	g_signal_connect (G_OBJECT (menuitem), "drag-end",
-			  G_CALLBACK (drag_end_menu_cb), NULL);
+	g_signal_connect (menuitem, "drag-begin",
+	                  G_CALLBACK (drag_begin_menu_cb),
+	                  NULL);
+	g_signal_connect_data (menuitem, "drag-data-get",
+	                       G_CALLBACK (drag_data_get_string_cb),
+	                       g_strdup (panel_action_get_drag_id (type)),
+	                       (GClosureNotify) G_CALLBACK (g_free),
+	                       0 /* connect_flags */);
+	g_signal_connect (menuitem, "drag-end",
+	                  G_CALLBACK (drag_end_menu_cb),
+	                  NULL);
 }
 
 static void
@@ -1117,12 +1121,15 @@ create_menuitem (GtkWidget          *menu,
 			}
 		}
 
-		g_signal_connect (G_OBJECT (menuitem), "drag-begin",
-				  G_CALLBACK (drag_begin_menu_cb), NULL);
+		g_signal_connect (menuitem, "drag-begin",
+		                  G_CALLBACK (drag_begin_menu_cb),
+		                  NULL);
 		g_signal_connect (menuitem, "drag-data-get",
-				  G_CALLBACK (drag_data_get_menu_cb), entry);
+		                  G_CALLBACK (drag_data_get_menu_cb),
+		                  entry);
 		g_signal_connect (menuitem, "drag-end",
-				  G_CALLBACK (drag_end_menu_cb), NULL);
+		                  G_CALLBACK (drag_end_menu_cb),
+		                  NULL);
 	}
 
 	gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);

--- a/mate-panel/panel-addto.c
+++ b/mate-panel/panel-addto.c
@@ -339,12 +339,12 @@ panel_addto_setup_drag (GtkTreeView          *tree_view,
 						GDK_BUTTON1_MASK|GDK_BUTTON2_MASK,
 						target, 1, GDK_ACTION_COPY);
 
-	g_signal_connect_data (G_OBJECT (tree_view), "drag-data-get",
+	g_signal_connect_data (tree_view, "drag-data-get",
 			       G_CALLBACK (panel_addto_drag_data_get_cb),
 			       g_strdup (text),
 			       (GClosureNotify) G_CALLBACK (g_free),
 			       0 /* connect_flags */);
-	g_signal_connect_after (G_OBJECT (tree_view), "drag-begin",
+	g_signal_connect_after (tree_view, "drag-begin",
 	                        G_CALLBACK (panel_addto_drag_begin_cb),
 	                        NULL);
 }
@@ -1288,10 +1288,12 @@ panel_addto_dialog_new (PanelWidget *panel_widget)
 	gtk_box_set_spacing (GTK_BOX (dialog_vbox), 12);
 	gtk_container_set_border_width (GTK_CONTAINER (dialog_vbox), 5);
 
-	g_signal_connect (G_OBJECT (dialog->addto_dialog), "response",
-			  G_CALLBACK (panel_addto_dialog_response), dialog);
+	g_signal_connect (dialog->addto_dialog, "response",
+	                  G_CALLBACK (panel_addto_dialog_response),
+	                  dialog);
 	g_signal_connect (dialog->addto_dialog, "destroy",
-			  G_CALLBACK (panel_addto_dialog_destroy), dialog);
+	                  G_CALLBACK (panel_addto_dialog_destroy),
+	                  dialog);
 
 	inner_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_box_pack_start (GTK_BOX (dialog_vbox), inner_vbox, TRUE, TRUE, 0);
@@ -1308,10 +1310,12 @@ panel_addto_dialog_new (PanelWidget *panel_widget)
 			    FALSE, FALSE, 0);
 
 	dialog->search_entry = gtk_entry_new ();
-	g_signal_connect (G_OBJECT (dialog->search_entry), "changed",
-			  G_CALLBACK (panel_addto_search_entry_changed), dialog);
-	g_signal_connect (G_OBJECT (dialog->search_entry), "activate",
-			  G_CALLBACK (panel_addto_search_entry_activated), dialog);
+	g_signal_connect (dialog->search_entry, "changed",
+	                  G_CALLBACK (panel_addto_search_entry_changed),
+	                  dialog);
+	g_signal_connect (dialog->search_entry, "activate",
+			  G_CALLBACK (panel_addto_search_entry_activated),
+	                  dialog);
 
 	gtk_box_pack_end (GTK_BOX (find_hbox), dialog->search_entry,
 			  TRUE, TRUE, 0);

--- a/mate-panel/panel-context-menu.c
+++ b/mate-panel/panel-context-menu.c
@@ -238,8 +238,9 @@ panel_context_menu_build_edition (PanelWidget *panel_widget,
 
 	gtk_widget_show (menuitem);
 	gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
-        g_signal_connect (G_OBJECT (menuitem), "activate",
-	      	       	  G_CALLBACK (panel_addto_present), panel_widget);
+        g_signal_connect (menuitem, "activate",
+	      	       	  G_CALLBACK (panel_addto_present),
+                          panel_widget);
 
 	if (!panel_profile_id_lists_are_writable ())
 		gtk_widget_set_sensitive (menuitem, FALSE);
@@ -265,12 +266,12 @@ panel_context_menu_build_edition (PanelWidget *panel_widget,
 
 	gtk_widget_show (menuitem);
 	gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
-	g_signal_connect_swapped (G_OBJECT (menuitem), "activate",
-				  G_CALLBACK (panel_context_menu_delete_panel),
-				  panel_widget->toplevel);
-	g_signal_connect (G_OBJECT (menu), "show",
-			  G_CALLBACK (panel_context_menu_setup_delete_panel_item),
-			  menuitem);
+	g_signal_connect_swapped (menuitem, "activate",
+	                          G_CALLBACK (panel_context_menu_delete_panel),
+	                          panel_widget->toplevel);
+	g_signal_connect (menu, "show",
+	                  G_CALLBACK (panel_context_menu_setup_delete_panel_item),
+	                  menuitem);
 
 	add_menu_separator (menu);
 
@@ -279,8 +280,8 @@ panel_context_menu_build_edition (PanelWidget *panel_widget,
 	gtk_widget_show (menuitem);
 	gtk_menu_shell_append (GTK_MENU_SHELL (menu), menuitem);
 	g_signal_connect (menuitem, "activate",
-			  G_CALLBACK (panel_context_menu_create_new_panel),
-			  NULL);
+	                  G_CALLBACK (panel_context_menu_create_new_panel),
+	                  NULL);
 	gtk_widget_set_sensitive (menuitem,
 				  panel_profile_id_lists_are_writable ());
 

--- a/mate-panel/panel-ditem-editor.c
+++ b/mate-panel/panel-ditem-editor.c
@@ -900,10 +900,10 @@ panel_ditem_editor_connect_signals (PanelDItemEditor *dialog)
 	priv = dialog->priv;
 
 #define CONNECT_CHANGED(widget, callback) \
-	g_signal_connect_swapped (G_OBJECT (widget), "changed", \
+	g_signal_connect_swapped (widget, "changed", \
 				  G_CALLBACK (callback), \
 				  dialog); \
-	g_signal_connect_swapped (G_OBJECT (widget), "changed", \
+	g_signal_connect_swapped (widget, "changed", \
 				  G_CALLBACK (panel_ditem_editor_changed), \
 				  dialog);
 

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -106,7 +106,7 @@ static void panel_menu_bar_setup_tooltip(PanelMenuBar* menubar)
 	g_signal_connect(menubar->priv->desktop_item, "activate", G_CALLBACK (panel_menu_bar_hide_tooltip_and_focus), menubar);
 
 	/* Reset tooltip when the menu bar is not used */
-	g_signal_connect(GTK_MENU_SHELL (menubar), "deactivate", G_CALLBACK (panel_menu_bar_reinit_tooltip), menubar);
+	g_signal_connect(menubar, "deactivate", G_CALLBACK (panel_menu_bar_reinit_tooltip), menubar);
 }
 
 static void

--- a/mate-panel/panel-menu-items.c
+++ b/mate-panel/panel-menu-items.c
@@ -244,8 +244,9 @@ panel_menu_items_append_from_desktop (GtkWidget *menu,
 			       G_CALLBACK (panel_menu_item_activate_desktop_file),
 			       g_strdup (full_path),
 			       (GClosureNotify) G_CALLBACK (g_free), 0);
-	g_signal_connect (G_OBJECT (item), "button-press-event",
-			  G_CALLBACK (menu_dummy_button_press_event), NULL);
+	g_signal_connect (item, "button-press-event",
+	                  G_CALLBACK (menu_dummy_button_press_event),
+	                  NULL);
 
 	uri = g_filename_to_uri (full_path, NULL, NULL);
 
@@ -293,8 +294,9 @@ panel_menu_items_append_place_item (const char *icon_name,
 	g_signal_connect_data (item, "activate", callback, user_data,
 			       (GClosureNotify) G_CALLBACK (g_free), 0);
 
-	g_signal_connect (G_OBJECT (item), "button-press-event",
-			  G_CALLBACK (menu_dummy_button_press_event), NULL);
+	g_signal_connect (item, "button-press-event",
+	                  G_CALLBACK (menu_dummy_button_press_event),
+	                  NULL);
 
 	if (g_str_has_prefix (uri, "file:")) /*Links only work for local files*/
 		setup_uri_drag (item, uri, icon_name, GDK_ACTION_LINK);
@@ -323,9 +325,11 @@ panel_menu_items_create_action_item_full (PanelActionButtonType  action_type,
 					panel_action_get_tooltip (action_type));
 
 	g_signal_connect (item, "activate",
-			  panel_action_get_invoke (action_type), NULL);
-	g_signal_connect (G_OBJECT (item), "button-press-event",
-			  G_CALLBACK (menu_dummy_button_press_event), NULL);
+			  panel_action_get_invoke (action_type),
+	                  NULL);
+	g_signal_connect (item, "button-press-event",
+	                  G_CALLBACK (menu_dummy_button_press_event),
+	                  NULL);
 	setup_internal_applet_drag (item, action_type);
 
 	return item;
@@ -608,8 +612,9 @@ panel_menu_item_append_drive (GtkWidget *menu,
 			       g_object_ref (drive),
 			       (GClosureNotify) G_CALLBACK (g_object_unref), 0);
 
-	g_signal_connect (G_OBJECT (item), "button-press-event",
-			  G_CALLBACK (menu_dummy_button_press_event), NULL);
+	g_signal_connect (item, "button-press-event",
+	                  G_CALLBACK (menu_dummy_button_press_event),
+	                  NULL);
 }
 
 typedef struct {
@@ -708,8 +713,9 @@ panel_menu_item_append_volume (GtkWidget *menu,
 			       g_object_ref (volume),
 			       (GClosureNotify) G_CALLBACK (g_object_unref), 0);
 
-	g_signal_connect (G_OBJECT (item), "button-press-event",
-			  G_CALLBACK (menu_dummy_button_press_event), NULL);
+	g_signal_connect (item, "button-press-event",
+	                  G_CALLBACK (menu_dummy_button_press_event),
+	                  NULL);
 }
 
 static void
@@ -1358,8 +1364,7 @@ panel_place_menu_item_init (PanelPlaceMenuItem *menuitem)
 			   bookmarks_filename, error->message);
 		g_error_free (error);
 	} else {
-		g_signal_connect (G_OBJECT (menuitem->priv->bookmarks_monitor),
-				  "changed",
+		g_signal_connect (menuitem->priv->bookmarks_monitor, "changed",
 				  (GCallback) panel_place_menu_item_gtk_bookmarks_changed,
 				  menuitem);
 	}

--- a/mate-panel/panel-recent.c
+++ b/mate-panel/panel-recent.c
@@ -200,12 +200,13 @@ panel_recent_append_documents_menu (GtkWidget        *top_menu,
 				  _("Recent Documents"));
 	recent_menu = gtk_recent_chooser_menu_new_for_manager (manager);
 	gtk_menu_item_set_submenu (GTK_MENU_ITEM (menu_item), recent_menu);
-	
+
 	gtk_recent_chooser_set_limit (GTK_RECENT_CHOOSER (recent_menu),
 				      recent_items_limit);
 
-	g_signal_connect (G_OBJECT (recent_menu), "button-press-event",
-			  G_CALLBACK (menu_dummy_button_press_event), NULL);
+	g_signal_connect (recent_menu, "button-press-event",
+			  G_CALLBACK (menu_dummy_button_press_event),
+	                  NULL);
 
 	gtk_menu_shell_append (GTK_MENU_SHELL (top_menu), menu_item);
 	gtk_widget_show_all (menu_item);
@@ -217,8 +218,7 @@ panel_recent_append_documents_menu (GtkWidget        *top_menu,
 	gtk_recent_chooser_set_sort_type (GTK_RECENT_CHOOSER (recent_menu),
 					  GTK_RECENT_SORT_MRU);
 
-	g_signal_connect (GTK_RECENT_CHOOSER (recent_menu),
-			  "item-activated",
+	g_signal_connect (recent_menu, "item-activated",
 			  G_CALLBACK (recent_documents_activate_cb),
 			  NULL);
 

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -4016,10 +4016,9 @@ panel_toplevel_update_gtk_settings (PanelToplevel *toplevel)
 
 	toplevel->priv->gtk_settings = gtk_widget_get_settings (GTK_WIDGET (toplevel->priv->panel_widget));
 
-	g_signal_connect_swapped (G_OBJECT (toplevel->priv->gtk_settings),
-				  "notify::gtk-dnd-drag-threshold",
-				  G_CALLBACK (panel_toplevel_drag_threshold_changed),
-				  toplevel);
+	g_signal_connect_swapped (toplevel->priv->gtk_settings, "notify::gtk-dnd-drag-threshold",
+	                          G_CALLBACK (panel_toplevel_drag_threshold_changed),
+	                          toplevel);
 
 	panel_toplevel_drag_threshold_changed (toplevel);
 }
@@ -4790,7 +4789,7 @@ panel_toplevel_init (PanelToplevel *toplevel)
 	/* Prevent the window from being deleted via Alt+F4 by accident.  This
 	 * happens with "alternative" window managers such as Sawfish or XFWM4.
 	 */
-	g_signal_connect(GTK_WIDGET(toplevel), "delete-event", G_CALLBACK(gtk_true), NULL);
+	g_signal_connect (toplevel, "delete-event", G_CALLBACK(gtk_true), NULL);
 
 	panel_background_init (&toplevel->background,
 			       (PanelBackgroundChangedNotify) background_changed,

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -289,7 +289,7 @@ panel_widget_class_init (PanelWidgetClass *class)
 	GtkContainerClass *container_class = (GtkContainerClass*) class;
 
 	panel_widget_signals[SIZE_CHANGE_SIGNAL] =
-                g_signal_new ("size_change",
+                g_signal_new ("size-change",
                               G_TYPE_FROM_CLASS (object_class),
                               G_SIGNAL_RUN_LAST,
                               G_STRUCT_OFFSET (PanelWidgetClass, size_change),
@@ -300,7 +300,7 @@ panel_widget_class_init (PanelWidgetClass *class)
                               0);
 
 	panel_widget_signals[BACK_CHANGE_SIGNAL] =
-                g_signal_new ("back_change",
+                g_signal_new ("back-change",
                               G_TYPE_FROM_CLASS (object_class),
                               G_SIGNAL_RUN_LAST,
                               G_STRUCT_OFFSET (PanelWidgetClass, back_change),
@@ -311,7 +311,7 @@ panel_widget_class_init (PanelWidgetClass *class)
                               0);
 
 	panel_widget_signals[APPLET_MOVE_SIGNAL] =
-                g_signal_new ("applet_move",
+                g_signal_new ("applet-move",
                               G_TYPE_FROM_CLASS (object_class),
                               G_SIGNAL_RUN_LAST,
                               G_STRUCT_OFFSET (PanelWidgetClass, applet_move),
@@ -323,7 +323,7 @@ panel_widget_class_init (PanelWidgetClass *class)
                               G_TYPE_POINTER);
 
 	panel_widget_signals[APPLET_ADDED_SIGNAL] =
-                g_signal_new ("applet_added",
+                g_signal_new ("applet-added",
                               G_TYPE_FROM_CLASS (object_class),
                               G_SIGNAL_RUN_LAST,
                               G_STRUCT_OFFSET (PanelWidgetClass, applet_added),
@@ -335,7 +335,7 @@ panel_widget_class_init (PanelWidgetClass *class)
                               G_TYPE_POINTER);
 
 	panel_widget_signals[APPLET_REMOVED_SIGNAL] =
-                g_signal_new ("applet_removed",
+                g_signal_new ("applet-removed",
                               G_TYPE_FROM_CLASS (object_class),
                               G_SIGNAL_RUN_LAST,
                               G_STRUCT_OFFSET (PanelWidgetClass, applet_removed),

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -2313,9 +2313,9 @@ bind_applet_events(GtkWidget *widget, gpointer data)
 	 */
 
 	if (gtk_widget_get_has_window (widget))
-		g_signal_connect (G_OBJECT(widget), "event",
-				  G_CALLBACK (panel_sub_event_handler),
-				  data);
+		g_signal_connect (widget, "event",
+		                  G_CALLBACK (panel_sub_event_handler),
+		                  data);
 
 	if (GTK_IS_CONTAINER(widget))
 		gtk_container_foreach (GTK_CONTAINER (widget),
@@ -2354,7 +2354,7 @@ bind_top_applet_events (GtkWidget *widget)
 {
 	g_return_if_fail(GTK_IS_WIDGET(widget));
 
-	g_signal_connect (G_OBJECT(widget), "destroy",
+	g_signal_connect (widget, "destroy",
 			  G_CALLBACK (panel_widget_applet_destroy),
 			  NULL);
 

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -1321,19 +1321,19 @@ drag_data_recieved_cb (GtkWidget	*widget,
 static void
 panel_widget_setup(PanelWidget *panel)
 {
-	g_signal_connect (panel, "applet_added",
+	g_signal_connect (panel, "applet-added",
 			  G_CALLBACK(mate_panel_applet_added),
 			  NULL);
-	g_signal_connect (panel, "applet_removed",
+	g_signal_connect (panel, "applet-removed",
 			  G_CALLBACK(mate_panel_applet_removed),
 			  NULL);
-	g_signal_connect (panel, "applet_move",
+	g_signal_connect (panel, "applet-move",
 			  G_CALLBACK(mate_panel_applet_move),
 			  NULL);
-	g_signal_connect (panel, "back_change",
+	g_signal_connect (panel, "back-change",
 			  G_CALLBACK (panel_back_change),
 			  NULL);
-	g_signal_connect (panel, "size_change",
+	g_signal_connect (panel, "size-change",
 			  G_CALLBACK (panel_size_change),
 			  NULL);
 }

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -1321,24 +1321,19 @@ drag_data_recieved_cb (GtkWidget	*widget,
 static void
 panel_widget_setup(PanelWidget *panel)
 {
-	g_signal_connect (G_OBJECT(panel),
-			  "applet_added",
+	g_signal_connect (panel, "applet_added",
 			  G_CALLBACK(mate_panel_applet_added),
 			  NULL);
-	g_signal_connect (G_OBJECT(panel),
-			  "applet_removed",
+	g_signal_connect (panel, "applet_removed",
 			  G_CALLBACK(mate_panel_applet_removed),
 			  NULL);
-	g_signal_connect (G_OBJECT(panel),
-			  "applet_move",
+	g_signal_connect (panel, "applet_move",
 			  G_CALLBACK(mate_panel_applet_move),
 			  NULL);
-	g_signal_connect (G_OBJECT (panel),
-			  "back_change",
+	g_signal_connect (panel, "back_change",
 			  G_CALLBACK (panel_back_change),
 			  NULL);
-	g_signal_connect (G_OBJECT (panel),
-			  "size_change",
+	g_signal_connect (panel, "size_change",
 			  G_CALLBACK (panel_size_change),
 			  NULL);
 }
@@ -1507,9 +1502,9 @@ panel_deletion_dialog (PanelToplevel *toplevel)
 
 	gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_CENTER);
 
-	 g_signal_connect (dialog, "destroy",
-                           G_CALLBACK (panel_deletion_destroy_dialog),
-                           toplevel);
+	g_signal_connect (dialog, "destroy",
+	                  G_CALLBACK (panel_deletion_destroy_dialog),
+	                  toplevel);
 
 	g_object_set_data (G_OBJECT (toplevel), "panel-delete-dialog", dialog);
 	panel_toplevel_push_autohide_disabler (toplevel);

--- a/mate-panel/xstuff.c
+++ b/mate-panel/xstuff.c
@@ -207,8 +207,9 @@ draw_zoom_animation_composited (GdkScreen *gscreen,
 
 	gtk_window_move (GTK_WINDOW (win), wx, wy);
 
-	g_signal_connect (G_OBJECT (win), "draw",
-			 G_CALLBACK (zoom_draw), zoom);
+	g_signal_connect (win, "draw",
+	                  G_CALLBACK (zoom_draw),
+	                  zoom);
 
 	/* see doc for gtk_widget_set_app_paintable() */
 	gtk_widget_realize (win);


### PR DESCRIPTION
In addition, use dashes for signals: applet-added, applet-removed, applet-move, back-change, size-change