### PR TITLE
custom font to render clock applet

### DIFF
--- a/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
+++ b/applets/clock/org.mate.panel.applet.clock.gschema.xml.in
@@ -34,6 +34,16 @@
       <summary>Custom format of the clock</summary>
       <description>This key specifies the format used by the clock applet when the format key is set to "custom". You can use conversion specifiers understood by strftime() to obtain a specific format. See the strftime() manual for more information.</description>
     </key>
+    <key name="use-custom-font" type="b">
+      <default>false</default>
+      <summary>Use custom font of the clock</summary>
+      <description>If true, use custom font.</description>
+    </key>
+    <key name="custom-font" type="s">
+      <default>''</default>
+      <summary>Custom font of the clock</summary>
+      <description>Custom font of the clock. GTK3 CSS font format is preferable.</description>
+    </key>
     <key name="show-seconds" type="b">
       <default>false</default>
       <summary>Show time with seconds</summary>


### PR DESCRIPTION
use custom font to render clock applet.
configuration is available via gsettings/dconf-editor

example how it looks with vertical panel (panel width: 44, font:8 "DejaVu Sans", format: '24-hour'):
![image](https://user-images.githubusercontent.com/93562/219978589-c64540aa-2b70-42bb-b715-aab138739e66.png)

can be helpful for https://github.com/mate-desktop/mate-panel/issues/1090 and https://github.com/mate-desktop/mate-panel/issues/157
