### PR TITLE
Clock Applet: Add scrollbar to Locations lists when the lists get too long

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1248,6 +1248,7 @@ location_tile_need_clock_format_cb(ClockLocationTile *tile, gpointer data)
 static void
 create_cities_section (ClockData *cd)
 {
+        GtkWidget *cities_box;
         GSList *node;
         GSList *cities;
         GSList *l;
@@ -1261,8 +1262,16 @@ create_cities_section (ClockData *cd)
                 g_slist_free (cd->location_tiles);
         cd->location_tiles = NULL;
 
-        cd->cities_section = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
-        gtk_container_set_border_width (GTK_CONTAINER (cd->cities_section), 0);
+        cd->cities_section = gtk_scrolled_window_new (NULL, NULL);
+        gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (cd->cities_section),
+                                        GTK_POLICY_NEVER,
+                                        GTK_POLICY_AUTOMATIC);
+        gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (cd->cities_section),
+                                             GTK_SHADOW_NONE);
+        gtk_scrolled_window_set_propagate_natural_height (GTK_SCROLLED_WINDOW (cd->cities_section),
+                                                          TRUE);
+
+        cities_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 
         cities = cd->locations;
         if (g_slist_length (cities) == 0) {
@@ -1284,7 +1293,7 @@ create_cities_section (ClockData *cd)
                 g_signal_connect (city, "need-clock-format",
                                   G_CALLBACK (location_tile_need_clock_format_cb), cd);
 
-                gtk_box_pack_start (GTK_BOX (cd->cities_section),
+                gtk_box_pack_start (GTK_BOX (cities_box),
                                     GTK_WIDGET (city),
                                     FALSE, FALSE, 0);
 
@@ -1294,6 +1303,8 @@ create_cities_section (ClockData *cd)
         }
 
         g_slist_free (node);
+
+        gtk_container_add (GTK_CONTAINER (cd->cities_section), cities_box);
 
         gtk_box_pack_end (GTK_BOX (cd->clock_vbox),
                           cd->cities_section, FALSE, FALSE, 0);

--- a/applets/clock/clock.ui
+++ b/applets/clock/clock.ui
@@ -606,8 +606,9 @@
                       <object class="GtkScrolledWindow" id="scrolledwindow10">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
+                        <property name="expand">True</property>
                         <property name="hscrollbar-policy">never</property>
-                        <property name="vscrollbar-policy">never</property>
+                        <property name="vscrollbar-policy">automatic</property>
                         <property name="shadow-type">in</property>
                         <child>
                           <object class="GtkTreeView" id="cities_list">


### PR DESCRIPTION
Before this pull request, the Clock Applet's popup window would expand off the screen if the user added more than a few locations to the Locations list. In addition, the list of locations in the Clock Applet Preferences could get extremely tall as well, and could even push the bottom part of the Preferences dialog off the screen.

This PR adds (vertical) scrollbars to both widgets.  Here's how the Clock Applet popup looks now:
![mate-panel-clock-applet-locations-with-scrollbar](https://github.com/user-attachments/assets/a4f83aa1-b4e5-4c4d-883c-424ec7fcd831)

And here is how the Preferences dialog looks now:
![mate-panel-clock-applet-preferences-locations-with-scrollbar](https://github.com/user-attachments/assets/def176b2-cfc3-41a3-b8f0-8c22b04c0cf9)
