### PR TITLE
Update layout of clock window

### DIFF
--- a/applets/clock/clock.ui
+++ b/applets/clock/clock.ui
@@ -600,6 +600,7 @@
                 <child>
                   <object class="GtkBox" id="hbox54">
                     <property name="visible">True</property>
+                    <property name="vexpand">True</property>
                     <property name="can-focus">False</property>
                     <property name="spacing">6</property>
                     <child>


### PR DESCRIPTION
Updates the layout of the list to fill the window.
Tested by rebuilding MATE 1.27 Debian source package.

<img width="431" height="306" alt="before" src="https://github.com/user-attachments/assets/08fb1cbd-9d49-4080-80dd-a89069e77a37" />

![after.png](https://github.com/user-attachments/assets/8deb1b26-817f-4cfa-b3dd-cad4113a8f7c)
