### PR TITLE
Allow to theme panel buttons

### DIFF
--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -416,6 +416,7 @@ button_widget_draw (GtkWidget *widget,
     y = off + (height - h) / 2;
 
     context = gtk_widget_get_style_context (widget);
+    gtk_style_context_add_class (context, "flat-panel-button");
     gtk_render_background (context, cr, 0, 0, width, height);
     gtk_render_frame (context, cr, 0, 0, width, height);
 

--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -415,6 +415,10 @@ button_widget_draw (GtkWidget *widget,
     x = off + (width - w) / 2;
     y = off + (height - h) / 2;
 
+    context = gtk_widget_get_style_context (widget);
+    gtk_render_background (context, cr, 0, 0, width, height);
+    gtk_render_frame (context, cr, 0, 0, width, height);
+
     cairo_save (cr);
 
     if (!button_widget->priv->activatable) {
@@ -433,10 +437,6 @@ button_widget_draw (GtkWidget *widget,
 
     cairo_paint (cr);
     cairo_restore (cr);
-
-    context = gtk_widget_get_style_context (widget);
-    gtk_render_background (context, cr, 0, 0, width, height);
-    gtk_render_frame (context, cr, 0, 0, width, height);
 
     if (button_widget->priv->arrow) {
         gdouble angle, size;

--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -435,6 +435,8 @@ button_widget_draw (GtkWidget *widget,
     cairo_restore (cr);
 
     context = gtk_widget_get_style_context (widget);
+    gtk_render_background (context, cr, 0, 0, width, height);
+    gtk_render_frame (context, cr, 0, 0, width, height);
 
     if (button_widget->priv->arrow) {
         gdouble angle, size;

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -364,8 +364,8 @@ panel_menu_button_menu_deactivated (PanelMenuButton *button)
 {
 	panel_toplevel_pop_autohide_disabler (button->priv->toplevel);
 
-	gtk_widget_unset_state_flags (GTK_WIDGET (button),
-				      GTK_STATE_FLAG_PRELIGHT);
+	gtk_widget_unset_state_flags (GTK_WIDGET (button), GTK_STATE_FLAG_PRELIGHT);
+	gtk_widget_unset_state_flags (GTK_WIDGET (button), GTK_STATE_FLAG_CHECKED);
 	button_widget_set_ignore_leave (BUTTON_WIDGET (button), FALSE);
 }
 
@@ -446,6 +446,7 @@ panel_menu_button_popup_menu (PanelMenuButton *button,
 
 	panel_toplevel_push_autohide_disabler (button->priv->toplevel);
 
+	gtk_widget_set_state_flags (GTK_WIDGET (button), GTK_STATE_FLAG_CHECKED, FALSE);
 	button_widget_set_ignore_leave (BUTTON_WIDGET (button), TRUE);
 
 	screen = gtk_window_get_screen (GTK_WINDOW (button->priv->toplevel));


### PR DESCRIPTION
And add the state checked for compact menu button.
Tested by rebuilding Mate 1.26 Debian source package.

![image](https://github.com/user-attachments/assets/c8034aba-6e35-45b8-8146-419ece96e339)

```css
.mate-panel-menu-bar .flat-panel-button {
	border: 1px solid yellow;
	border-radius: 0;
	background: pink;
}
.mate-panel-menu-bar #mate-panel-main-menu-button:checked {
	color: white;
	border-color: black;
	background: blue;
}
```

But there is something strange:

- In my CSS I have `button { box-shadow:...; }` (and I can't remove it)
- So I remove it with `.mate-panel-menu-bar .flat-panel-button { box-shadow:none; }`
- But, I need to add `margin:-1px;` to keep the `border`

Fix #1471.