### PR TITLE
panel-run-dialog: address of array 'dent->d_name' will always evaluate to 'true'

### DIFF
--- a/mate-panel/panel-run-dialog.c
+++ b/mate-panel/panel-run-dialog.c
@@ -1317,8 +1317,7 @@ fill_files_from (const char *dirname,
 		char       *item;
 		const char *suffix;
 
-		if (!dent->d_name ||
-		    dent->d_name [0] != prefix)
+		if (dent->d_name [0] != prefix)
 			continue;
 
 		file = g_build_filename (dirname, dent->d_name, NULL);


### PR DESCRIPTION
`d_name` is never NULL since it points to a character array.
```
panel-run-dialog.c:1320:14: warning: address of array 'dent->d_name' will always evaluate to 'true' [-Wpointer-bool-conversion]
                if (!dent->d_name ||
                    ~~~~~~~^~~~~~
```
### glibc
```
           struct dirent {
               ino_t          d_ino;       /* Inode number */
               off_t          d_off;       /* Not an offset; see below */
               unsigned short d_reclen;    /* Length of this record */
               unsigned char  d_type;      /* Type of file; not supported
                                              by all filesystem types */
               char           d_name[256]; /* Null-terminated filename */
           };
```
https://man7.org/linux/man-pages/man3/readdir.3.html
### libc
```
The buffer must be large enough for a struct dirent with a d_name array with {NAME_MAX} + 1 elements.
```
https://www.freebsd.org/cgi/man.cgi?query=readdir&sektion=3&manpath=freebsd-release-ports