### PR TITLE
Force-quit/x11: Fix misalignment of popup with multimonitors

### DIFF
--- a/mate-panel/panel-force-quit.c
+++ b/mate-panel/panel-force-quit.c
@@ -58,8 +58,12 @@ display_popup_window (GdkScreen *screen)
 	GtkWidget     *image;
 	GtkWidget     *frame;
 	GtkWidget     *label;
-	int            screen_width, screen_height, scale;
+	int            monitor_width, monitor_height;
 	GtkAllocation  allocation;
+	GdkWindow      *window;
+	GdkDisplay     *display;
+	GdkMonitor     *monitor;
+	GdkRectangle    geometry;
 
 	retval = gtk_window_new (GTK_WINDOW_POPUP);
 	atk_object_set_role (gtk_widget_get_accessible (retval), ATK_ROLE_ALERT);
@@ -93,15 +97,18 @@ display_popup_window (GdkScreen *screen)
 
 	gtk_widget_realize (retval);
 
-	scale = gtk_widget_get_scale_factor (retval);
-	screen_width  = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
-	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
+	display = gdk_display_get_default();
+	window = gtk_widget_get_window (retval);
+	monitor = gdk_display_get_monitor_at_window (display, window);
+	gdk_monitor_get_geometry (monitor, &geometry);
+	monitor_width  = geometry.width;
+	monitor_height = geometry.height;
 
 	gtk_widget_get_allocation (retval, &allocation);
 
 	gtk_window_move (GTK_WINDOW (retval),
-			 (screen_width  - (allocation.width * scale)) / (2 * scale),
-			 (screen_height - (allocation.height * scale)) / (2 * scale));
+			 monitor_width / 2 - (allocation.width / 2 ),
+			 monitor_height / 2 -  (allocation.height / 2));
 
 	gtk_widget_show (GTK_WIDGET (retval));
 


### PR DESCRIPTION
*Compute the size of the monitor we are actually showing the popup on *by getting the monitor it is shown on and running gdk_monitor_get_geometry()

*This returns application (scaled) pixels not device pixels and apparently so does gtk_widget_get_allocation()
*Thus we no longer have to compute the scale ourselves and the popup window centers on the panel's monitor
*Previously we got the rectangle covering ALL monitors and centered on that