### PR TITLE
Wayland, Tray applet: allow in-process applet to load, using SNI only

### DIFF
--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -494,11 +494,6 @@ applet_factory (MatePanelApplet *applet,
         strcmp (iid, "SystemTrayApplet") == 0))
     return FALSE;
 
-  if (!GDK_IS_X11_DISPLAY (gtk_widget_get_display (GTK_WIDGET (applet)))) {
-    g_warning ("Notification area only works on X");
-    return FALSE;
-  }
-
 #ifndef NOTIFICATION_AREA_INPROCESS
   gtk_window_set_default_icon_name (NOTIFICATION_AREA_ICON);
 #endif

--- a/applets/notification_area/na-grid.c
+++ b/applets/notification_area/na-grid.c
@@ -316,22 +316,26 @@ na_grid_realize (GtkWidget *widget)
 {
   NaGrid *self = NA_GRID (widget);
   GdkScreen *screen;
+  GdkDisplay *display;
   GtkOrientation orientation;
   NaHost *tray_host;
   GSettings *settings;
 
   GTK_WIDGET_CLASS (na_grid_parent_class)->realize (widget);
 
+  display = gdk_display_get_default ();
   /* Instantiate the hosts now we have a screen */
   screen = gtk_widget_get_screen (GTK_WIDGET (self));
-  orientation = gtk_orientable_get_orientation (GTK_ORIENTABLE (self));
-  tray_host = na_tray_new_for_screen (screen, orientation);
-  g_object_bind_property (self, "orientation",
+  if  (GDK_IS_X11_DISPLAY (display))
+  {
+    orientation = gtk_orientable_get_orientation (GTK_ORIENTABLE (self));
+    tray_host = na_tray_new_for_screen (screen, orientation);
+    g_object_bind_property (self, "orientation",
                           tray_host, "orientation",
                           G_BINDING_DEFAULT);
 
-  add_host (self, tray_host);
-
+    add_host (self, tray_host);
+  }
   settings = g_settings_new ("org.mate.panel");
   if (g_settings_get_boolean (settings, "enable-sni-support"))
     add_host (self, sn_host_v0_new ());

--- a/applets/notification_area/org.mate.panel.NotificationAreaApplet.mate-panel-applet.desktop.in.in
+++ b/applets/notification_area/org.mate.panel.NotificationAreaApplet.mate-panel-applet.desktop.in.in
@@ -11,7 +11,7 @@ Description=Area where notification icons appear
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=mate-panel-notification-area
 MateComponentId=OAFIID:MATE_NotificationAreaApplet;OAFIID:MATE_SystemTrayApplet;
-Platforms=X11;
+Platforms=X11;Wayland;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-panel
 X-MATE-Bugzilla-Component=notification area

--- a/applets/notification_area/status-notifier/sn-dbus-menu-item.c
+++ b/applets/notification_area/status-notifier/sn-dbus-menu-item.c
@@ -204,6 +204,7 @@ sn_dbus_menu_item_new (GVariant *props)
             }
 
           item->item = gtk_image_menu_item_new ();
+          gtk_image_menu_item_set_always_show_image (GTK_IMAGE_MENU_ITEM (item->item), TRUE);
           gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (item->item),
                                          image);
         }

--- a/applets/notification_area/status-notifier/sn-item.c
+++ b/applets/notification_area/status-notifier/sn-item.c
@@ -358,6 +358,7 @@ sn_item_ready (SnItem *item)
   priv = SN_ITEM (item)->priv;
   priv->menu = sn_dbus_menu_new (priv->bus_name, menu);
   g_object_ref_sink (priv->menu);
+  gtk_button_set_always_show_image (GTK_BUTTON (item),TRUE);
 }
 
 static const gchar *


### PR DESCRIPTION
*We cannot load the legacy system tray in Wayland as that requires xembed. *We CAN load the status-notifier (SNI support)
*Wayland needs us to explicitly set gtk_button_set_always_show_image to TRUE 
*Wayland needs us to explicitly set gtk_image_menu_item_set_always_show_image to TRUE