### PR TITLE
panel-toplevel: Redundant condition (cppcheck)

### DIFF
--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -2508,8 +2508,7 @@ panel_toplevel_update_geometry (PanelToplevel  *toplevel,
 
 #ifdef HAVE_X11
 	if (GDK_IS_X11_DISPLAY (gtk_widget_get_display (GTK_WIDGET (toplevel)))) {
-		if (toplevel->priv->state == PANEL_STATE_NORMAL ||
-		    toplevel->priv->state != PANEL_STATE_AUTO_HIDDEN) {
+		if (toplevel->priv->state == PANEL_STATE_NORMAL) {
 			panel_struts_update_toplevel_geometry (toplevel,
 							&toplevel->priv->geometry.x,
 							&toplevel->priv->geometry.y,


### PR DESCRIPTION
```
cppcheck --enable=warning -q .
```
Fit the cppcheck warning below:
```
mate-panel/panel-toplevel.c:2511:51: style: Redundant condition: If 'EXPR == 0', the comparison 'EXPR != 1' is always true. [redundantCondition]
  if (toplevel->priv->state == PANEL_STATE_NORMAL ||
                                                  ^
```