### PR TITLE
libmate-panel-applet: don't use panel plug to find the screen

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -618,7 +618,7 @@ mate_panel_applet_request_focus (MatePanelApplet	 *applet,
 	g_return_if_fail (MATE_PANEL_IS_APPLET (applet));
 
 	priv    = mate_panel_applet_get_instance_private (applet);
-	screen  = gtk_window_get_screen (GTK_WINDOW (priv->plug));
+	screen  = gdk_screen_get_default(); /*There is only one screen since GTK 3.22*/
 	root	= gdk_screen_get_root_window (screen);
 	display = gdk_screen_get_display (screen);
 


### PR DESCRIPTION
* There is only one screen in GTK 3.22 or later
* Finding the screen from that used by GtkPanelPlug is out of process only
* Any in-process applet calling mate_panel_applet_request_focus needs this to avoid a segfault
* One known user: dictionary applet