### PR TITLE
applets/clock: Fix compatibility with musl libc

### DIFF
--- a/applets/clock/clock-location-tile.c
+++ b/applets/clock/clock-location-tile.c
@@ -434,7 +434,7 @@ format_time (struct tm   *now,
                          * weekday differs from the weekday at the location
                          * (the %A expands to the weekday). The %p expands to
                          * am/pm. */
-                        format = _("%l:%M <small>%p (%A)</small>");
+                        format = _("%_I:%M <small>%p (%A)</small>");
                 }
                 else {
                         /* Translators: This is a strftime format string.
@@ -451,7 +451,7 @@ format_time (struct tm   *now,
                          * It is used to display the time in 12-hours format
                          * (eg, like in the US: 8:10 am). The %p expands to
                          * am/pm. */
-                        format = _("%l:%M <small>%p</small>");
+                        format = _("%_I:%M <small>%p</small>");
                 }
                 else {
                         /* Translators: This is a strftime format string.
@@ -497,7 +497,7 @@ convert_time_to_str (time_t now, ClockFormat clock_format)
                  * It is used to display the time in 12-hours format (eg, like
                  * in the US: 8:10 am). The %p expands to am/pm.
                  */
-                format = _("%l:%M %p");
+                format = _("%_I:%M %p");
         }
         else {
                 /* Translators: This is a strftime format string.

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -458,7 +458,7 @@ get_updated_timeformat (ClockData *cd)
                 /* Translators: This is a strftime format string.
                  * It is used to display the time in 12-hours format (eg, like
                  * in the US: 8:10 am). The %p expands to am/pm. */
-                time_format = cd->showseconds ? _("%l:%M:%S %p") : _("%l:%M %p");
+                time_format = cd->showseconds ? _("%_I:%M:%S %p") : _("%_I:%M %p");
         else
                 /* Translators: This is a strftime format string.
                  * It is used to display the time in 24-hours format (eg, like


### PR DESCRIPTION
%l is an glibc extension for strftime, this extensions isn't supported by musl libc.

Replace %l with %_I, which is functionaly equivalence. %_I itself is also an extensions, however, %_I is supported by both glibc, musl, FreeBSD and deriviates, AIX, and Solaris.

Fix: #1451