### PR TITLE
Fix distribution of applet service files

### DIFF
--- a/applets/clock/Makefile.am
+++ b/applets/clock/Makefile.am
@@ -138,9 +138,9 @@ $(applet_in_files): $(applet_in_files).in Makefile
 $(applet_DATA): $(applet_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+service_in_files = org.mate.panel.applet.ClockAppletFactory.service.in
 if !CLOCK_INPROCESS
 servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.ClockAppletFactory.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 
 org.mate.panel.applet.ClockAppletFactory.service: $(service_in_files)

--- a/applets/fish/Makefile.am
+++ b/applets/fish/Makefile.am
@@ -53,9 +53,9 @@ $(applet_in_files): $(applet_in_files).in Makefile
 $(applet_DATA): $(applet_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+service_in_files = org.mate.panel.applet.FishAppletFactory.service.in
 if !FISH_INPROCESS
 servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.FishAppletFactory.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 
 org.mate.panel.applet.FishAppletFactory.service: $(service_in_files)

--- a/applets/notification_area/Makefile.am
+++ b/applets/notification_area/Makefile.am
@@ -83,9 +83,9 @@ $(applet_in_files): $(applet_in_files).in Makefile
 		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
 		$< > $@
 
+service_in_files = org.mate.panel.applet.NotificationAreaAppletFactory.service.in
 if !NOTIFICATION_AREA_INPROCESS
 servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.NotificationAreaAppletFactory.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 
 org.mate.panel.applet.NotificationAreaAppletFactory.service: $(service_in_files)

--- a/applets/wncklet/Makefile.am
+++ b/applets/wncklet/Makefile.am
@@ -78,9 +78,9 @@ $(applet_in_files): $(applet_in_files).in Makefile
 $(applet_DATA): $(applet_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+service_in_files = org.mate.panel.applet.WnckletFactory.service.in
 if !WNCKLET_INPROCESS
 servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.WnckletFactory.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 
 org.mate.panel.applet.WnckletFactory.service: $(service_in_files)


### PR DESCRIPTION
Fix distribution of the applet service files sources when building from an in-process-configured build.  This fixes `make distcheck` and tarballs in builds configured with `--with-in-process-applets=all` (or actually any in-process applet).

The issue was that the .service.in file was referenced indirectly in EXTRA_DIST, and the variable listed there was only filled in a conditional.  Automake is not able to resolve this and see it still should distribute the reference of that variable, even if set conditionally.  Fix this by always setting the variable properly, even if it's only used for out-of-process builds.