### PR TITLE
status-notifier: Plug large leak with icons from paths

### DIFF
--- a/applets/notification_area/status-notifier/sn-item-v0.c
+++ b/applets/notification_area/status-notifier/sn-item-v0.c
@@ -287,7 +287,12 @@ update (SnItemV0 *v0)
           if (pixbuf && icon_size > 1)
             {
               /*An icon specified by path and filename may be the wrong size for the tray */
-              pixbuf = gdk_pixbuf_scale_simple (pixbuf, icon_size-2, icon_size-2, GDK_INTERP_BILINEAR);
+              GdkPixbuf *scaled_pixbuf;
+
+              scaled_pixbuf = gdk_pixbuf_scale_simple (pixbuf, icon_size-2, icon_size-2, GDK_INTERP_BILINEAR);
+              g_object_unref (pixbuf);
+              pixbuf = scaled_pixbuf;
+
               surface = gdk_cairo_surface_create_from_pixbuf (pixbuf, scale, NULL);
             }
           if (pixbuf)


### PR DESCRIPTION
When loading an icon from a path rather than the icon theme, we scale it down to match the scale we need[^1], but we leaked the original pixbuf in this case.

Fixes #1444.

[^1]: See commit e5c8646d8f6167fe2d3634a4604a1bf9ec8ee5af