### PR TITLE
ci: Upgrade libsoup dependency from 2.4 to 3.0

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -51,7 +51,7 @@ requires:
     - libmateweather-dev
     - libpango1.0-dev
     - libsm-dev
-    - libsoup2.4-dev
+    - libsoup-3.0-dev
     - libwnck-3-dev
     - libx11-dev
     - libxrandr-dev
@@ -113,7 +113,7 @@ requires:
     - libmateweather-dev
     - libpango1.0-dev
     - libsm-dev
-    - libsoup2.4-dev
+    - libsoup-3.0-dev
     - libwnck-3-dev
     - libx11-dev
     - libxrandr-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ env:
     libmateweather-dev
     libpango1.0-dev
     libsm-dev
-    libsoup2.4-dev
+    libsoup-3.0-dev
     libwnck-3-dev
     libx11-dev
     libxrandr-dev


### PR DESCRIPTION
mate-panel uses libsoup indirectly through libmateweather, which already requires libsoup-3.0. Evolution Data Server (used by the clock applet for calendar integration) also requires libsoup-3.0.