### PR TITLE
applets/wncklet/window-list: Add option to disable middle-click to close in window list

### DIFF
--- a/applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in
+++ b/applets/wncklet/org.mate.panel.applet.window-list.gschema.xml.in
@@ -25,5 +25,10 @@
       <summary>Whether to enable mouse scrolling in the switch window list</summary>
       <description>If true, enable mouse scrolling in window list, otherwise disable mouse scrolling in window list.</description>
     </key>
+    <key name="middle-click-close" type="b">
+      <default>true</default>
+      <summary>Close window on middle mouse click</summary>
+      <description>If true, then clicking the middle mouse button over a taskbar item will close the window.</description>
+    </key>
   </schema>
 </schemalist>

--- a/applets/wncklet/window-list.ui
+++ b/applets/wncklet/window-list.ui
@@ -278,6 +278,64 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkBox" id="middle_click_close_box">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="middle_click_close_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Middle mouse button</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="middle_click_close_vbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">6</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkCheckButton" id="middle_click_close_check">
+                            <property name="label" translatable="yes">_Click to close window</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkBox" id="mouse_scroll_box">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -332,7 +390,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
Add a check button in the preferences context menu to select whether a middle mouse click in the window list should close the window or not.
Addresses issue #962.