### PR TITLE
wncklet: The values stored in the wrapper hash table are incorrect

### DIFF
--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -255,7 +255,6 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
                           int          *thumbnail_scale)
 {
 	GdkWindow *window;
-	GdkWindow *window_wrapper = NULL;
 	Window win;
 	cairo_surface_t *thumbnail;
 	cairo_t *cr;
@@ -264,20 +263,9 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 
 	win = wnck_window_get_xid (wnck_window);
 
-	if ((window = gdk_x11_window_lookup_for_display (gdk_display_get_default (), win)) == NULL)
+	if ((window = gdk_x11_window_foreign_new_for_display (gdk_display_get_default (), win)) == NULL)
 	{
-		if ((window = gdk_x11_window_foreign_new_for_display (gdk_display_get_default (), win)) == NULL)
-		{
-			return NULL;
-		}
-		else
-		{
-			window_wrapper = window;
-		}
-	}
-	else
-	{
-		g_object_ref (window);
+		return NULL;
 	}
 
 	*thumbnail_scale = scale = gdk_window_get_scale_factor (window);
@@ -310,8 +298,6 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 	cairo_paint (cr);
 	cairo_destroy (cr);
 
-	if (window_wrapper)
-		g_object_unref (window_wrapper);
 	g_object_unref (window);
 
 	return thumbnail;


### PR DESCRIPTION
The values stored in the lookup hash table (`display_x11->xid_ht`) are no longer valid after 06292db.

gdk/x11/gdkwindow-x11.c
```
GdkWindow *
gdk_x11_window_foreign_new_for_display (GdkDisplay *display,
                                        Window      window)
{
...
  if ((win = gdk_x11_window_lookup_for_display (display, window)) != NULL) /* search in the lookup table */
    return g_object_ref (win);
...
  win = _gdk_display_create_window (display);
  win->impl = g_object_new (GDK_TYPE_WINDOW_IMPL_X11, NULL);
....
  g_object_ref (win);
  _gdk_x11_display_add_window (display, &GDK_WINDOW_XID (win), win); /* add in the lookup table */
....
  return win;
}
```

gdk/x11/gdkxid.c
```
void
_gdk_x11_display_add_window (GdkDisplay *display,
                             XID        *xid,
                             GdkWindow  *data)
{
...
  g_hash_table_insert (display_x11->xid_ht, xid, data);
}
```
```
GdkWindow *
gdk_x11_window_lookup_for_display (GdkDisplay *display,
                                   Window      window)
{
  GdkX11Display *display_x11;
...
  if (display_x11->xid_ht)
    data = g_hash_table_lookup (display_x11->xid_ht, &window);

  return data;
}
```
It reverts the commits below:
- c4a5e77 "wncklet: search the window before creating a new one"
- 06292db "wncklet: remove extra ref on gdk_x11_window_foreign_new_for_display"

closes #1246