### PR TITLE
Make mate-panel build with X11 disabled (including notification area)

### DIFF
--- a/applets/Makefile.am
+++ b/applets/Makefile.am
@@ -1,7 +1,9 @@
 SUBDIRS =			\
 	clock			\
 	fish			\
-	wncklet
+	wncklet			\
+	notification_area
+
 
 if ENABLE_X11
 SUBDIRS += \

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -60,6 +60,11 @@
 #include <gdk/gdkx.h>
 #endif
 
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
+
 #include <libmateweather/mateweather-prefs.h>
 #include <libmateweather/location-entry.h>
 #include <libmateweather/timezone-menu.h>

--- a/applets/notification_area/Makefile.am
+++ b/applets/notification_area/Makefile.am
@@ -1,10 +1,15 @@
 SUBDIRS =				\
 	libstatus-notifier-watcher	\
-	status-notifier			\
-	system-tray
+	status-notifier
+
+if ENABLE_X11
+SUBDIRS += \
+        system-tray
+
+noinst_PROGRAMS = testtray
+endif
 
 noinst_LTLIBRARIES = libtray.la
-noinst_PROGRAMS = testtray
 
 AM_CPPFLAGS =							\
 	$(NOTIFICATION_AREA_CFLAGS)				\
@@ -29,8 +34,17 @@ libtray_la_SOURCES =				\
 
 libtray_la_LIBADD =							\
 	libstatus-notifier-watcher/libstatus-notifier-watcher.la	\
-	status-notifier/libstatus-notifier.la				\
+	status-notifier/libstatus-notifier.la	
+
+if ENABLE_X11
+libtray_la_LIBADD +=							\
 	system-tray/libsystem-tray.la
+
+testtray_SOURCES = testtray.c
+testtray_LDADD =			\
+	libtray.la \
+	$(NOTIFICATION_AREA_LIBS)
+endif 
 
 NOTIFICATION_AREA_SOURCES = \
 	main.c \
@@ -42,12 +56,6 @@ NOTIFICATION_AREA_LDADD =				\
 	libtray.la \
 	$(NOTIFICATION_AREA_LIBS)			\
 	$(LIBMATE_PANEL_APPLET_LIBS)
-
-
-testtray_SOURCES = testtray.c
-testtray_LDADD =			\
-	libtray.la \
-	$(NOTIFICATION_AREA_LIBS)
 
 if NOTIFICATION_AREA_INPROCESS
 APPLET_IN_PROCESS = true

--- a/applets/notification_area/main.c
+++ b/applets/notification_area/main.c
@@ -23,10 +23,6 @@
 
 #include <config.h>
 
-#ifndef HAVE_X11
-#error file should only be built when HAVE_X11 is enabled
-#endif
-
 #include <string.h>
 
 #include <mate-panel-applet.h>
@@ -302,7 +298,6 @@ static void
 na_tray_applet_realize (GtkWidget *widget)
 {
   NaTrayApplet      *applet = NA_TRAY_APPLET (widget);
-
   if (parent_class_realize)
     parent_class_realize (widget);
 

--- a/applets/notification_area/na-grid.c
+++ b/applets/notification_area/na-grid.c
@@ -29,7 +29,10 @@
 
 #include "na-grid.h"
 
+#ifdef HAVE_X11 
 #include "system-tray/na-tray.h"
+#endif
+
 #include "status-notifier/sn-host-v0.h"
 
 #define MIN_ICON_SIZE_DEFAULT 24
@@ -324,6 +327,7 @@ na_grid_realize (GtkWidget *widget)
   display = gdk_display_get_default ();
   /* Instantiate the hosts now we have a screen */
   screen = gtk_widget_get_screen (GTK_WIDGET (self));
+#ifdef HAVE_X11
   if  (GDK_IS_X11_DISPLAY (display))
   {
     GtkOrientation orientation;
@@ -337,6 +341,7 @@ na_grid_realize (GtkWidget *widget)
 
     add_host (self, tray_host);
   }
+#endif
   settings = g_settings_new ("org.mate.panel");
   if (g_settings_get_boolean (settings, "enable-sni-support"))
     add_host (self, sn_host_v0_new ());

--- a/applets/notification_area/na-grid.h
+++ b/applets/notification_area/na-grid.h
@@ -31,6 +31,11 @@
 #include <gdk/gdkx.h>
 #endif
 
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
+
 #include <gtk/gtk.h>
 
 G_BEGIN_DECLS

--- a/applets/wncklet/Makefile.am
+++ b/applets/wncklet/Makefile.am
@@ -19,11 +19,17 @@ WNCKLET_SOURCES = \
 	window-menu.h \
 	window-list.c \
 	window-list.h \
-	workspace-switcher.c \
-	workspace-switcher.h \
 	showdesktop.c \
 	showdesktop.h \
 	$(BUILT_SOURCES)
+
+if ENABLE_X11
+WNCKLET_SOURCES += \
+	workspace-switcher.c \
+	workspace-switcher.h
+endif
+
+
 
 WNCKLET_LDADD =						\
 	../../libmate-panel-applet/libmate-panel-applet-4.la	\
@@ -93,9 +99,17 @@ ui_FILES = \
 	showdesktop-menu.xml \
 	window-list-menu.xml \
 	window-list.ui \
-	window-menu-menu.xml \
+	window-menu-menu.xml
+
+if ENABLE_X11
+ui_FILES += \
 	workspace-switcher-menu.xml \
 	workspace-switcher.ui
+
+endif
+
+
+
 
 wncklet-resources.c: wncklet.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/wncklet.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name wncklet $<

--- a/applets/wncklet/showdesktop.c
+++ b/applets/wncklet/showdesktop.c
@@ -35,6 +35,11 @@
 #include <libwnck/libwnck.h>
 #endif
 
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
+
 #include "wncklet.h"
 #include "showdesktop.h"
 

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -25,6 +25,11 @@
 #include <libwnck/libwnck.h>
 #endif /* HAVE_X11 */
 
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
+
 #ifdef HAVE_WAYLAND
 #include <gdk/gdkwayland.h>
 #include "wayland-backend.h"

--- a/applets/wncklet/window-menu.c
+++ b/applets/wncklet/window-menu.c
@@ -45,6 +45,10 @@
 #include <gdk/gdkwayland.h>
 #endif /* HAVE_WAYLAND */
 
+#ifndef HAVE_X11
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
+
 #include "wncklet.h"
 #include "window-menu.h"
 

--- a/applets/wncklet/wncklet.c
+++ b/applets/wncklet/wncklet.c
@@ -35,11 +35,15 @@
 #include <gdk/gdkx.h>
 #define WNCK_I_KNOW_THIS_IS_UNSTABLE
 #include <libwnck/libwnck.h>
+#include "workspace-switcher.h"
+#endif
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
 #endif
 
 #include "wncklet.h"
 #include "window-menu.h"
-#include "workspace-switcher.h"
 #include "window-list.h"
 #include "showdesktop.h"
 
@@ -138,8 +142,10 @@ static gboolean wncklet_factory(MatePanelApplet* applet, const char* iid, gpoint
 
 	if (!strcmp(iid, "WindowMenuApplet"))
 		retval = window_menu_applet_fill(applet);
+#ifdef HAVE_X11
 	else if (!strcmp(iid, "WorkspaceSwitcherApplet") || !strcmp(iid, "PagerApplet"))
 		retval = workspace_switcher_applet_fill(applet);
+#endif
 	else if (!strcmp(iid, "WindowListApplet") || !strcmp(iid, "TasklistApplet"))
 		retval = window_list_applet_fill(applet);
 	else if (!strcmp(iid, "ShowDesktopApplet"))

--- a/applets/wncklet/workspace-switcher.c
+++ b/applets/wncklet/workspace-switcher.c
@@ -29,6 +29,11 @@
 #include <libwnck/libwnck.h>
 #endif /* HAVE_X11 */
 
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
+
 #ifdef HAVE_WAYLAND
 #include <gdk/gdkwayland.h>
 #endif /* HAVE_WAYLAND */

--- a/libmate-panel-applet/mate-panel-applet.c
+++ b/libmate-panel-applet/mate-panel-applet.c
@@ -45,6 +45,10 @@
 #include <X11/Xatom.h>
 #include "panel-plug-private.h"
 #endif
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
 
 #include "mate-panel-applet.h"
 #include "panel-applet-private.h"

--- a/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applet-frame-dbus.c
@@ -245,6 +245,7 @@ mate_panel_applet_frame_dbus_change_background (MatePanelAppletFrame    *frame,
 	MatePanelAppletFrameDBusPrivate *priv = dbus_frame->priv;
 	char *bg_str;
 
+#ifdef HAVE_X11
 	bg_str = _mate_panel_applet_frame_get_background_string (
 			frame, PANEL_WIDGET (gtk_widget_get_parent (GTK_WIDGET (frame))), type);
 
@@ -261,6 +262,7 @@ mate_panel_applet_frame_dbus_change_background (MatePanelAppletFrame    *frame,
 
 		g_free (bg_str);
 	}
+#endif
 }
 
 static void

--- a/mate-panel/libmate-panel-applet-private/panel-applets-manager-dbus.c
+++ b/mate-panel/libmate-panel-applet-private/panel-applets-manager-dbus.c
@@ -38,6 +38,9 @@
 #ifdef HAVE_WAYLAND
 #include <gdk/gdkwayland.h>
 #endif
+#ifndef HAVE_X11
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
 
 struct _MatePanelAppletsManagerDBusPrivate
 {

--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -65,6 +65,9 @@
 #include <gdk/gdkwayland.h>
 
 #endif
+#ifndef HAVE_X11
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
 
 enum {
 	PROP_0,

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -645,6 +645,7 @@ _mate_panel_applet_frame_update_size_hints (MatePanelAppletFrame *frame,
 					    n_elements);
 }
 
+#ifdef HAVE_X11
 char *
 _mate_panel_applet_frame_get_background_string (MatePanelAppletFrame    *frame,
 					   PanelWidget         *panel,
@@ -679,6 +680,8 @@ _mate_panel_applet_frame_get_background_string (MatePanelAppletFrame    *frame,
 
 	return panel_background_make_string (&panel->toplevel->background, x, y);
 }
+#endif
+
 
 static void
 mate_panel_applet_frame_reload_response (GtkWidget        *dialog,

--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -763,6 +763,7 @@ panel_background_free (PanelBackground *background)
 	background->default_pattern = NULL;
 }
 
+#ifdef HAVE_X11
 char *
 panel_background_make_string (PanelBackground *background,
 			      int              x,
@@ -799,6 +800,7 @@ panel_background_make_string (PanelBackground *background,
 
 	return retval;
 }
+#endif
 
 PanelBackgroundType
 panel_background_get_type (PanelBackground *background)

--- a/mate-panel/panel-layout.c
+++ b/mate-panel/panel-layout.c
@@ -34,6 +34,11 @@
 #include <gdk/gdkx.h>
 #endif
 
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
+
 #include <libmate-desktop/mate-dconf.h>
 #include <libmate-desktop/mate-gsettings.h>
 

--- a/mate-panel/panel-multimonitor.c
+++ b/mate-panel/panel-multimonitor.c
@@ -33,6 +33,11 @@
 #include <gdk/gdkx.h>
 #endif /* HAVE_X11 */
 
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
+
 #include "panel-multimonitor.h"
 
 #include <string.h>

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -36,6 +36,11 @@
 #include <gdk/gdkx.h>
 #endif
 
+#ifndef HAVE_X11
+#include <gdk/gdkwayland.h>
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
+
 #include <libpanel-util/panel-list.h>
 #include <libmate-desktop/mate-dconf.h>
 #include <libmate-desktop/mate-gsettings.h>

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -61,6 +61,9 @@
 #ifdef HAVE_WAYLAND
 #include "wayland-backend.h"
 #endif
+#ifndef HAVE_X11
+#define GDK_IS_X11_DISPLAY(object)        !(G_TYPE_CHECK_INSTANCE_TYPE ((object), GDK_TYPE_WAYLAND_DISPLAY))
+#endif
 
 #define DEFAULT_SIZE              48
 #define DEFAULT_AUTO_HIDE_SIZE    1

--- a/mate-panel/wayland-backend.c
+++ b/mate-panel/wayland-backend.c
@@ -71,6 +71,7 @@ wayland_panel_toplevel_update_placement (PanelToplevel* toplevel)
 		break;
 	case PANEL_ORIENTATION_BOTTOM:
 		anchor[GTK_LAYER_SHELL_EDGE_BOTTOM] = TRUE;
+		anchor[GTK_LAYER_SHELL_EDGE_RIGHT] = TRUE;
 		anchor[GTK_LAYER_SHELL_EDGE_TOP] = FALSE;
 		break;
 	default:


### PR DESCRIPTION
Some proof of concept update to make mate-panel buildable (and usable) without X11 at all. 
Built and tested with X11 and wayland, wayland only and X11 only.

No functionality improvements  - just fixed applets that did work on wayland before but required X11 to compile by placing X11 specific code under #ifdef HAVE_X11 in *.c *.h  files and if ENABLED_X11 in makefiles.  

Also reimplemented GDK_IS_X11_DISPLAY using GDK_IS_WAYLAND_DISPLAY in the case if gdkx.h not there.