### PR TITLE
wncklet: link against libX11 for window preview thumbnails

### DIFF
--- a/applets/wncklet/Makefile.am
+++ b/applets/wncklet/Makefile.am
@@ -36,6 +36,11 @@ WNCKLET_LDADD =						\
 	$(WNCKLET_LIBS)					\
 	$(LIBMATE_PANEL_APPLET_LIBS)
 
+if ENABLE_X11
+WNCKLET_LDADD += \
+	$(X_LIBS)
+endif
+
 if ENABLE_WAYLAND
 WNCKLET_SOURCES += \
 	wayland-backend.c \


### PR DESCRIPTION
The window-list preview code uses XGetWindowAttributes and XGetWindowProperty to capture window decorations, but the wncklet Makefile was missing the X11 linker flags, causing a build failure.

Fixes #1561