### PR TITLE
Fix two leaks

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -368,7 +368,7 @@ calculate_minimum_height (GtkWidget        *widget,
 {
         GtkStateFlags    state;
         GtkStyleContext *style_context;
-        const PangoFontDescription *font_desc;
+        PangoFontDescription *font_desc;
         GtkBorder        padding;
         PangoContext     *pango_context;
         PangoFontMetrics *metrics;
@@ -389,6 +389,7 @@ calculate_minimum_height (GtkWidget        *widget,
         descent = pango_font_metrics_get_descent (metrics);
 
         pango_font_metrics_unref (metrics);
+        pango_font_description_free (font_desc);
 
         gtk_style_context_get_padding (style_context, state, &padding);
 

--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1610,8 +1610,9 @@ mate_panel_applet_change_background(MatePanelApplet *applet,
 	switch (type) {
 		case PANEL_NO_BACKGROUND:
 			if (priv->out_of_process){
-				pattern = cairo_pattern_create_rgba (0,0,0,0);     /* Using NULL here breaks transparent */
-				gdk_window_set_background_pattern(window,pattern); /* backgrounds set by GTK theme */
+				cairo_pattern_t *transparent = cairo_pattern_create_rgba (0, 0, 0, 0);   /* Using NULL here breaks transparent */
+				gdk_window_set_background_pattern (window, transparent);                 /* backgrounds set by GTK theme */
+				cairo_pattern_destroy (transparent);
 			}
 			break;
 		case PANEL_COLOR_BACKGROUND:


### PR DESCRIPTION
Fix a leak in the clock applet (`gtk_style_context_get()` return values are owned by the caller), and in the no-background code path for all applets ([`gdk_window_set_background_pattern()`](https://docs.gtk.org/gdk3/method.Window.set_background_pattern.html) gets its own reference to the given pattern, so we need to release our own).

IMO the commits make more sense split as they are here, so I'd advise a rebase (rather than a squash).