### PR TITLE
wnck-pager: Fix workspace switcher aspect ratio

### DIFF
--- a/applets/wncklet/Makefile.am
+++ b/applets/wncklet/Makefile.am
@@ -23,6 +23,8 @@ WNCKLET_SOURCES = \
 	workspace-switcher.h \
 	showdesktop.c \
 	showdesktop.h \
+	pager-container.c \
+	pager-container.h \
 	$(BUILT_SOURCES)
 
 WNCKLET_LDADD =						\

--- a/applets/wncklet/pager-container.c
+++ b/applets/wncklet/pager-container.c
@@ -1,0 +1,156 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*- */
+/*
+ * Copyright (C) 2022 Alberts Muktupāvels
+ * Copyright (C) 2023 Colomban Wendling
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* See:
+ * https://github.com/mate-desktop/mate-panel/issues/1230#issuecomment-1046235088
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "pager-container.h"
+#include <gtk/gtk.h>
+
+
+G_DEFINE_TYPE (PagerContainer, pager_container, GTK_TYPE_BIN)
+
+static gboolean
+queue_resize_idle_cb (gpointer user_data)
+{
+	gtk_widget_queue_resize (GTK_WIDGET (user_data));
+	return G_SOURCE_REMOVE;
+}
+
+static void
+pager_container_get_preferred_width (GtkWidget *widget,
+                                     int       *minimum_width,
+                                     int       *natural_width)
+{
+	PagerContainer *self;
+
+	self = PAGER_CONTAINER (widget);
+
+	if (self->orientation == GTK_ORIENTATION_VERTICAL)
+	{
+		/* self->size is panel width */
+		*minimum_width = *natural_width = self->size;
+	}
+	else
+	{
+		/* self->size is panel size/height, that will get allocated to pager, request width for this size */
+		gtk_widget_get_preferred_width_for_height (gtk_bin_get_child (GTK_BIN (self)),
+		                                           self->size,
+		                                           minimum_width,
+		                                           natural_width);
+	}
+}
+
+static void
+pager_container_get_preferred_height (GtkWidget *widget,
+                                      int       *minimum_height,
+                                      int       *natural_height)
+{
+	PagerContainer *self;
+
+	self = PAGER_CONTAINER (widget);
+
+	if (self->orientation == GTK_ORIENTATION_VERTICAL)
+	{
+		/* self->size is panel size/width that will get allocated to pager, request height for this size */
+		gtk_widget_get_preferred_height_for_width (gtk_bin_get_child (GTK_BIN (self)),
+		                                           self->size,
+		                                           minimum_height,
+		                                           natural_height);
+	}
+	else
+	{
+		/* self->size is panel height */
+		*minimum_height = *natural_height = self->size;
+	}
+}
+
+static void
+pager_container_size_allocate (GtkWidget     *widget,
+                               GtkAllocation *allocation)
+{
+	PagerContainer *self;
+	int size;
+
+	self = PAGER_CONTAINER (widget);
+
+	if (self->orientation == GTK_ORIENTATION_VERTICAL)
+		size = allocation->width;
+	else
+		size = allocation->height;
+
+	size = MAX (size, 1);
+
+	if (self->size != size)
+	{
+		self->size = size;
+		g_idle_add (queue_resize_idle_cb, self);
+		return;
+	}
+
+	GTK_WIDGET_CLASS (pager_container_parent_class)->size_allocate (widget,
+	                                                                allocation);
+}
+
+static void
+pager_container_class_init (PagerContainerClass *self_class)
+{
+	GtkWidgetClass *widget_class;
+
+	widget_class = GTK_WIDGET_CLASS (self_class);
+
+	widget_class->get_preferred_width = pager_container_get_preferred_width;
+	widget_class->get_preferred_height = pager_container_get_preferred_height;
+	widget_class->size_allocate = pager_container_size_allocate;
+}
+
+static void
+pager_container_init (PagerContainer *self)
+{
+}
+
+GtkWidget *
+pager_container_new (GtkWidget     *child,
+                     GtkOrientation orientation)
+{
+	PagerContainer *self;
+
+	self = g_object_new (PAGER_CONTAINER_TYPE, "child", child, NULL);
+
+	self->orientation = orientation;
+
+	return GTK_WIDGET (self);
+}
+
+void
+pager_container_set_orientation (PagerContainer *self,
+                                 GtkOrientation  orientation)
+{
+	if (self->orientation == orientation)
+		return;
+
+	self->orientation = orientation;
+
+	gtk_widget_queue_resize (GTK_WIDGET (self));
+}

--- a/applets/wncklet/pager-container.h
+++ b/applets/wncklet/pager-container.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Alberts Muktupāvels
+ * Copyright (C) 2023 Colomban Wendling
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef H_PAGER_CONTAINER
+#define H_PAGER_CONTAINER
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+#define PAGER_CONTAINER_TYPE (pager_container_get_type ())
+#define PAGER_CONTAINER(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), PAGER_CONTAINER_TYPE, PagerContainer))
+
+typedef struct _PagerContainer PagerContainer;
+typedef GtkBinClass PagerContainerClass;
+
+struct _PagerContainer
+{
+	GtkBin          parent;
+	GtkOrientation  orientation;
+	int             size;
+};
+
+GType       pager_container_get_type        (void);
+GtkWidget  *pager_container_new             (GtkWidget     *child,
+                                             GtkOrientation orientation);
+void        pager_container_set_orientation (PagerContainer *self,
+                                             GtkOrientation orientation);
+
+G_END_DECLS
+
+#endif /* guard */

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -36,6 +36,7 @@
 #include <libmate-desktop/mate-gsettings.h>
 
 #include "workspace-switcher.h"
+#include "pager-container.h"
 
 #include "wncklet.h"
 
@@ -65,6 +66,7 @@ typedef enum {
 typedef struct {
 	GtkWidget* applet;
 
+	GtkWidget* pager_container;
 	GtkWidget* pager;
 
 	WnckScreen* screen;
@@ -289,6 +291,8 @@ static void applet_change_orient(MatePanelApplet* applet, MatePanelAppletOrient 
 
 	pager->orientation = new_orient;
 	pager_update(pager);
+
+	pager_container_set_orientation(PAGER_CONTAINER(pager->pager_container), pager->orientation);
 
 	if (pager->label_row_col)
 		gtk_label_set_text(GTK_LABEL(pager->label_row_col), pager->orientation == GTK_ORIENTATION_HORIZONTAL ? _("rows") : _("columns"));
@@ -659,7 +663,8 @@ gboolean workspace_switcher_applet_fill(MatePanelApplet* applet)
 	                  G_CALLBACK (applet_scroll),
 	                  pager);
 
-	gtk_container_add(GTK_CONTAINER(pager->applet), pager->pager);
+	pager->pager_container = pager_container_new(pager->pager, pager->orientation);
+	gtk_container_add(GTK_CONTAINER(pager->applet), pager->pager_container);
 
 	g_signal_connect (pager->applet, "realize",
 	                  G_CALLBACK (applet_realized),
@@ -678,6 +683,7 @@ gboolean workspace_switcher_applet_fill(MatePanelApplet* applet)
 	                  context);
 
 	gtk_widget_show (pager->pager);
+	gtk_widget_show (pager->pager_container);
 	gtk_widget_show (pager->applet);
 
 	action_group = gtk_action_group_new("WorkspaceSwitcher Applet Actions");


### PR DESCRIPTION
This is a dirty hack, but it works both in-process and out-of-process, and doesn't break window list on non-expanded panels.

A better solution would be to actually fix the panel's layout code, but nobody seems to have enough time and experience with this to actually do this at the moment.

Based off an idea and code from Alberts Muktupāvels[^1], thanks.

Fixes #1230.

[^1]: https://github.com/mate-desktop/mate-panel/issues/1230#issuecomment-1046235088