### PR TITLE
panel-menu-button.c: apply a name to the main menu button

### DIFF
--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -694,7 +694,7 @@ panel_menu_button_load (const char  *menu_path,
 		return;
 	}
 
-	gtk_widget_set_name(GTK_WIDGET (button),"mate-panel-main-menu-button");
+	gtk_widget_set_name (GTK_WIDGET (button), "mate-panel-main-menu-button");
 
 	button->priv->applet_id = g_strdup (info->id);
 


### PR DESCRIPTION
Apply a name to the main menu button (compact menu)