### PR TITLE
wncklet: fix preview window positioning for right & down

### DIFF
--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -367,14 +367,14 @@ preview_window_reposition (WnckTasklist    *tl,
 			x_pos = monitor_geom.width + monitor_geom.x - width - tasklist->size - PREVIEW_PADDING;
 			break;
 		case MATE_PANEL_APPLET_ORIENT_RIGHT:
-			x_pos = tasklist->size + PREVIEW_PADDING;
+			x_pos = monitor_geom.x + tasklist->size + PREVIEW_PADDING;
 			break;
 		case MATE_PANEL_APPLET_ORIENT_UP:
 			y_pos = monitor_geom.height + monitor_geom.y - height - tasklist->size - PREVIEW_PADDING;
 			break;
 		case MATE_PANEL_APPLET_ORIENT_DOWN:
 		default:
-			y_pos = tasklist->size + PREVIEW_PADDING;
+			y_pos = monitor_geom.y + tasklist->size + PREVIEW_PADDING;
 			break;
 	}
 


### PR DESCRIPTION
The monitor origin needs to be taken into account.

This coincidentally fixes a case of excessive CPU usage in certain configurations. I have a dual-monitor setup, and one of the monitors has a positive `monitor_geom.y` coordinate. When I hover the mouse pointer over the window list (in a Top-positioned panel), the preview appears directly underneath the cursor. This causes the window list to lose its 'hovered' status, hiding the preview window. After the window is hidden, the cycle repeats until the cursor is moved away.