### PR TITLE
Fix crashes caused by MateImageMenuItem vs GtkImageMenuItem conflict

### DIFF
--- a/mate-panel/panel-menu-items.c
+++ b/mate-panel/panel-menu-items.c
@@ -88,8 +88,8 @@ struct _PanelDesktopMenuItemPrivate {
 	guint        append_lock_logout : 1;
 };
 
-G_DEFINE_TYPE_WITH_PRIVATE (PanelPlaceMenuItem, panel_place_menu_item, MATE_TYPE_IMAGE_MENU_ITEM)
-G_DEFINE_TYPE_WITH_PRIVATE (PanelDesktopMenuItem, panel_desktop_menu_item, MATE_TYPE_IMAGE_MENU_ITEM)
+G_DEFINE_TYPE_WITH_PRIVATE (PanelPlaceMenuItem, panel_place_menu_item, GTK_TYPE_IMAGE_MENU_ITEM)
+G_DEFINE_TYPE_WITH_PRIVATE (PanelDesktopMenuItem, panel_desktop_menu_item, GTK_TYPE_IMAGE_MENU_ITEM)
 
 static void activate_uri_on_screen(const char* uri, GdkScreen* screen)
 {


### PR DESCRIPTION
- fix crashing panel with --replace option

This reverts commit 675f72ff302409dcbfb1991cf56fd09a294039bf.

First fix for https://github.com/mate-desktop/mate-panel/issues/1433