### PR TITLE
clock: cast from function call of type 'gdouble' to non-matching type

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1819,11 +1819,11 @@ output_cb (GtkSpinButton *spin,
 {
         GtkAdjustment *adj;
         gchar *text;
-        int value;
+        gdouble value;
 
         adj = gtk_spin_button_get_adjustment (spin);
-        value = (int) gtk_adjustment_get_value (adj);
-        text = g_strdup_printf ("%02d", value);
+        value = gtk_adjustment_get_value (adj);
+        text = g_strdup_printf ("%02.0f", value);
         gtk_entry_set_text (GTK_ENTRY (spin), text);
         g_free (text);
 


### PR DESCRIPTION
```
git submodule init
git submodule update --recursive --remote
CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
Fix the build warning below:
```
clock.c:1825:23: warning: cast from function call of type 'gdouble' (aka 'double') to non-matching type 'int' [-Wbad-function-cast]
        value = (int) gtk_adjustment_get_value (adj);
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```