### PR TITLE
Use gint64 to track UNIX timestamps

### DIFF
--- a/applets/clock/clock-sunpos.c
+++ b/applets/clock/clock-sunpos.c
@@ -52,7 +52,7 @@
 /* Calculate number of days since 4713BC.
  */
 static gdouble
-unix_time_to_julian_date (gint unix_time)
+unix_time_to_julian_date (gint64 unix_time)
 {
   return UNIX_EPOCH + (double) unix_time / (60 * 60 * 24);
 }


### PR DESCRIPTION
Use `gint64` to track UNIX timestamps to make it work after the year 2038

See https://en.wikipedia.org/wiki/Year_2038_problem

This patch was done while reviewing potential year-2038 issues in openSUSE.