### PR TITLE
notification_area: fix build warning -Wbad-function-cast

### DIFF
--- a/applets/notification_area/testtray.c
+++ b/applets/notification_area/testtray.c
@@ -86,12 +86,16 @@ tray_removed_cb (GtkContainer *box, GtkWidget *icon, TrayData *data)
 
 static void orientation_changed_cb (GtkComboBox *combo, TrayData *data)
 {
-  GtkOrientation orientation = (GtkOrientation) gtk_combo_box_get_active (combo);
+  gint active;
 
-  g_print ("[Screen %u tray %p] Setting orientation to \"%s\"\n",
-	   data->screen_num, data->traybox, orientation == 0 ? "horizontal" : "vertical");
-
-  gtk_orientable_set_orientation (GTK_ORIENTABLE (data->traybox), orientation);
+  if ((active = gtk_combo_box_get_active (combo)) != -1) {
+    GtkOrientation orientation = (GtkOrientation) active;
+    g_print ("[Screen %u tray %p] Setting orientation to \"%s\"\n",
+             data->screen_num,
+             data->traybox,
+             orientation == GTK_ORIENTATION_HORIZONTAL ? "horizontal" : "vertical");
+    gtk_orientable_set_orientation (GTK_ORIENTABLE (data->traybox), orientation);
+  }
 }
 
 static void


### PR DESCRIPTION
```
testtray.c:89:49: warning: cast from function call of type 'gint' (aka 'int') to non-matching type 'GtkOrientation' [-Wbad-function-cast]
  GtkOrientation orientation = (GtkOrientation) gtk_combo_box_get_active (combo);
                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
https://docs.gtk.org/gtk3/method.ComboBox.get_active.html