### PR TITLE
status-notifier: Show AttentionIcon when Status is NeedsAttention 

### DIFF
--- a/applets/notification_area/status-notifier/sn-dbus-menu-item.c
+++ b/applets/notification_area/status-notifier/sn-dbus-menu-item.c
@@ -253,7 +253,7 @@ sn_dbus_menu_item_new (GVariant *props)
 }
 
 void
-sn_dubs_menu_item_free (gpointer data)
+sn_dbus_menu_item_free (gpointer data)
 {
   SnDBusMenuItem *item;
 

--- a/applets/notification_area/status-notifier/sn-dbus-menu-item.c
+++ b/applets/notification_area/status-notifier/sn-dbus-menu-item.c
@@ -21,7 +21,7 @@
 #include "sn-dbus-menu-item.h"
 
 static GdkPixbuf *
-pxibuf_new (GVariant *variant)
+pixbuf_new (GVariant *variant)
 {
   gsize length;
   const guchar *data;
@@ -150,7 +150,7 @@ sn_dbus_menu_item_new (GVariant *props)
       else if (g_strcmp0 (prop, "icon-name") == 0)
         item->icon_name = g_variant_dup_string (value, NULL);
       else if (g_strcmp0 (prop, "icon-data") == 0)
-        item->icon_data = pxibuf_new (value);
+        item->icon_data = pixbuf_new (value);
       else if (g_strcmp0 (prop, "label") == 0)
         item->label = g_variant_dup_string (value, NULL);
       else if (g_strcmp0 (prop, "shortcut") == 0)
@@ -334,7 +334,7 @@ sn_dbus_menu_item_update_props (SnDBusMenuItem *item,
           GtkWidget *image;
 
           g_clear_object (&item->icon_data);
-          item->icon_data = pxibuf_new (value);
+          item->icon_data = pixbuf_new (value);
 
           if (item->icon_data)
             {

--- a/applets/notification_area/status-notifier/sn-dbus-menu-item.h
+++ b/applets/notification_area/status-notifier/sn-dbus-menu-item.h
@@ -51,7 +51,7 @@ typedef struct
 
 SnDBusMenuItem *sn_dbus_menu_item_new          (GVariant       *props);
 
-void            sn_dubs_menu_item_free         (gpointer        data);
+void            sn_dbus_menu_item_free         (gpointer        data);
 
 void            sn_dbus_menu_item_update_props (SnDBusMenuItem *item,
                                                 GVariant       *props);

--- a/applets/notification_area/status-notifier/sn-dbus-menu.c
+++ b/applets/notification_area/status-notifier/sn-dbus-menu.c
@@ -485,7 +485,7 @@ sn_dbus_menu_class_init (SnDBusMenuClass *menu_class)
 static void
 sn_dbus_menu_init (SnDBusMenu *menu)
 {
-  menu->items = g_hash_table_new_full (NULL, NULL, NULL, sn_dubs_menu_item_free);
+  menu->items = g_hash_table_new_full (NULL, NULL, NULL, sn_dbus_menu_item_free);
   menu->cancellable = g_cancellable_new ();
 }
 


### PR DESCRIPTION
Fixes #1412.

This PR also includes 2 unrelated typo fixes extracted from gnome-panel.  I can move remove them from this PR if wanted, as they are unrelated (and not necessary for anything but not having typos in the code).