### PR TITLE
window-list: Add preview window decorations

### DIFF
--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -21,6 +21,7 @@
 
 #ifdef HAVE_X11
 #include <gdk/gdkx.h>
+#include <X11/Xatom.h>
 #define WNCK_I_KNOW_THIS_IS_UNSTABLE
 #include <libwnck/libwnck.h>
 #endif /* HAVE_X11 */
@@ -251,15 +252,32 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
                           int          *thumbnail_scale)
 {
 	GdkWindow *window;
-	Window win;
+	GdkDisplay *display;
+	Display *xdpy;
+	Window win, frame, parent, root;
+	Window *children;
+	unsigned int nchildren;
 	cairo_surface_t *thumbnail;
 	cairo_t *cr;
 	double ratio;
 	int width, height, scale;
+	int src_x = 0, src_y = 0;
 
 	win = wnck_window_get_xid (wnck_window);
+	display = gdk_display_get_default ();
+	xdpy = GDK_DISPLAY_XDISPLAY (display);
 
-	if ((window = gdk_x11_window_foreign_new_for_display (gdk_display_get_default (), win)) == NULL)
+	/* Find the frame window (WM parent) which includes decorations */
+	frame = win;
+	if (XQueryTree (xdpy, win, &root, &parent, &children, &nchildren))
+	{
+		if (children)
+			XFree (children);
+		if (parent != root)
+			frame = parent;
+	}
+
+	if ((window = gdk_x11_window_foreign_new_for_display (display, frame)) == NULL)
 	{
 		return NULL;
 	}
@@ -267,6 +285,45 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 	*thumbnail_scale = scale = gdk_window_get_scale_factor (window);
 	width = gdk_window_get_width (window) * scale;
 	height = gdk_window_get_height (window) * scale;
+
+	/* Strip invisible resize borders using _NET_FRAME_EXTENTS */
+	if (frame != win)
+	{
+		Atom frame_extents = XInternAtom (xdpy, "_NET_FRAME_EXTENTS", False);
+		Atom type;
+		int fmt;
+		unsigned long nitems, bytes;
+		unsigned char *data = NULL;
+
+		if (XGetWindowProperty (xdpy, win, frame_extents, 0, 4, False,
+		                        XA_CARDINAL, &type, &fmt, &nitems, &bytes,
+		                        &data) == Success && data && nitems >= 4)
+		{
+			unsigned long *ext = (unsigned long *) data;
+			XWindowAttributes wa;
+
+			if (XGetWindowAttributes (xdpy, win, &wa))
+			{
+				int vis_w = (wa.width  + ext[0] + ext[1]) * scale;
+				int vis_h = (wa.height + ext[2] + ext[3]) * scale;
+				int border_x = (wa.x - (int) ext[0]) * scale;
+				int border_y = (wa.y - (int) ext[2]) * scale;
+
+				if (border_x > 0 && vis_w < width)
+				{
+					src_x = border_x;
+					width = vis_w;
+				}
+				if (border_y > 0 && vis_h < height)
+				{
+					src_y = border_y;
+					height = vis_h;
+				}
+			}
+		}
+		if (data)
+			XFree (data);
+	}
 
 	/* Scale to configured size while maintaining aspect ratio */
 	if (width > height)
@@ -292,7 +349,7 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 	cairo_surface_set_device_scale (thumbnail, scale, scale);
 	cr = cairo_create (thumbnail);
 	cairo_scale (cr, ratio, ratio);
-	gdk_cairo_set_source_window (cr, window, 0, 0);
+	gdk_cairo_set_source_window (cr, window, -src_x / scale, -src_y / scale);
 	cairo_paint (cr);
 	cairo_destroy (cr);
 

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -283,8 +283,8 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 	}
 
 	*thumbnail_scale = scale = gdk_window_get_scale_factor (window);
-	width = gdk_window_get_width (window) * scale;
-	height = gdk_window_get_height (window) * scale;
+	width = gdk_window_get_width (window);
+	height = gdk_window_get_height (window);
 
 	/* Strip invisible resize borders using _NET_FRAME_EXTENTS */
 	if (frame != win)
@@ -304,10 +304,10 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 
 			if (XGetWindowAttributes (xdpy, win, &wa))
 			{
-				int vis_w = (wa.width  + ext[0] + ext[1]) * scale;
-				int vis_h = (wa.height + ext[2] + ext[3]) * scale;
-				int border_x = (wa.x - (int) ext[0]) * scale;
-				int border_y = (wa.y - (int) ext[2]) * scale;
+				int vis_w = (wa.width  + ext[0] + ext[1]) / scale;
+				int vis_h = (wa.height + ext[2] + ext[3]) / scale;
+				int border_x = (wa.x - (int) ext[0]) / scale;
+				int border_y = (wa.y - (int) ext[2]) / scale;
 
 				if (border_x > 0 && vis_w < width)
 				{
@@ -328,24 +328,24 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 	/* Scale to configured size while maintaining aspect ratio */
 	if (width > height)
 	{
-		int max_size = MIN (width, tasklist->thumbnail_size * scale);
+		int max_size = MIN (width, tasklist->thumbnail_size);
 		ratio = (double) max_size / (double) width;
-		*thumbnail_width = max_size;
-		*thumbnail_height = (int) ((double) height * ratio);
+		*thumbnail_width = max_size * scale;
+		*thumbnail_height = (int) ((double) height * ratio) * scale;
 	}
 	else
 	{
-		int max_size = MIN (height, tasklist->thumbnail_size * scale);
+		int max_size = MIN (height, tasklist->thumbnail_size);
 		ratio = (double) max_size / (double) height;
-		*thumbnail_height = max_size;
-		*thumbnail_width = (int) ((double) width * ratio);
+		*thumbnail_height = max_size * scale;
+		*thumbnail_width = (int) ((double) width * ratio) * scale;
 	}
 
 	gdk_x11_display_error_trap_push (gdk_window_get_display (window));
 
 	GdkPixbuf *pixbuf = gdk_pixbuf_get_from_window (window,
-	                                                src_x / scale, src_y / scale,
-	                                                width / scale, height / scale);
+	                                                src_x, src_y,
+	                                                width, height);
 
 	if (gdk_x11_display_error_trap_pop (gdk_window_get_display (window)) || pixbuf == NULL)
 	{
@@ -358,7 +358,9 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 	                                        *thumbnail_height);
 	cairo_surface_set_device_scale (thumbnail, scale, scale);
 	cr = cairo_create (thumbnail);
-	cairo_scale (cr, ratio, ratio);
+	cairo_scale (cr,
+	             (double) *thumbnail_width / scale / gdk_pixbuf_get_width (pixbuf),
+	             (double) *thumbnail_height / scale / gdk_pixbuf_get_height (pixbuf));
 	gdk_cairo_set_source_pixbuf (cr, pixbuf, 0, 0);
 	cairo_paint (cr);
 	cairo_destroy (cr);

--- a/applets/wncklet/window-list.c
+++ b/applets/wncklet/window-list.c
@@ -343,21 +343,26 @@ preview_window_thumbnail (WnckWindow   *wnck_window,
 
 	gdk_x11_display_error_trap_push (gdk_window_get_display (window));
 
+	GdkPixbuf *pixbuf = gdk_pixbuf_get_from_window (window,
+	                                                src_x / scale, src_y / scale,
+	                                                width / scale, height / scale);
+
+	if (gdk_x11_display_error_trap_pop (gdk_window_get_display (window)) || pixbuf == NULL)
+	{
+		g_object_unref (window);
+		return NULL;
+	}
+
 	thumbnail = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
 	                                        *thumbnail_width,
 	                                        *thumbnail_height);
 	cairo_surface_set_device_scale (thumbnail, scale, scale);
 	cr = cairo_create (thumbnail);
 	cairo_scale (cr, ratio, ratio);
-	gdk_cairo_set_source_window (cr, window, -src_x / scale, -src_y / scale);
+	gdk_cairo_set_source_pixbuf (cr, pixbuf, 0, 0);
 	cairo_paint (cr);
 	cairo_destroy (cr);
-
-	if (gdk_x11_display_error_trap_pop (gdk_window_get_display (window)))
-	{
-		cairo_surface_destroy (thumbnail);
-		thumbnail = NULL;
-	}
+	g_object_unref (pixbuf);
 
 	g_object_unref (window);
 


### PR DESCRIPTION
This adds window decorations to the on-hover preview. It also fixes the thumbnail so that the content is captured fresh on each hover.