### PR TITLE
wnck-pager: update workspace switcher aspect ratio 1.26

### DIFF
--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -1146,15 +1146,21 @@ mate_panel_applet_get_preferred_height (GtkWidget *widget,
 static GtkSizeRequestMode
 mate_panel_applet_get_request_mode (GtkWidget *widget)
 {
-	/* Do not use GTK_SIZE_REQUEST_HEIGHT_FOR_WIDTH
-	 * or GTK_SIZE_REQUEST_WIDTH_FOR_HEIGHT
-	 * to avoid problems with in-process applets
-	 * when the panel is not expanded
-	 * See https://github.com/mate-desktop/mate-panel/issues/797
-	 * and https://github.com/mate-desktop/mate-panel/issues/799
-	 * Out of process applets already use GTK_SIZE_REQUEST_CONSTANT_SIZE
-	 */
-	return GTK_SIZE_REQUEST_CONSTANT_SIZE;
+	MatePanelApplet *applet = MATE_PANEL_APPLET (widget);
+	MatePanelAppletPrivate *priv;
+	MatePanelAppletOrient orientation;
+
+	priv = mate_panel_applet_get_instance_private (applet);
+
+	if (priv->out_of_process)
+		return GTK_SIZE_REQUEST_CONSTANT_SIZE;
+
+	orientation = mate_panel_applet_get_orient (applet);
+	if (orientation == MATE_PANEL_APPLET_ORIENT_UP ||
+	    orientation == MATE_PANEL_APPLET_ORIENT_DOWN)
+		return GTK_SIZE_REQUEST_HEIGHT_FOR_WIDTH;
+
+	return GTK_SIZE_REQUEST_WIDTH_FOR_HEIGHT;
 }
 
 static void

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1362,6 +1362,45 @@ queue_resize_on_all_applets(PanelWidget *panel)
 }
 
 static void
+get_preferred_size (PanelWidget    *self,
+                    AppletData     *ad,
+                    GtkRequisition *minimum_size)
+{
+	if (self->orient == GTK_ORIENTATION_HORIZONTAL)
+	{
+		if (ad->expand_minor)
+			minimum_size->height = self->sz;
+		else
+			gtk_widget_get_preferred_height (ad->applet,
+							 &minimum_size->height,
+							 NULL);
+
+		gtk_widget_get_preferred_width_for_height (ad->applet,
+							   minimum_size->height,
+							   &minimum_size->width,
+							   NULL);
+	}
+	else if (self->orient == GTK_ORIENTATION_VERTICAL)
+	{
+		if (ad->expand_minor)
+			minimum_size->width = self->sz;
+		else
+			gtk_widget_get_preferred_width (ad->applet,
+							&minimum_size->width,
+							NULL);
+
+		gtk_widget_get_preferred_height_for_width (ad->applet,
+							   minimum_size->width,
+							   &minimum_size->height,
+							   NULL);
+	}
+	else
+	{
+		g_assert_not_reached ();
+	}
+}
+
+static void
 panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 {
 	PanelWidget *panel;
@@ -1405,15 +1444,13 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 			AppletData *ad = list->data;
 			GtkAllocation challoc;
 			GtkRequisition chreq;
-			gtk_widget_get_preferred_size (ad->applet, &chreq, NULL);
+			get_preferred_size (panel, ad, &chreq);
 
 			ad->constrained = i;
 
 			challoc.width = chreq.width;
 			challoc.height = chreq.height;
 			if(panel->orient == GTK_ORIENTATION_HORIZONTAL) {
-				if (ad->expand_minor)
-					challoc.height = allocation->height;
 
 				if (ad->expand_major && ad->size_hints) {
 					int width = panel->applets_using_hint[applet_using_hint_index].size;
@@ -1425,8 +1462,6 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 				challoc.x = ltr ? ad->constrained : panel->size - ad->constrained - challoc.width;
 				challoc.y = allocation->height / 2 - challoc.height / 2;
 			} else {
-				if (ad->expand_minor)
-					challoc.width = allocation->width;
 
 				if (ad->expand_major && ad->size_hints) {
 					int height = panel->applets_using_hint[applet_using_hint_index].size;
@@ -1456,7 +1491,7 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 			AppletData *ad = list->data;
 			GtkRequisition chreq;
 
-			gtk_widget_get_preferred_size (ad->applet, &chreq, NULL);
+			get_preferred_size (panel, ad, &chreq);
 
 			if (!ad->expand_major || !ad->size_hints) {
 				if(panel->orient == GTK_ORIENTATION_HORIZONTAL)
@@ -1525,22 +1560,16 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 			AppletData *ad = list->data;
 			GtkAllocation challoc;
 			GtkRequisition chreq;
-			gtk_widget_get_preferred_size (ad->applet, &chreq, NULL);
+			get_preferred_size (panel, ad, &chreq);
 
 			challoc.width = chreq.width;
 			challoc.height = chreq.height;
 			if(panel->orient == GTK_ORIENTATION_HORIZONTAL) {
 				challoc.width = ad->cells;
-				if (ad->expand_minor) {
-					challoc.height = allocation->height;
-				}
 				challoc.x = ltr ? ad->constrained : panel->size - ad->constrained - challoc.width;
 				challoc.y = allocation->height / 2 - challoc.height / 2;
 			} else {
 				challoc.height = ad->cells;
-				if (ad->expand_minor) {
-					challoc.width = allocation->width;
-				}
 				challoc.x = allocation->width / 2 - challoc.width / 2;
 				challoc.y = ad->constrained;
 			}


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-panel/issues/1230 This is needed because of an update in libwnck
https://gitlab.gnome.org/GNOME/libwnck/-/commit/3456b747b6381f17d48629dd8fdd4d511e739b10

With that commit applets should be build out-of-process to avoid issues with windows-list and tray applets.
See https://github.com/mate-desktop/mate-panel/pull/1417 for more infos.

@cwendling @lukefromdc 
Please do a review because commit is a bit different to 1.27 version.
Not sure if we really should merge it into stable branch now until the issues with windows-list and tray applets  aren't fix, when applets are build in-process.
But i need this for fedora and i can use it without merging.