### PR TITLE
Main menus: fix missing Places, System icons

### DIFF
--- a/mate-panel/panel-menu-items.c
+++ b/mate-panel/panel-menu-items.c
@@ -88,8 +88,8 @@ struct _PanelDesktopMenuItemPrivate {
 	guint        append_lock_logout : 1;
 };
 
-G_DEFINE_TYPE_WITH_PRIVATE (PanelPlaceMenuItem, panel_place_menu_item, GTK_TYPE_IMAGE_MENU_ITEM)
-G_DEFINE_TYPE_WITH_PRIVATE (PanelDesktopMenuItem, panel_desktop_menu_item, GTK_TYPE_IMAGE_MENU_ITEM)
+G_DEFINE_TYPE_WITH_PRIVATE (PanelPlaceMenuItem, panel_place_menu_item, MATE_TYPE_IMAGE_MENU_ITEM)
+G_DEFINE_TYPE_WITH_PRIVATE (PanelDesktopMenuItem, panel_desktop_menu_item, MATE_TYPE_IMAGE_MENU_ITEM)
 
 static void activate_uri_on_screen(const char* uri, GdkScreen* screen)
 {


### PR DESCRIPTION
After replacing gtk_image_menu_item with mate_image_menu_item 
We must also replace 
GTK_TYPE_IMAGE_MENU_ITEM
with
MATE_TYPE_IMAGE_MENU_ITEM

This fixes leftover GtkImageMenuItem deprecation warnings and restores missing Places and System icons in main menus