### PR TITLE
Fix uninitialized and unused screen vars

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -940,6 +940,7 @@ position_calendar_popup (ClockData *cd)
                 button_w = allocation.width;
                 button_h = allocation.height;
 
+                screen = gtk_widget_get_screen (GTK_WIDGET (cd->calendar_popup));
                 display = gtk_widget_get_display (GTK_WIDGET (cd->calendar_popup));
 
                 n = gdk_display_get_n_monitors (display);

--- a/applets/fish/fish.c
+++ b/applets/fish/fish.c
@@ -819,7 +819,6 @@ static void display_fortune_dialog(FishApplet* fish)
 	int          argc;
 	char       **argv;
 	GdkDisplay  *display;
-	GdkScreen   *screen;
 	char        *display_name;
 
 	/* if there is still a pipe, close it */

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -769,7 +769,6 @@ gboolean window_list_applet_fill(MatePanelApplet* applet)
 	TasklistData* tasklist;
 	GtkActionGroup* action_group;
 	GtkCssProvider  *provider;
-	GdkScreen *screen;
 
 	tasklist = g_new0(TasklistData, 1);
 

--- a/mate-panel/panel-toplevel.c
+++ b/mate-panel/panel-toplevel.c
@@ -862,11 +862,12 @@ static void panel_toplevel_rotate_to_pointer(PanelToplevel* toplevel, int pointe
 #ifdef HAVE_X11
 static gboolean panel_toplevel_warp_pointer_increment(PanelToplevel* toplevel, int keyval, int increment)
 {
+	GdkScreen *screen;
 	GdkWindow *root_window;
 	GdkDevice      *device;
 	int        new_x, new_y;
 
-	GdkScreen *screen = gtk_widget_get_screen (GTK_WIDGET (toplevel));
+	screen = gtk_widget_get_screen (GTK_WIDGET (toplevel));
 	g_return_val_if_fail (GDK_IS_X11_SCREEN (screen), FALSE);
 	root_window = gdk_screen_get_root_window (screen);
 	device = gdk_seat_get_pointer (gdk_display_get_default_seat (gtk_widget_get_display (GTK_WIDGET(root_window))));


### PR DESCRIPTION
A previous overzealous cleanup left some hanging screen variables and one instance of an uninitialized screen being used.