### PR TITLE
fish: Fix alternating animation during April Fools

### DIFF
--- a/applets/fish/fish.c
+++ b/applets/fish/fish.c
@@ -1181,7 +1181,7 @@ static void check_april_fools(FishApplet* fish)
 	} else if (tm->tm_mon  == fools_month    &&
 		 tm->tm_mday == fools_day        &&
 		 tm->tm_hour >= fools_hour_start &&
-		 tm->tm_hour <= fools_hour_end) {
+		 tm->tm_hour < fools_hour_end) {
 		fish->april_fools = TRUE;
 		update_pixmap (fish);
 	}


### PR DESCRIPTION
During April Fools in the morning, Wanda the fish is expected to show up upside down, with dirty-looking water, as though dead. However, because of the hour comparison, it ends up alternating between the standard animation and the dead fish.