### PR TITLE
Fix translation: pt_BR (inicie -> iniciar), mate-panel/panel-menu-items.c:1586

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2948,7 +2948,7 @@ msgstr "Encerrar sessão de %s..."
 #: mate-panel/panel-menu-items.c:1586
 #, c-format
 msgid "Log out %s of this session to log in as a different user"
-msgstr "Encerra a sessão de %s para que outro usuário possa inicie sua sessão"
+msgstr "Encerra a sessão de %s para que outro usuário possa iniciar sua sessão"
 
 #: mate-panel/panel-properties-dialog.c:120 mate-panel/panel-test-applets.c:59
 msgctxt "Orientation"


### PR DESCRIPTION
`inicie` is incorrectly conjugated; it should be `iniciar`.
`inicie` is in the imperative form. Most of the time, this form fits nicely in the beginning of sentences. However, this is not the case here. In this case, the correct would be to use the infinitive form, which is `iniciar`.

Other thing to note is the string has kinda a different meaning in Portuguese; the current translation is:
`Log out of %s, so that another user can log in`
one better way to phrase that would be:
`Encerrar a sessão de %s e iniciar uma sessão com um usuário diferente.`
but I think the current string does the job well.