### PR TITLE
clock: fix memory leak

### DIFF
--- a/applets/clock/calendar-window.c
+++ b/applets/clock/calendar-window.c
@@ -403,6 +403,8 @@ calendar_window_dispose (GObject *object)
 
 	calwin = CALENDAR_WINDOW (object);
 
+	g_clear_pointer (&calwin->priv->prefs_path, g_free);
+
 	if (calwin->priv->settings)
 		g_object_unref (calwin->priv->settings);
 	calwin->priv->settings = NULL;


### PR DESCRIPTION
```
Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fc2ab23a93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fc2a9d131bf in g_malloc ../glib/gmem.c:106
    #2 0x7fc2a9d13502 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fc2a9d35995 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x40eee9 in calendar_window_set_prefs_path /home/robert/builddir.gcc/mate-panel/applets/clock/calendar-window.c:622
    #5 0x40d949 in calendar_window_set_property /home/robert/builddir.gcc/mate-panel/applets/clock/calendar-window.c:390
    #6 0x7fc2a9e29629 in object_set_property ../gobject/gobject.c:1571
    #7 0x7fc2a9e2e024 in g_object_constructor ../gobject/gobject.c:2331
    #8 0x40d3a5 in calendar_window_constructor /home/robert/builddir.gcc/mate-panel/applets/clock/calendar-window.c:315
    #9 0x7fc2a9e2ecc1 in g_object_new_with_custom_constructor ../gobject/gobject.c:1863
    #10 0x7fc2a9e28bbf in g_object_new_internal ../gobject/gobject.c:1943
    #11 0x7fc2a9e28940 in g_object_new_valist ../gobject/gobject.c:2288
    #12 0x7fc2a9e27f31 in g_object_new ../gobject/gobject.c:1788
    #13 0x40df0d in calendar_window_new /home/robert/builddir.gcc/mate-panel/applets/clock/calendar-window.c:493
    #14 0x41259e in create_calendar /home/robert/builddir.gcc/mate-panel/applets/clock/clock.c:838
    #15 0x41515a in update_calendar_popup /home/robert/builddir.gcc/mate-panel/applets/clock/clock.c:1252
    #16 0x415328 in toggle_calendar /home/robert/builddir.gcc/mate-panel/applets/clock/clock.c:1277
    #17 0x7fc2a9e2203f in g_cclosure_marshal_VOID__VOID ../gobject/gmarshal.c:117
    #18 0x7fc2a9e1e354 in g_closure_invoke ../gobject/gclosure.c:830
    #19 0x7fc2a9e3ed92 in signal_emit_unlocked_R ../gobject/gsignal.c:3742
    #20 0x7fc2a9e406ac in g_signal_emit_valist ../gobject/gsignal.c:3497
    #21 0x7fc2a9e40eae in g_signal_emit ../gobject/gsignal.c:3553
    #22 0x7fc2aa7c16e4 in gtk_toggle_button_clicked (/lib64/libgtk-3.so.0+0x34a6e4)
```