### PR TITLE
applet clock: Fix proportional font digits by tnum

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -1546,6 +1546,16 @@ create_main_clock_label (ClockData *cd)
         GtkWidget *label;
 
         label = gtk_label_new (NULL);
+
+        // Fix proportional font by font feature tabular numbers (tnum) (if supported by the font)
+        PangoAttribute *attr;
+        PangoAttrList *alist;
+        attr = pango_attr_font_features_new ("tnum=1");
+        alist = pango_attr_list_new ();
+        pango_attr_list_insert (alist, attr);
+        gtk_label_set_attributes (GTK_LABEL (label), alist);
+        pango_attr_list_unref (alist);
+
 /*Fixme-this is invalid for labels with any recent GTK3 version, maybe all of them*/
 /*
         g_signal_connect (label, "size-request",


### PR DESCRIPTION
Fixes #1338: The clock-time was jumping (and also the rest of the panel), due to different width of the digits.

This fix uses "tabular numbers" as fix.
The font must support this feature, otherwise this fix will not work.

Example Fonts, which will be fixed here: [Cantarell](https://en.wikipedia.org/wiki/Cantarell_(typeface)) and [Inter (variant of Adwaita Sans)](https://en.wikipedia.org/wiki/Inter_(typeface)#Variants)

---------
Perspective:
- I will send soon another separate fix for these non-supported fonts (e.g. font "Quicksand"): set the width of each single Glyph, if needed.
- I also planing to rework the current calculate_minimum_width(). Otherwise its maybe jumping between this views (but only at wrong defined set width): <img width="158" height="192" alt="toggle_orient_clock_screen_2_16f" src="https://github.com/user-attachments/assets/05eff141-07df-44d4-ab84-a62a14c8d605" />
