### PR TITLE
windows-list.ui: lower gtk3 required version

### DIFF
--- a/applets/wncklet/window-list.ui
+++ b/applets/wncklet/window-list.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">999</property>
     <property name="step-increment">1</property>


### PR DESCRIPTION
Using gtk+-3.24 prevent starting the windows-list-preferences window in rhel8. See https://bugzilla.redhat.com/show_bug.cgi?id=2149747
Using gtk+-3.22 fixes the issue.
New version is checked with glade