### PR TITLE
ci: Bump dpl branches for Ruby 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_deploy:
 deploy:
   - provider: pages
     edge:
-      branch: v2.0.3-beta.4
+      branch: v2.0.5
     token: $GITHUB_TOKEN
     keep_history: false
     committer_from_gh: true
@@ -59,7 +59,7 @@ deploy:
       condition: ${DISTRO} =~ ^fedora.*$
   - provider: script
     edge:
-      branch: v2.0.3-beta.4
+      branch: v2.0.5
     script: ./docker-build --verbose --config .build.yml --release github
     on:
       tags: true


### PR DESCRIPTION
The CI error on master:
```
/home/travis/.rvm/gems/ruby-3.3.5/gems/cl-1.2.4/lib/cl/opts.rb:112:in `block in taint': undefined method `taint' for an instance of String (NoMethodError)

          [key, self[key] && self[key].secret? ? value.taint : value]
                                                      ^^^^^^
```

That error with Ruby 3 was fixed here: https://github.com/travis-ci/travis-cl/commit/e17a1b2bd2fe51eb9cc4fd90d19c8a12997717a0#diff-ee038a05d1feba327913a56ad3533ada6845400f2aa2a1b2b2d2584d4e2852ba

I'm hoping that bumping from https://github.com/travis-ci/dpl/releases/tag/v2.0.3-beta.4 to https://github.com/travis-ci/dpl/releases/tag/v2.0.5 pulls in the fix.