### PR TITLE
clock: Store calendar client in ClockData

### DIFF
--- a/applets/clock/calendar-client.c
+++ b/applets/clock/calendar-client.c
@@ -116,11 +116,6 @@ static void calendar_client_start_query (CalendarClient       *client,
 static void calendar_client_source_finalize (CalendarClientSource *source);
 static void calendar_client_query_finalize  (CalendarClientQuery  *query);
 
-static void
-calendar_client_update_appointments (CalendarClient *client);
-static void
-calendar_client_update_tasks (CalendarClient *client);
-
 enum
 {
   PROP_O,
@@ -1420,7 +1415,7 @@ calendar_client_start_query (CalendarClient       *client,
   }
 }
 
-static void
+void
 calendar_client_update_appointments (CalendarClient *client)
 {
   GSList *l;
@@ -1458,7 +1453,7 @@ calendar_client_update_appointments (CalendarClient *client)
 /* FIXME:
  * perhaps we should use evo's "hide_completed_tasks" pref?
  */
-static void
+void
 calendar_client_update_tasks (CalendarClient *client)
 {
   GSList *l;

--- a/applets/clock/calendar-client.h
+++ b/applets/clock/calendar-client.h
@@ -144,6 +144,9 @@ void            calendar_client_set_task_completed       (CalendarClient     *cl
 gboolean        calendar_client_create_task              (CalendarClient     *client,
 							  const char         *summary);
 
+void            calendar_client_update_appointments      (CalendarClient *client);
+void            calendar_client_update_tasks             (CalendarClient *client);
+
 void calendar_event_free (CalendarEvent *event);
 
 G_END_DECLS

--- a/applets/clock/calendar-window.h
+++ b/applets/clock/calendar-window.h
@@ -31,6 +31,10 @@
 #include <gtk/gtk.h>
 #include "clock-utils.h"
 
+#ifdef HAVE_EDS
+#include "calendar-client.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -77,6 +81,10 @@ void       calendar_window_set_show_weeks   (CalendarWindow *calwin,
 ClockFormat calendar_window_get_time_format (CalendarWindow *calwin);
 void       calendar_window_set_time_format  (CalendarWindow *calwin,
 					     ClockFormat     time_format);
+
+#ifdef HAVE_EDS
+void       calendar_window_set_client (CalendarWindow *calwin, CalendarClient *client);
+#endif
 
 #ifdef __cplusplus
 }

--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -211,6 +211,10 @@ struct _ClockData {
         const gchar *weather_icon_name;
 
         GDBusProxy *system_manager_proxy;
+
+#ifdef HAVE_EDS
+        CalendarClient *calendar_client;
+#endif
 };
 
 /* Used to count the number of clock instances. It's there to know when we
@@ -828,6 +832,13 @@ destroy_clock (GtkWidget * widget, ClockData *cd)
                 cd->builder = NULL;
         }
 
+#ifdef HAVE_EDS
+        if (cd->calendar_client) {
+                g_object_unref (cd->calendar_client);
+                cd->calendar_client = NULL;
+        }
+#endif
+
         g_free (cd);
 }
 
@@ -886,6 +897,12 @@ create_calendar (ClockData *cd)
                                       cd->orient == MATE_PANEL_APPLET_ORIENT_UP,
                                       cd->settings);
         g_free (prefs_path);
+
+#ifdef HAVE_EDS
+        if (cd->calendar_client) {
+                calendar_window_set_client (CALENDAR_WINDOW (window), cd->calendar_client);
+        }
+#endif
 
         calendar_window_set_show_weeks (CALENDAR_WINDOW (window),
                                         cd->showweek);
@@ -2762,6 +2779,11 @@ fill_clock_applet (MatePanelApplet *applet)
          * the clock if/when the system resumes from sleep (e.g. suspend/
          * hibernate). */
         setup_monitor_for_resume (cd);
+
+#ifdef HAVE_EDS
+        /* Initialize persistent calendar client */
+        cd->calendar_client = calendar_client_new (cd->settings);
+#endif
 
         return TRUE;
 }


### PR DESCRIPTION
This simplifies the evolution calendar client architecture and makes the popup show up faster, since we don't need to create a new one every time we open it.