### PR TITLE
Wayland: Fix force-quit unsupported message dialog

### DIFF
--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -471,7 +471,7 @@ panel_action_force_quit (GtkWidget *widget)
 	}
 #endif
 	flags = GTK_DIALOG_DESTROY_WITH_PARENT;
-	dialog = gtk_message_dialog_new (GTK_WINDOW (widget),
+	dialog = gtk_message_dialog_new (NULL,
 					 flags,
 					 GTK_MESSAGE_ERROR,
 					 GTK_BUTTONS_CLOSE,


### PR DESCRIPTION
*For some reason "widget" is not being properly passed to this, so use NULL for the parent window
*This makes the "force-quit only available in x11" dialog work