### PR TITLE
run-dialog: Don't needlessly override DISPLAY environment variable

### DIFF
--- a/mate-panel/panel-run-dialog.c
+++ b/mate-panel/panel-run-dialog.c
@@ -407,15 +407,6 @@ command_is_executable (const char   *command,
 	return TRUE;
 }
 
-/*
- * Set the DISPLAY variable, to be use by g_spawn_async.
- */
-static void
-set_environment (gpointer display)
-{
-  g_setenv ("DISPLAY", display, TRUE);
-}
-
 static void
 dummy_child_watch (GPid         pid,
 		   		   gint         status,
@@ -432,32 +423,24 @@ panel_run_dialog_launch_command (PanelRunDialog *dialog,
 				 const char     *command,
 				 const char     *locale_command)
 {
-	GdkDisplay *display;
-	GdkScreen  *screen;
 	gboolean    result;
 	GError     *error = NULL;
 	char      **argv;
 	int         argc;
-	char       *display_name;
 	GPid        pid;
 
 	if (!command_is_executable (locale_command, &argc, &argv))
 		return FALSE;
 
-	screen = gtk_window_get_screen (GTK_WINDOW (dialog->run_dialog));
-
 	if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (dialog->terminal_checkbox)))
 		mate_desktop_prepend_terminal_to_vector (&argc, &argv);
-
-	display = gdk_screen_get_display (screen);
-	display_name = g_strdup (gdk_display_get_name (display));
 
 	result = g_spawn_async (NULL, /* working directory */
 				argv,
 				NULL, /* envp */
 				G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
-				set_environment,
-				display_name,
+				NULL,
+				NULL,
 				&pid,
 				&error);
 
@@ -477,7 +460,6 @@ panel_run_dialog_launch_command (PanelRunDialog *dialog,
 	}
 
 	g_strfreev (argv);
-	g_free (display_name);
 
 	return result;
 }


### PR DESCRIPTION
This code got introduced with 3c21f66bf30810fcb25dfe8c3c0960df270dc416 trying to mimic `gdk_spawn_on_screen()`, but does not: what `gdk_spawn_on_screen()` did (on X11) was to append the screen number to the display, so that it worked on a multi-screen setup where the app is not on the default X screen.

However, the code that got introduced just sets the display, which is gonna be already there anyway (yet possibly loosing the default screen in the process?), and AFAIK GDK dropped support for multi-screen setups anyway (not to be confused with multi-monitor with e.g. Xinerama).

We should actually be better of without any of this, as it most likely doesn't do what it is supposed to, nobody needs what it failed to do, and it breaks XWayland on Wayland.

Fixes #1387.

:warning: I didn't actually test that much, and not at all on Wayland.  But it should help.