### PR TITLE
wnck-pager: update workspace switcher aspect ratio

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1132,15 +1132,21 @@ mate_panel_applet_get_preferred_height (GtkWidget *widget,
 static GtkSizeRequestMode
 mate_panel_applet_get_request_mode (GtkWidget *widget)
 {
-	/* Do not use GTK_SIZE_REQUEST_HEIGHT_FOR_WIDTH
-	 * or GTK_SIZE_REQUEST_WIDTH_FOR_HEIGHT
-	 * to avoid problems with in-process applets
-	 * when the panel is not expanded
-	 * See https://github.com/mate-desktop/mate-panel/issues/797
-	 * and https://github.com/mate-desktop/mate-panel/issues/799
-	 * Out of process applets already use GTK_SIZE_REQUEST_CONSTANT_SIZE
-	 */
-	return GTK_SIZE_REQUEST_CONSTANT_SIZE;
+	MatePanelApplet *applet = MATE_PANEL_APPLET (widget);
+	MatePanelAppletPrivate *priv;
+	MatePanelAppletOrient orientation;
+
+	priv = mate_panel_applet_get_instance_private (applet);
+
+	if (priv->out_of_process)
+		return GTK_SIZE_REQUEST_CONSTANT_SIZE;
+
+	orientation = mate_panel_applet_get_orient (applet);
+	if (orientation == MATE_PANEL_APPLET_ORIENT_UP ||
+	    orientation == MATE_PANEL_APPLET_ORIENT_DOWN)
+		return GTK_SIZE_REQUEST_HEIGHT_FOR_WIDTH;
+
+	return GTK_SIZE_REQUEST_WIDTH_FOR_HEIGHT;
 }
 
 static void

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1402,6 +1402,45 @@ queue_resize_on_all_applets(PanelWidget *panel)
 }
 
 static void
+get_preferred_size (PanelWidget    *self,
+                    AppletData     *ad,
+                    GtkRequisition *minimum_size)
+{
+	if (self->orient == GTK_ORIENTATION_HORIZONTAL)
+	{
+		if (ad->expand_minor)
+			minimum_size->height = self->sz;
+		else
+			gtk_widget_get_preferred_height (ad->applet,
+							 &minimum_size->height,
+							 NULL);
+
+		gtk_widget_get_preferred_width_for_height (ad->applet,
+							   minimum_size->height,
+							   &minimum_size->width,
+							   NULL);
+	}
+	else if (self->orient == GTK_ORIENTATION_VERTICAL)
+	{
+		if (ad->expand_minor)
+			minimum_size->width = self->sz;
+		else
+			gtk_widget_get_preferred_width (ad->applet,
+							&minimum_size->width,
+							NULL);
+
+		gtk_widget_get_preferred_height_for_width (ad->applet,
+							   minimum_size->width,
+							   &minimum_size->height,
+							   NULL);
+	}
+	else
+	{
+		g_assert_not_reached ();
+	}
+}
+
+static void
 panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 {
 	PanelWidget *panel;
@@ -1441,15 +1480,13 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 			AppletData *ad = list->data;
 			GtkAllocation challoc;
 			GtkRequisition chreq;
-			gtk_widget_get_preferred_size (ad->applet, &chreq, NULL);
+			get_preferred_size (panel, ad, &chreq);
 
 			ad->constrained = i;
 
 			challoc.width = chreq.width;
 			challoc.height = chreq.height;
 			if(panel->orient == GTK_ORIENTATION_HORIZONTAL) {
-				if (ad->expand_minor)
-					challoc.height = allocation->height;
 
 				if (ad->expand_major && ad->size_hints) {
 					int width = panel->applets_using_hint[applet_using_hint_index].size;
@@ -1461,8 +1498,6 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 				challoc.x = ltr ? ad->constrained : panel->size - ad->constrained - challoc.width;
 				challoc.y = allocation->height / 2 - challoc.height / 2;
 			} else {
-				if (ad->expand_minor)
-					challoc.width = allocation->width;
 
 				if (ad->expand_major && ad->size_hints) {
 					int height = panel->applets_using_hint[applet_using_hint_index].size;
@@ -1509,7 +1544,7 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 			PanelObjectEdgeRelativity edge_relativity = PANEL_EDGE_START;
 			gboolean right_stuck = FALSE;
 
-			gtk_widget_get_preferred_size (ad->applet, &chreq, NULL);
+			get_preferred_size (panel, ad, &chreq);
 
 			if (!ad->expand_major || !ad->size_hints) {
 				if(panel->orient == GTK_ORIENTATION_HORIZONTAL)
@@ -1674,7 +1709,7 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 				const char *id;
 				AppletInfo *info;
 				PanelObjectEdgeRelativity edge_relativity = PANEL_EDGE_START;
-				gboolean right_stuck;
+				gboolean right_stuck = FALSE;
 				AppletData *pad;
 				int prior_space;
 				int following_space;
@@ -1762,22 +1797,16 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 			AppletData *ad = list->data;
 			GtkAllocation challoc;
 			GtkRequisition chreq;
-			gtk_widget_get_preferred_size (ad->applet, &chreq, NULL);
+			get_preferred_size (panel, ad, &chreq);
 
 			challoc.width = chreq.width;
 			challoc.height = chreq.height;
 			if(panel->orient == GTK_ORIENTATION_HORIZONTAL) {
 				challoc.width = ad->cells;
-				if (ad->expand_minor) {
-					challoc.height = allocation->height;
-				}
 				challoc.x = ltr ? ad->constrained : panel->size - ad->constrained - challoc.width;
 				challoc.y = allocation->height / 2 - challoc.height / 2;
 			} else {
 				challoc.height = ad->cells;
-				if (ad->expand_minor) {
-					challoc.width = allocation->width;
-				}
 				challoc.x = allocation->width / 2 - challoc.width / 2;
 				challoc.y = ad->constrained;
 			}


### PR DESCRIPTION
This fixes https://github.com/mate-desktop/mate-panel/issues/1230 
and is needed because of an update in libwnck
https://gitlab.gnome.org/GNOME/libwnck/-/commit/3456b747b6381f17d48629dd8fdd4d511e739b10

In fedora i could workaround this issue with reverting the libwnck commit.
But it seems that xfce users had problems with the xfce-panel because of reverted libwnck commit. See https://gitlab.xfce.org/xfce/xfce4-panel/-/issues/630#note_80841 and https://bugzilla.redhat.com/show_bug.cgi?id=2242944
I offered a test RPM without the mentioned patch to confirm the xfce issue.
But we should really try to fix the issue with wnck-pager from our side after 2 years. It is urgent!

As a downside this PR overwrites  https://github.com/mate-desktop/mate-panel/pull/806 which fixed 2 issues.
I can't reproduce https://github.com/mate-desktop/mate-panel/issues/799 with PR anymore, but unfortunately https://github.com/mate-desktop/mate-panel/issues/797 still exists with PR.

@mate-desktop/core-team 
Please help to fix https://github.com/mate-desktop/mate-panel/issues/797 on top of this PR
If we find no solution the only option is to use PR plus disable applet in-process build for fedora and all other distributions which use libwnck >= 40.
