### PR TITLE
Add "center-stick" capability applets on the panel

### DIFF
--- a/data/default.layout
+++ b/data/default.layout
@@ -19,7 +19,7 @@ object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=top
 position=10
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object clock]
@@ -27,7 +27,7 @@ object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=top
 position=0
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object show-desktop]
@@ -49,5 +49,5 @@ object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
 position=0
-panel-right-stick=true
+relative-to-edge=end
 locked=true

--- a/data/fedora.layout
+++ b/data/fedora.layout
@@ -40,7 +40,7 @@ object-type=applet
 applet-iid=GvcAppletFactory::GvcApplet
 toplevel-id=top
 position=20
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object notification-area]
@@ -48,7 +48,7 @@ object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=top
 position=10
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object clock]
@@ -56,7 +56,7 @@ object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=top
 position=0
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object show-desktop]
@@ -78,5 +78,5 @@ object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
 position=0
-panel-right-stick=true
+relative-to-edge=end
 locked=true

--- a/data/linuxmint.layout
+++ b/data/linuxmint.layout
@@ -29,7 +29,7 @@ object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=bottom
 position=10
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object clock]
@@ -37,5 +37,5 @@ object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=bottom
 position=0
-panel-right-stick=true
+relative-to-edge=end
 locked=true

--- a/data/mageia.layout
+++ b/data/mageia.layout
@@ -40,7 +40,7 @@ object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=top
 position=10
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object clock]
@@ -48,7 +48,7 @@ object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=top
 position=0
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object show-desktop]
@@ -70,6 +70,6 @@ object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
 position=0
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 

--- a/data/opensuse.layout
+++ b/data/opensuse.layout
@@ -29,7 +29,7 @@ object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=bottom
 position=30
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object workspace-switcher]
@@ -37,7 +37,7 @@ object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
 position=20
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object clock]
@@ -45,7 +45,7 @@ object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=bottom
 position=10
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object show-desktop]
@@ -53,5 +53,5 @@ object-type=applet
 applet-iid=WnckletFactory::ShowDesktopApplet
 toplevel-id=bottom
 position=0
-panel-right-stick=true
+relative-to-edge=end
 locked=true

--- a/data/org.mate.panel.object.gschema.xml.in
+++ b/data/org.mate.panel.object.gschema.xml.in
@@ -17,8 +17,13 @@
     </key>
     <key name="panel-right-stick" type="b">
       <default>false</default>
-      <summary>Interpret position relative to bottom/right edge</summary>
-      <description>If true, the position of the object is interpreted relative to the right (or bottom if vertical) edge of the panel.</description>
+      <summary>Interpret position relative to bottom/right edge (DEPRECATED)</summary>
+      <description>If true, the position of the object is interpreted relative to the right (or bottom if vertical) edge of the panel.  This key is provided only for backward compatibility with old panel layouts; please set the "relative-to-edge" property instead.</description>
+    </key>
+    <key name="relative-to-edge" enum="org.mate.panel.PanelObjectEdgeRelativity">
+      <default>'start'</default>
+      <summary>Whether to interpret the value of the "position" key relative to the start, center or end of the panel</summary>
+      <description>The position of the object is interpreted relative to one edge of the panel.  The value of this key determines whether the object is positioned relative to the start (left/top edge), center, or end (right/bottom edge) of the panel.  Valid values for this key are 'start', 'center', and 'end'.</description>
     </key>
     <key name="locked" type="b">
       <default>false</default>

--- a/data/ubuntu.layout
+++ b/data/ubuntu.layout
@@ -26,23 +26,23 @@ menu-path=applications:/
 object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=top
-position=30
-panel-right-stick=true
+position=20
+relative-to-edge=end
 locked=true
 
 [Object clock]
 object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=top
-position=20
-panel-right-stick=true
+position=10
+relative-to-edge=end
 locked=true
 
 [Object shutdown]
 action-type=shutdown
 object-type=action
-position=10
-panel-right-stick=true
+position=0
+relative-to-edge=end
 toplevel-id=top
 locked=true
 
@@ -65,7 +65,7 @@ object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
 position=10
-panel-right-stick=true
+relative-to-edge=end
 locked=true
 
 [Object trashapplet]
@@ -74,4 +74,4 @@ position=0
 toplevel-id=bottom
 applet-iid=TrashAppletFactory::TrashApplet
 object-type=applet
-panel-right-stick=true
+relative-to-edge=end

--- a/mate-panel/applet.h
+++ b/mate-panel/applet.h
@@ -67,12 +67,12 @@ GSList     *mate_panel_applet_list_applets (void);
 
 void        mate_panel_applet_clean        (AppletInfo    *info);
 
-void mate_panel_applet_queue_applet_to_load (const char      *id,
-					PanelObjectType  type,
-					const char      *toplevel_id,
-					int              position,
-					gboolean         right_stick,
-					gboolean         locked);
+void mate_panel_applet_queue_applet_to_load (const char           *id,
+					PanelObjectType            type,
+					const char                *toplevel_id,
+					int                        position,
+					PanelObjectEdgeRelativity  edge_relativity,
+					gboolean                   locked);
 void mate_panel_applet_load_queued_applets  (gboolean initial_load);
 gboolean mate_panel_applet_on_load_queue    (const char *id);
 
@@ -94,7 +94,7 @@ void        mate_panel_applet_save_position           (AppletInfo *applet_info,
 int         mate_panel_applet_get_position    (AppletInfo *applet);
 
 /* True if all the keys relevant to moving are writable
-   (position, toplevel_id, panel_right_stick) */
+   (position, toplevel-id, relative-to-edge) */
 gboolean    mate_panel_applet_can_freely_move (AppletInfo *applet);
 
 /* True if the locked flag is writable */

--- a/mate-panel/drawer.c
+++ b/mate-panel/drawer.c
@@ -622,7 +622,7 @@ panel_drawer_create (PanelToplevel *toplevel,
 {
     char *id;
 
-    id = panel_profile_prepare_object (PANEL_OBJECT_DRAWER, toplevel, position, FALSE);
+    id = panel_profile_prepare_object (PANEL_OBJECT_DRAWER, toplevel, position);
 
     panel_drawer_prepare (id, custom_icon, use_custom_icon, tooltip, NULL);
 
@@ -641,7 +641,7 @@ panel_drawer_create_with_id (const char    *toplevel_id,
     char *id;
     char *attached_toplevel_id = NULL;
 
-    id = panel_profile_prepare_object_with_id (PANEL_OBJECT_DRAWER, toplevel_id, position, FALSE);
+    id = panel_profile_prepare_object_with_id (PANEL_OBJECT_DRAWER, toplevel_id, position);
 
     panel_drawer_prepare (id, custom_icon, use_custom_icon, tooltip, &attached_toplevel_id);
 

--- a/mate-panel/launcher.c
+++ b/mate-panel/launcher.c
@@ -1093,8 +1093,7 @@ panel_launcher_create_with_id (const char    *toplevel_id,
 
 	id = panel_profile_prepare_object_with_id (PANEL_OBJECT_LAUNCHER,
 						   toplevel_id,
-						   position,
-						   FALSE);
+						   position);
 
 	path = g_strdup_printf ("%s%s/", PANEL_OBJECT_PATH, id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -751,7 +751,7 @@ panel_action_button_create (PanelToplevel         *toplevel,
 	char        *id;
 	char        *path;
 
-	id = panel_profile_prepare_object (PANEL_OBJECT_ACTION, toplevel, position, FALSE);
+	id = panel_profile_prepare_object (PANEL_OBJECT_ACTION, toplevel, position);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -1070,7 +1070,7 @@ mate_panel_applet_frame_create (PanelToplevel *toplevel,
 
 	g_return_if_fail (iid != NULL);
 
-	id = panel_profile_prepare_object (PANEL_OBJECT_APPLET, toplevel, position, FALSE);
+	id = panel_profile_prepare_object (PANEL_OBJECT_APPLET, toplevel, position);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-enums-gsettings.h
+++ b/mate-panel/panel-enums-gsettings.h
@@ -61,6 +61,12 @@ typedef enum {
 } PanelObjectType;
 
 typedef enum {
+	PANEL_EDGE_START  = 0,
+	PANEL_EDGE_CENTER = 1,
+	PANEL_EDGE_END    = 2
+} PanelObjectEdgeRelativity;
+
+typedef enum {
 	PANEL_ACTION_NONE = 0,
 	PANEL_ACTION_LOCK,
 	PANEL_ACTION_LOGOUT,

--- a/mate-panel/panel-layout.c
+++ b/mate-panel/panel-layout.c
@@ -77,6 +77,7 @@ static PanelLayoutKeyDefinition panel_layout_object_keys[] = {
         { PANEL_OBJECT_TOPLEVEL_ID_KEY,          G_TYPE_STRING   },
         { PANEL_OBJECT_POSITION_KEY,             G_TYPE_INT      },
         { PANEL_OBJECT_PANEL_RIGHT_STICK_KEY,    G_TYPE_BOOLEAN  },
+        { PANEL_OBJECT_RELATIVE_TO_EDGE_KEY,     G_TYPE_STRING   },
         { PANEL_OBJECT_LOCKED_KEY,               G_TYPE_BOOLEAN  },
         { PANEL_OBJECT_APPLET_IID_KEY,           G_TYPE_STRING   },
         { PANEL_OBJECT_ATTACHED_TOPLEVEL_ID_KEY, G_TYPE_STRING   },

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -379,7 +379,7 @@ void panel_menu_bar_create(PanelToplevel* toplevel, int position)
 {
 	char* id;
 
-	id = panel_profile_prepare_object(PANEL_OBJECT_MENU_BAR, toplevel, position, FALSE);
+	id = panel_profile_prepare_object(PANEL_OBJECT_MENU_BAR, toplevel, position);
 	panel_profile_add_to_list(PANEL_GSETTINGS_OBJECTS, id);
 	g_free(id);
 }

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -965,7 +965,7 @@ panel_menu_button_create (PanelToplevel *toplevel,
 	const char  *scheme;
 	char        *id;
 
-	id = panel_profile_prepare_object (PANEL_OBJECT_MENU, toplevel, position, FALSE);
+	id = panel_profile_prepare_object (PANEL_OBJECT_MENU, toplevel, position);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -1183,10 +1183,9 @@ panel_profile_destroy_toplevel (const char *id)
 }
 
 char *
-panel_profile_prepare_object_with_id (PanelObjectType  object_type,
-				      const char      *toplevel_id,
-				      int              position,
-				      gboolean         right_stick)
+panel_profile_prepare_object_with_id (PanelObjectType            object_type,
+				      const char                *toplevel_id,
+				      int                        position)
 {
 	PanelGSettingsKeyType  key_type;
 	char              *id;
@@ -1203,7 +1202,6 @@ panel_profile_prepare_object_with_id (PanelObjectType  object_type,
 	g_settings_set_enum (settings, PANEL_OBJECT_TYPE_KEY, object_type);
 	g_settings_set_string (settings, PANEL_OBJECT_TOPLEVEL_ID_KEY, toplevel_id);
 	g_settings_set_int (settings, PANEL_OBJECT_POSITION_KEY, position);
-	g_settings_set_boolean (settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY, right_stick);
 
 	/* Force writing the settings in order to reserve the object ID *now*,
 	 * so that a later call to panel_profile_find_new_id() won't find the same
@@ -1217,15 +1215,13 @@ panel_profile_prepare_object_with_id (PanelObjectType  object_type,
 }
 
 char *
-panel_profile_prepare_object (PanelObjectType  object_type,
-			      PanelToplevel   *toplevel,
-			      int              position,
-			      gboolean         right_stick)
+panel_profile_prepare_object (PanelObjectType            object_type,
+			      PanelToplevel             *toplevel,
+			      int                        position)
 {
 	return panel_profile_prepare_object_with_id (object_type,
 						     panel_profile_get_toplevel_id (toplevel),
-						     position,
-						     right_stick);
+						     position);
 }
 
 void
@@ -1243,13 +1239,13 @@ panel_profile_delete_object (AppletInfo *applet_info)
 static void
 panel_profile_load_object (char *id)
 {
-	PanelObjectType  object_type;
-	char            *object_path;
-	char            *toplevel_id;
-	int              position;
-	gboolean         right_stick;
-	gboolean         locked;
-	GSettings       *settings;
+	PanelObjectType            object_type;
+	char                      *object_path;
+	char                      *toplevel_id;
+	int                        position;
+	PanelObjectEdgeRelativity  edge_relativity;
+	gboolean                   locked;
+	GSettings                 *settings;
 
 	object_path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, object_path);
@@ -1257,14 +1253,53 @@ panel_profile_load_object (char *id)
 	object_type = g_settings_get_enum (settings, PANEL_OBJECT_TYPE_KEY);
 	position = g_settings_get_int (settings, PANEL_OBJECT_POSITION_KEY);
 	toplevel_id = g_settings_get_string (settings, PANEL_OBJECT_TOPLEVEL_ID_KEY);
-	right_stick = g_settings_get_boolean (settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY);
+	edge_relativity = g_settings_get_enum (settings, PANEL_OBJECT_RELATIVE_TO_EDGE_KEY);
 	locked = g_settings_get_boolean (settings, PANEL_OBJECT_LOCKED_KEY);
+
+	/* If a panel layout uses the deprecated 'panel-right-stick' property,
+	 * interpret the position of the applet relative to the applet's left
+	 * side, rather than its right like we'd do for end-relative objects.
+	 * The position of an end-relative applet is relative to the *right*
+	 * side of the applet, which makes more sense, IMHO.  The difference
+	 * between these two positioning schemes is on the order of the width
+	 * of the applet; without this backwards-compatible safeguard, many of
+	 * the user's manually-placed right-stuck applets may be moved far out
+	 * of place when they upgrade the panel to this version.
+	 *
+	 * The `panel-right-stick` property will, unfortunately, remain set,
+	 * unless and until the user explicitly moves the applet under the new
+	 * version of the panel.  Keeping the `panel-right-stick` property set
+	 * is necessary since we can't know the equivalent 'edge-relative'
+	 * position to use in the place of the old, 'right-stuck' position;
+	 * after all, we have no idea of the size of the applet when it was
+	 * first positioned on the panel.  (Some applets dynamically change
+	 * size; sure, chances are right-stuck applets will be forced /
+	 * constrained to the very far right side of the panel, but who knows,
+	 * somebody might have set the positions of their applets using a
+	 * layout file or directly via GSettings.)
+	 *
+	 * If the user moves the applets, of course, the applets will be
+	 * repositioned edge-relatively, which is good -- unless the user ever
+	 * downgrades the panel, in which case the applets will be in the wrong
+	 * places.  However, there's a limit to what you can do -- hopefully
+	 * the user will only downgrade the panel if they know what they are
+	 * doing, and the user will have a completely screwed-up panel if they
+	 * *center*-stuck applets and then downgraded.  So the point of this
+	 * hack is to ensure the user experiences a seamless (or nearly
+	 * seamless) transition forward, but if the user moves backward a few
+	 * versions, then we really can't help them.
+	 */
+	if (g_settings_get_boolean (settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY)) {
+		edge_relativity = PANEL_EDGE_END;
+		g_settings_set_enum (settings, PANEL_OBJECT_RELATIVE_TO_EDGE_KEY, edge_relativity);
+	}
+
 
 	mate_panel_applet_queue_applet_to_load (id,
 					   object_type,
 					   toplevel_id,
 					   position,
-					   right_stick,
+					   edge_relativity,
 					   locked);
 
 	g_free (toplevel_id);

--- a/mate-panel/panel-profile.h
+++ b/mate-panel/panel-profile.h
@@ -50,23 +50,21 @@ gboolean    panel_profile_is_writable_show_program_list (void);
 gboolean    panel_profile_get_enable_program_list (void);
 gboolean    panel_profile_get_enable_autocompletion (void);
 
-void           panel_profile_add_to_list            (PanelGSettingsKeyType  type,
-						     const char        *id);
-void           panel_profile_remove_from_list       (PanelGSettingsKeyType  type,
-						     const char        *id);
+void           panel_profile_add_to_list            (PanelGSettingsKeyType      type,
+						     const char                *id);
+void           panel_profile_remove_from_list       (PanelGSettingsKeyType      type,
+						     const char                *id);
 gboolean       panel_profile_id_lists_are_writable  (void);
-void           panel_profile_create_toplevel        (GdkScreen         *screen);
-PanelToplevel *panel_profile_load_toplevel          (const char        *toplevel_id);
-void           panel_profile_delete_toplevel        (PanelToplevel     *toplevel);
-char          *panel_profile_prepare_object         (PanelObjectType    object_type,
-						     PanelToplevel     *toplevel,
-						     int                position,
-						     gboolean           right_stick);
-char          *panel_profile_prepare_object_with_id (PanelObjectType    object_type,
-						     const char        *toplevel_id,
-						     int                position,
-						     gboolean           right_stick);
-void           panel_profile_delete_object          (AppletInfo        *applet_info);
+void           panel_profile_create_toplevel        (GdkScreen                 *screen);
+PanelToplevel *panel_profile_load_toplevel          (const char                *toplevel_id);
+void           panel_profile_delete_toplevel        (PanelToplevel             *toplevel);
+char          *panel_profile_prepare_object         (PanelObjectType            object_type,
+						     PanelToplevel             *toplevel,
+						     int                        position);
+char          *panel_profile_prepare_object_with_id (PanelObjectType            object_type,
+						     const char                *toplevel_id,
+						     int                        position);
+void           panel_profile_delete_object          (AppletInfo                *applet_info);
 
 gboolean    panel_profile_key_is_writable            (PanelToplevel *toplevel,
 						      gchar         *key);

--- a/mate-panel/panel-schemas.h
+++ b/mate-panel/panel-schemas.h
@@ -47,6 +47,7 @@
 #define PANEL_OBJECT_TOPLEVEL_ID_KEY         "toplevel-id"
 #define PANEL_OBJECT_POSITION_KEY            "position"
 #define PANEL_OBJECT_PANEL_RIGHT_STICK_KEY   "panel-right-stick"
+#define PANEL_OBJECT_RELATIVE_TO_EDGE_KEY    "relative-to-edge"
 #define PANEL_OBJECT_LOCKED_KEY              "locked"
 #define PANEL_OBJECT_APPLET_IID_KEY          "applet-iid"
 #define PANEL_OBJECT_ATTACHED_TOPLEVEL_ID_KEY "attached-toplevel-id"

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -263,7 +263,7 @@ panel_separator_create (PanelToplevel *toplevel,
 	char *id;
 
 	id = panel_profile_prepare_object (PANEL_OBJECT_SEPARATOR,
-					   toplevel, position, FALSE);
+					   toplevel, position);
 	panel_profile_add_to_list (PANEL_GSETTINGS_OBJECTS, id);
 	g_free (id);
 }

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -2898,8 +2898,8 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 {
 	GtkWidget *widget;
 
-	GList *list;
-	gboolean stick;
+/*	GList *list;
+	PanelObjectEdgeRelativity edge_relativity;*/
 
 	widget = GTK_WIDGET (toplevel);
 
@@ -2919,30 +2919,6 @@ panel_toplevel_move_resize_window (PanelToplevel *toplevel,
 		gdk_window_resize (gtk_widget_get_window (widget),
 				   toplevel->priv->geometry.width,
 				   toplevel->priv->geometry.height);
-
-	if (resize || move) {
-		for (list = toplevel->priv->panel_widget->applet_list; list != NULL; list = g_list_next (list)) {
-			AppletData *ad = list->data;
-			const char *id = mate_panel_applet_get_id_by_widget (ad->applet);
-
-			if (!id)
-				return;
-
-			AppletInfo *info;
-			info = mate_panel_applet_get_by_id (id);
-
-			stick = g_settings_get_boolean (info->settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY);
-
-			if (stick) {
-				int position = g_settings_get_int (info->settings, PANEL_OBJECT_POSITION_KEY);
-				if (toplevel->priv->orientation & PANEL_HORIZONTAL_MASK) {
-					ad->pos = toplevel->priv->geometry.width - position;
-				} else {
-					ad->pos = toplevel->priv->geometry.height - position;
-				}
-			}
-		}
-	}
 }
 
 static void

--- a/mate-panel/panel-widget.h
+++ b/mate-panel/panel-widget.h
@@ -191,9 +191,9 @@ void		panel_widget_draw_all		(PanelWidget *panel,
 void		panel_widget_draw_icon		(PanelWidget *panel,
 						 ButtonWidget *applet);
 
-/*tells us if an applet is "stuck" on the right side*/
-int		panel_widget_is_applet_stuck	(PanelWidget *panel,
-						 GtkWidget *applet);
+/*Tells us to which panel edge (start, center, end) the applet is relative*/
+PanelObjectEdgeRelativity	panel_widget_determine_applet_edge_relativity	(PanelWidget *panel,
+										 GtkWidget *applet);
 /*get pos of the cursor location in panel coordinates*/
 int		panel_widget_get_cursorloc	(PanelWidget *panel);
 

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -1398,24 +1398,24 @@ panel_screen_from_panel_widget (PanelWidget *panel)
 	return gtk_window_get_screen (GTK_WINDOW (panel->toplevel));
 }
 
-gboolean
-panel_is_applet_right_stick (GtkWidget *applet)
+PanelObjectEdgeRelativity
+panel_determine_applet_edge_relativity (GtkWidget *applet)
 {
 	GtkWidget   *parent;
 	PanelWidget *panel_widget;
 
-	g_return_val_if_fail (GTK_IS_WIDGET (applet), FALSE);
+	g_return_val_if_fail (GTK_IS_WIDGET (applet), PANEL_EDGE_START);
 
 	parent = gtk_widget_get_parent (applet);
 
-	g_return_val_if_fail (PANEL_IS_WIDGET (parent), FALSE);
+	g_return_val_if_fail (PANEL_IS_WIDGET (parent), PANEL_EDGE_START);
 
 	panel_widget = PANEL_WIDGET (parent);
 
 	if (!panel_toplevel_get_expand (panel_widget->toplevel))
-		return FALSE;
+		return PANEL_EDGE_START;
 
-	return panel_widget_is_applet_stuck (panel_widget, applet);
+	return panel_widget_determine_applet_edge_relativity (panel_widget, applet);
 }
 
 static void

--- a/mate-panel/panel.h
+++ b/mate-panel/panel.h
@@ -26,7 +26,7 @@ PanelData *panel_setup (PanelToplevel *toplevel);
 
 GdkScreen *panel_screen_from_panel_widget  (PanelWidget *panel);
 
-gboolean panel_is_applet_right_stick (GtkWidget *applet);
+PanelObjectEdgeRelativity panel_determine_applet_edge_relativity (GtkWidget *applet);
 
 gboolean panel_check_dnd_target_data (GtkWidget      *widget,
 				      GdkDragContext *context,


### PR DESCRIPTION
Conventionally, the applets on a MATE Panel are positioned relative to the
left edge of the panel (if the panel is horizontal) or the top edge (if the
panel is vertical).  There has also been some (buggy) support for positioning
of applets relative to the right (or bottom) edge of the panel, so that
applets on the right side of the panel will stay on the right side even if
the user changes screen resolutions or if the panel changes size for some
other reason.

However, many users want to also place applets at or near the center of their
panel(s).  There is no such conventional support for positioning applets
relative to the center of the panel, so users have positioned applets near
the center of the panel -- but the position recorded is relative to the left
side of the panel.  As such, the applets will almost certainly shift over
to the left or right slightly if the panel is ever resized, and the user will
have to reposition all those centered applets yet again.  This is especially
frustrating if the user switches monitors on a regular basis!

This patch radically revamps the MATE Panel's positioning framework, and
deprecates the original "right-stick" feature.  To replace the right-stick
feature, this patch instead associates an "edge relativity" setting with
each and every panel applet:  An applet can be relative to the start (left/
top), end (right/bottom), or center of the panel.  This setting can be
changed using DConf/GSettings, using a custom panel layout file, or even
by simply dragging the applet to the appropriate place on the panel.
(Conventionally, applets are not even right-stuck automatically even when the
user drags the applet over to the far right of the panel!)  As a bonus, when
the user drags an applet across the center of the panel, the applet will
temporarily "stick" to the very center of the panel, to allow the user to
very precisely align any applet they wish.

Fixes:  #426