### PR TITLE
Backport gnome-panel pack model for zone positioning

### DIFF
--- a/data/default.layout
+++ b/data/default.layout
@@ -11,43 +11,43 @@ size=24
 [Object menu-bar]
 object-type=menu-bar
 toplevel-id=top
-position=0
+pack-index=0
 locked=true
 
 [Object notification-area]
 object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=top
-position=10
-panel-right-stick=true
+pack-type=end
+pack-index=1
 locked=true
 
 [Object clock]
 object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=top
-position=0
-panel-right-stick=true
+pack-type=end
+pack-index=0
 locked=true
 
 [Object show-desktop]
 object-type=applet
 applet-iid=WnckletFactory::ShowDesktopApplet
 toplevel-id=bottom
-position=0
+pack-index=0
 locked=true
 
 [Object window-list]
 object-type=applet
 applet-iid=WnckletFactory::WindowListApplet
 toplevel-id=bottom
-position=20
+pack-index=1
 locked=true
 
 [Object workspace-switcher]
 object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
-position=0
-panel-right-stick=true
+pack-type=end
+pack-index=0
 locked=true

--- a/data/fedora.layout
+++ b/data/fedora.layout
@@ -11,72 +11,72 @@ size=24
 [Object menu-bar]
 object-type=menu-bar
 toplevel-id=top
-position=0
+pack-index=0
 locked=true
 
 [Object file-browser]
 object-type=launcher
 launcher-location=/usr/share/applications/caja-browser.desktop
 toplevel-id=top
-position=10
+pack-index=1
 locked=true
 
 [Object terminal]
 object-type=launcher
 launcher-location=/usr/share/applications/mate-terminal.desktop
 toplevel-id=top
-position=20
+pack-index=2
 locked=true
 
 [Object web-browser]
 object-type=launcher
 launcher-location=/usr/share/applications/firefox.desktop
 toplevel-id=top
-position=30
+pack-index=3
 locked=true
 
 [Object volume-control]
 object-type=applet
 applet-iid=GvcAppletFactory::GvcApplet
 toplevel-id=top
-position=20
-panel-right-stick=true
+pack-type=end
+pack-index=2
 locked=true
 
 [Object notification-area]
 object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=top
-position=10
-panel-right-stick=true
+pack-type=end
+pack-index=1
 locked=true
 
 [Object clock]
 object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=top
-position=0
-panel-right-stick=true
+pack-type=end
+pack-index=0
 locked=true
 
 [Object show-desktop]
 object-type=applet
 applet-iid=WnckletFactory::ShowDesktopApplet
 toplevel-id=bottom
-position=0
+pack-index=0
 locked=true
 
 [Object window-list]
 object-type=applet
 applet-iid=WnckletFactory::WindowListApplet
 toplevel-id=bottom
-position=20
+pack-index=1
 locked=true
 
 [Object workspace-switcher]
 object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
-position=0
-panel-right-stick=true
+pack-type=end
+pack-index=0
 locked=true

--- a/data/linuxmint.layout
+++ b/data/linuxmint.layout
@@ -7,35 +7,35 @@ size=24
 object-type=applet
 applet-iid=MintMenuAppletFactory::MintMenuApplet
 toplevel-id=bottom
-position=0
+pack-index=0
 locked=true
 
 [Object show-desktop]
 object-type=applet
 applet-iid=WnckletFactory::ShowDesktopApplet
 toplevel-id=bottom
-position=1
+pack-index=1
 locked=true
 
 [Object window-list]
 object-type=applet
 applet-iid=WnckletFactory::WindowListApplet
 toplevel-id=bottom
-position=20
+pack-index=2
 locked=true
 
 [Object notification-area]
 object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=bottom
-position=10
-panel-right-stick=true
+pack-type=end
+pack-index=1
 locked=true
 
 [Object clock]
 object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=bottom
-position=0
-panel-right-stick=true
+pack-type=end
+pack-index=0
 locked=true

--- a/data/mageia.layout
+++ b/data/mageia.layout
@@ -11,65 +11,64 @@ size=24
 [Object menu-bar]
 object-type=menu-bar
 toplevel-id=top
-position=0
+pack-index=0
 locked=true
 
 [Object mcc]
 object-type=launcher
 launcher-location=/usr/share/applications/mageia-drakconf.desktop
 toplevel-id=top
-position=10
+pack-index=1
 locked=true
 
 [Object terminal]
 object-type=launcher
 launcher-location=/usr/share/applications/mate-terminal.desktop
 toplevel-id=top
-position=20
+pack-index=2
 locked=true
 
 [Object web-browser]
 object-type=launcher
 launcher-location=/usr/share/applications/firefox.desktop
 toplevel-id=top
-position=30
+pack-index=3
 locked=true
 
 [Object notification-area]
 object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=top
-position=10
-panel-right-stick=true
+pack-type=end
+pack-index=1
 locked=true
 
 [Object clock]
 object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=top
-position=0
-panel-right-stick=true
+pack-type=end
+pack-index=0
 locked=true
 
 [Object show-desktop]
 object-type=applet
 applet-iid=WnckletFactory::ShowDesktopApplet
 toplevel-id=bottom
-position=0
+pack-index=0
 locked=true
 
 [Object window-list]
 object-type=applet
 applet-iid=WnckletFactory::WindowListApplet
 toplevel-id=bottom
-position=20
+pack-index=1
 locked=true
 
 [Object workspace-switcher]
 object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
-position=0
-panel-right-stick=true
+pack-type=end
+pack-index=0
 locked=true
-

--- a/data/opensuse.layout
+++ b/data/opensuse.layout
@@ -7,51 +7,51 @@ size=24
 object-type=applet
 applet-iid=MateMenuAppletFactory::MateMenuApplet
 toplevel-id=bottom
-position=0
+pack-index=0
 locked=true
 
 [Object stickynotes]
 object-type=applet
 applet-iid=StickyNotesAppletFactory::StickyNotesApplet
 toplevel-id=bottom
-position=10
+pack-index=1
 locked=true
 
 [Object window-list]
 object-type=applet
 applet-iid=WnckletFactory::WindowListApplet
 toplevel-id=bottom
-position=20
+pack-index=2
 locked=true
 
 [Object notification-area]
 object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=bottom
-position=30
-panel-right-stick=true
+pack-type=end
+pack-index=3
 locked=true
 
 [Object workspace-switcher]
 object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
-position=20
-panel-right-stick=true
+pack-type=end
+pack-index=2
 locked=true
 
 [Object clock]
 object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=bottom
-position=10
-panel-right-stick=true
+pack-type=end
+pack-index=1
 locked=true
 
 [Object show-desktop]
 object-type=applet
 applet-iid=WnckletFactory::ShowDesktopApplet
 toplevel-id=bottom
-position=0
-panel-right-stick=true
+pack-type=end
+pack-index=0
 locked=true

--- a/data/org.mate.panel.object.gschema.xml.in
+++ b/data/org.mate.panel.object.gschema.xml.in
@@ -18,7 +18,7 @@
     <key name="pack-index" type="i">
       <default>0</default>
       <summary>Object's position on the panel</summary>
-      <description>The position of this panel object. The position is specified by the number of pixels from the left (or top if vertical) panel edge.</description>
+      <description>The index of this panel object within the other objects with the same pack-type, from the left (or top if vertical) panel edge.</description>
     </key>
     <key name="position" type="i">
       <default>0</default>

--- a/data/org.mate.panel.object.gschema.xml.in
+++ b/data/org.mate.panel.object.gschema.xml.in
@@ -10,15 +10,20 @@
       <summary>Toplevel panel containing object</summary>
       <description>The identifier of the toplevel panel which contains this object.</description>
     </key>
+    <key name="pack-type" enum="org.mate.panel.PanelObjectPackType">
+      <default>'start'</default>
+      <summary>Interpret position relative to bottom/right edge</summary>
+      <description>If set to 'end', the position of the object is interpreted relative to the right (or bottom if vertical) edge of the panel.</description>
+    </key>
     <key name="position" type="i">
       <default>0</default>
-      <summary>Object's position on the panel</summary>
-      <description>The position of this panel object. The position is specified by the number of pixels from the left (or top if vertical) panel edge.</description>
+      <summary>Object's position on the panel (deprecated)</summary>
+      <description>The position of this panel object. The position is specified by the number of pixels from the left (or top if vertical) panel edge. Deprecated in favor of pack-type and pack-index.</description>
     </key>
     <key name="panel-right-stick" type="b">
       <default>false</default>
-      <summary>Interpret position relative to bottom/right edge</summary>
-      <description>If true, the position of the object is interpreted relative to the right (or bottom if vertical) edge of the panel.</description>
+      <summary>Interpret position relative to bottom/right edge (deprecated)</summary>
+      <description>If true, the position of the object is interpreted relative to the right (or bottom if vertical) edge of the panel. Deprecated in favor of pack-type.</description>
     </key>
     <key name="locked" type="b">
       <default>false</default>

--- a/data/org.mate.panel.object.gschema.xml.in
+++ b/data/org.mate.panel.object.gschema.xml.in
@@ -15,6 +15,11 @@
       <summary>Interpret position relative to bottom/right edge</summary>
       <description>If set to 'end', the position of the object is interpreted relative to the right (or bottom if vertical) edge of the panel.</description>
     </key>
+    <key name="pack-index" type="i">
+      <default>0</default>
+      <summary>Object's position on the panel</summary>
+      <description>The position of this panel object. The position is specified by the number of pixels from the left (or top if vertical) panel edge.</description>
+    </key>
     <key name="position" type="i">
       <default>0</default>
       <summary>Object's position on the panel (deprecated)</summary>

--- a/data/ubuntu.layout
+++ b/data/ubuntu.layout
@@ -11,67 +11,67 @@ size=24
 [Object menu-bar]
 object-type=menu-bar
 toplevel-id=top
-position=0
+pack-index=0
 locked=true
 
 [Object firefox]
 locked=True
-position=10
 launcher-location=/usr/share/applications/firefox.desktop
 toplevel-id=top
 object-type=launcher
 menu-path=applications:/
+pack-index=1
 
 [Object notification-area]
 object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=top
-position=30
-panel-right-stick=true
+pack-type=end
+pack-index=2
 locked=true
 
 [Object clock]
 object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
 toplevel-id=top
-position=20
-panel-right-stick=true
+pack-type=end
+pack-index=1
 locked=true
 
 [Object shutdown]
 action-type=shutdown
 object-type=action
-position=10
-panel-right-stick=true
 toplevel-id=top
+pack-type=end
+pack-index=0
 locked=true
 
 [Object show-desktop]
 object-type=applet
 applet-iid=WnckletFactory::ShowDesktopApplet
 toplevel-id=bottom
-position=0
+pack-index=0
 locked=true
 
 [Object window-list]
 object-type=applet
 applet-iid=WnckletFactory::WindowListApplet
 toplevel-id=bottom
-position=20
+pack-index=1
 locked=true
 
 [Object workspace-switcher]
 object-type=applet
 applet-iid=WnckletFactory::WorkspaceSwitcherApplet
 toplevel-id=bottom
-position=10
-panel-right-stick=true
+pack-type=end
+pack-index=1
 locked=true
 
 [Object trashapplet]
 locked=True
-position=0
 toplevel-id=bottom
 applet-iid=TrashAppletFactory::TrashApplet
 object-type=applet
-panel-right-stick=true
+pack-type=end
+pack-index=0

--- a/mate-panel/applet.c
+++ b/mate-panel/applet.c
@@ -769,6 +769,7 @@ typedef struct {
 	char                *toplevel_id;
 	int                  position;
 	PanelObjectPackType  pack_type;
+	int                  pack_index;
 	guint                locked : 1;
 } MatePanelAppletToLoad;
 
@@ -907,6 +908,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 					applet->locked,
 					applet->position,
 					applet->pack_type,
+					applet->pack_index,
 					applet->id);
 		break;
 	case PANEL_OBJECT_DRAWER:
@@ -914,6 +916,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 					applet->locked,
 					applet->position,
 					applet->pack_type,
+					applet->pack_index,
 					applet->id);
 		break;
 	case PANEL_OBJECT_MENU:
@@ -921,6 +924,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 						   applet->locked,
 						   applet->position,
 						   applet->pack_type,
+						   applet->pack_index,
 						   TRUE,
 						   applet->id);
 		break;
@@ -929,6 +933,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 					  applet->locked,
 					  applet->position,
 					  applet->pack_type,
+					  applet->pack_index,
 					  applet->id);
 		break;
 	case PANEL_OBJECT_ACTION:
@@ -937,6 +942,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 				applet->locked,
 				applet->position,
 				applet->pack_type,
+				applet->pack_index,
 				TRUE,
 				applet->id);
 		break;
@@ -946,6 +952,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 				applet->locked,
 				applet->position,
 				applet->pack_type,
+				applet->pack_index,
 				TRUE,
 				applet->id);
 		break;
@@ -954,6 +961,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 						 applet->locked,
 						 applet->position,
 						 applet->pack_type,
+						 applet->pack_index,
 						 applet->id);
 		break;
 	default:
@@ -974,6 +982,7 @@ mate_panel_applet_queue_applet_to_load (const char          *id,
 					const char          *toplevel_id,
 					int                  position,
 					PanelObjectPackType  pack_type,
+					int                  pack_index,
 					gboolean             locked)
 {
 	MatePanelAppletToLoad *applet;
@@ -990,6 +999,7 @@ mate_panel_applet_queue_applet_to_load (const char          *id,
 	applet->toplevel_id = g_strdup (toplevel_id);
 	applet->position    = position;
 	applet->pack_type   = pack_type;
+	applet->pack_index  = pack_index;
 	applet->locked      = locked != FALSE;
 
 	mate_panel_applets_to_load = g_slist_prepend (mate_panel_applets_to_load, applet);
@@ -1005,7 +1015,14 @@ mate_panel_applet_compare (const MatePanelAppletToLoad *a,
 		return c;
 	else if (a->pack_type != b->pack_type)
 		return a->pack_type - b->pack_type; /* start < center < end */
+	else if (a->pack_index != b->pack_index)
+		/* note: for packed-end, we explicitly want to start loading
+		 * from the right/bottom instead of left/top to avoid moving
+		 * applets that are on the inside; so the maths are good even
+		 * in this case */
+		return a->pack_index - b->pack_index;
 	else
+		/* Fallback to pixel position in case all pack_index are 0. */
 		return a->position - b->position;
 }
 
@@ -1086,11 +1103,10 @@ mate_panel_applet_save_position (AppletInfo *applet_info,
 			    gboolean    immediate)
 {
 	PanelWidget       *panel_widget;
+	AppletData        *applet_data;
 	const char        *toplevel_id;
 	char              *old_toplevel_id;
-	gboolean           right_stick;
 	gboolean           locked;
-	int                position;
 
 	g_return_if_fail (applet_info != NULL);
 
@@ -1112,9 +1128,8 @@ mate_panel_applet_save_position (AppletInfo *applet_info,
 		return;
 
 	panel_widget = mate_panel_applet_get_panel_widget (applet_info);
-
-	/* FIXME: Instead of getting keys, comparing and setting, there
-	   should be a dirty flag */
+	applet_data = g_object_get_data (G_OBJECT (applet_info->widget),
+					 MATE_PANEL_APPLET_DATA);
 
 	old_toplevel_id = g_settings_get_string (applet_info->settings, PANEL_OBJECT_TOPLEVEL_ID_KEY);
 	if (old_toplevel_id == NULL || strcmp (old_toplevel_id, toplevel_id) != 0)
@@ -1122,33 +1137,22 @@ mate_panel_applet_save_position (AppletInfo *applet_info,
 	g_free (old_toplevel_id);
 
 	/* Note: changing some properties of the panel that may not be locked down
-	   (e.g. background) can change the state of the "panel_right_stick" and
-	   "position" properties of an applet that may in fact be locked down.
+	   (e.g. background) can change the state of the "pack-type" and
+	   "pack-index" properties of an applet that may in fact be locked down.
 	   So check if these are writable before attempting to write them */
 
 	locked = panel_widget_get_applet_locked (panel_widget, applet_info->widget) ? 1 : 0;
 	if (g_settings_get_boolean (applet_info->settings, PANEL_OBJECT_LOCKED_KEY) ? 1 : 0 != locked)
 		g_settings_set_boolean (applet_info->settings, PANEL_OBJECT_LOCKED_KEY, locked);
 
-	if (locked) {
-		/* Until position calculations are refactored to fix the issue of the panel applets
-		   getting reordered on resolution changes...
-		   .. don't save position/right-stick on locked applets */
-		return;
-	}
-
-	right_stick = panel_is_applet_right_stick (applet_info->widget) ? 1 : 0;
-	if (g_settings_is_writable (applet_info->settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY) &&
-	    (g_settings_get_boolean (applet_info->settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY) ? 1 : 0) != right_stick)
-		g_settings_set_boolean (applet_info->settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY, right_stick);
-
-	position = mate_panel_applet_get_position (applet_info);
-	if (right_stick && !panel_widget->packed)
-		position = panel_widget->size - position;
-
-	if (g_settings_is_writable (applet_info->settings, PANEL_OBJECT_POSITION_KEY) &&
-	    g_settings_get_int (applet_info->settings, PANEL_OBJECT_POSITION_KEY) != position)
-		g_settings_set_int (applet_info->settings, PANEL_OBJECT_POSITION_KEY, position);
+	if (g_settings_is_writable (applet_info->settings, PANEL_OBJECT_PACK_TYPE_KEY))
+		g_settings_set_enum (applet_info->settings,
+				     PANEL_OBJECT_PACK_TYPE_KEY,
+				     applet_data->pack_type);
+	if (g_settings_is_writable (applet_info->settings, PANEL_OBJECT_PACK_INDEX_KEY))
+		g_settings_set_int (applet_info->settings,
+				    PANEL_OBJECT_PACK_INDEX_KEY,
+				    applet_data->pack_index);
 }
 
 const char *
@@ -1227,6 +1231,7 @@ mate_panel_applet_register (GtkWidget           *applet,
 			    gboolean             locked,
 			    gint                 pos,
 			    PanelObjectPackType  pack_type,
+			    int                  pack_index,
 			    gboolean             exactpos,
 			    PanelObjectType      type,
 			    const char          *id)
@@ -1288,14 +1293,14 @@ mate_panel_applet_register (GtkWidget           *applet,
 
 	registered_applets = g_slist_append (registered_applets, info);
 
-	if (panel_widget_add (panel, applet, locked, pos, pack_type, exactpos) == -1 &&
-	    panel_widget_add (panel, applet, locked, 0, PANEL_OBJECT_PACK_START, FALSE) == -1) {
+	if (panel_widget_add (panel, applet, locked, pos, pack_type, pack_index, exactpos) == -1 &&
+	    panel_widget_add (panel, applet, locked, 0, PANEL_OBJECT_PACK_START, 0, FALSE) == -1) {
 		GSList *l;
 
 		for (l = panels; l; l = l->next) {
 			panel = PANEL_WIDGET (l->data);
 
-			if (panel_widget_add (panel, applet, locked, 0, PANEL_OBJECT_PACK_START, FALSE) != -1)
+			if (panel_widget_add (panel, applet, locked, 0, PANEL_OBJECT_PACK_START, 0, FALSE) != -1)
 				break;
 		}
 
@@ -1356,13 +1361,13 @@ mate_panel_applet_can_freely_move (AppletInfo *applet)
 	if (panel_lockdown_get_locked_down ())
 		return FALSE;
 
-	if (!g_settings_is_writable (applet->settings, PANEL_OBJECT_POSITION_KEY))
+	if (!g_settings_is_writable (applet->settings, PANEL_OBJECT_PACK_TYPE_KEY))
+		return FALSE;
+
+	if (!g_settings_is_writable (applet->settings, PANEL_OBJECT_PACK_INDEX_KEY))
 		return FALSE;
 
 	if (!g_settings_is_writable (applet->settings, PANEL_OBJECT_TOPLEVEL_ID_KEY))
-		return FALSE;
-
-	if (!g_settings_is_writable (applet->settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY))
 		return FALSE;
 
 	return TRUE;

--- a/mate-panel/applet.c
+++ b/mate-panel/applet.c
@@ -764,12 +764,12 @@ mate_panel_applet_destroy (GtkWidget  *widget,
 }
 
 typedef struct {
-	char            *id;
-	PanelObjectType  type;
-	char            *toplevel_id;
-	int              position;
-	guint            right_stick : 1;
-	guint            locked : 1;
+	char                *id;
+	PanelObjectType      type;
+	char                *toplevel_id;
+	int                  position;
+	PanelObjectPackType  pack_type;
+	guint                locked : 1;
 } MatePanelAppletToLoad;
 
 /* Each time those lists get both empty,
@@ -892,13 +892,6 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 
 	panel_widget = panel_toplevel_get_panel_widget (toplevel);
 
-	if (applet->right_stick) {
-		if (!panel_widget->packed)
-			applet->position = panel_widget->size - applet->position;
-		else
-			applet->position = -1;
-	}
-
 	/* We load applets asynchronously, so we specifically don't call
 	 * mate_panel_applet_stop_loading() for this type. However, in case of
 	 * failure during the load, we might call mate_panel_applet_stop_loading()
@@ -913,18 +906,21 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 					panel_widget,
 					applet->locked,
 					applet->position,
+					applet->pack_type,
 					applet->id);
 		break;
 	case PANEL_OBJECT_DRAWER:
 		drawer_load_from_gsettings (panel_widget,
 					applet->locked,
 					applet->position,
+					applet->pack_type,
 					applet->id);
 		break;
 	case PANEL_OBJECT_MENU:
 		panel_menu_button_load_from_gsettings (panel_widget,
 						   applet->locked,
 						   applet->position,
+						   applet->pack_type,
 						   TRUE,
 						   applet->id);
 		break;
@@ -932,6 +928,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 		launcher_load_from_gsettings (panel_widget,
 					  applet->locked,
 					  applet->position,
+					  applet->pack_type,
 					  applet->id);
 		break;
 	case PANEL_OBJECT_ACTION:
@@ -939,6 +936,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 				panel_widget,
 				applet->locked,
 				applet->position,
+				applet->pack_type,
 				TRUE,
 				applet->id);
 		break;
@@ -947,6 +945,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 				panel_widget,
 				applet->locked,
 				applet->position,
+				applet->pack_type,
 				TRUE,
 				applet->id);
 		break;
@@ -954,6 +953,7 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 		panel_separator_load_from_gsettings (panel_widget,
 						 applet->locked,
 						 applet->position,
+						 applet->pack_type,
 						 applet->id);
 		break;
 	default:
@@ -969,12 +969,12 @@ mate_panel_applet_load_idle_handler (gpointer dummy)
 }
 
 void
-mate_panel_applet_queue_applet_to_load (const char      *id,
-				   PanelObjectType  type,
-				   const char      *toplevel_id,
-				   int              position,
-				   gboolean         right_stick,
-				   gboolean         locked)
+mate_panel_applet_queue_applet_to_load (const char          *id,
+					PanelObjectType      type,
+					const char          *toplevel_id,
+					int                  position,
+					PanelObjectPackType  pack_type,
+					gboolean             locked)
 {
 	MatePanelAppletToLoad *applet;
 
@@ -989,7 +989,7 @@ mate_panel_applet_queue_applet_to_load (const char      *id,
 	applet->type        = type;
 	applet->toplevel_id = g_strdup (toplevel_id);
 	applet->position    = position;
-	applet->right_stick = right_stick != FALSE;
+	applet->pack_type   = pack_type;
 	applet->locked      = locked != FALSE;
 
 	mate_panel_applets_to_load = g_slist_prepend (mate_panel_applets_to_load, applet);
@@ -1003,8 +1003,8 @@ mate_panel_applet_compare (const MatePanelAppletToLoad *a,
 
 	if ((c = strcmp (a->toplevel_id, b->toplevel_id)))
 		return c;
-	else if (a->right_stick != b->right_stick)
-		return b->right_stick ? -1 : 1;
+	else if (a->pack_type != b->pack_type)
+		return a->pack_type - b->pack_type; /* start < center < end */
 	else
 		return a->position - b->position;
 }
@@ -1220,15 +1220,16 @@ mate_panel_applet_get_by_type (PanelObjectType object_type, GdkScreen *screen)
 }
 
 AppletInfo *
-mate_panel_applet_register (GtkWidget       *applet,
-		       gpointer         data,
-		       GDestroyNotify   data_destroy,
-		       PanelWidget     *panel,
-		       gboolean         locked,
-		       gint             pos,
-		       gboolean         exactpos,
-		       PanelObjectType  type,
-		       const char      *id)
+mate_panel_applet_register (GtkWidget           *applet,
+			    gpointer             data,
+			    GDestroyNotify       data_destroy,
+			    PanelWidget         *panel,
+			    gboolean             locked,
+			    gint                 pos,
+			    PanelObjectPackType  pack_type,
+			    gboolean             exactpos,
+			    PanelObjectType      type,
+			    const char          *id)
 {
 	AppletInfo *info;
 	gchar *path;
@@ -1287,14 +1288,14 @@ mate_panel_applet_register (GtkWidget       *applet,
 
 	registered_applets = g_slist_append (registered_applets, info);
 
-	if (panel_widget_add (panel, applet, locked, pos, exactpos) == -1 &&
-	    panel_widget_add (panel, applet, locked, 0, TRUE) == -1) {
+	if (panel_widget_add (panel, applet, locked, pos, pack_type, exactpos) == -1 &&
+	    panel_widget_add (panel, applet, locked, 0, PANEL_OBJECT_PACK_START, FALSE) == -1) {
 		GSList *l;
 
 		for (l = panels; l; l = l->next) {
 			panel = PANEL_WIDGET (l->data);
 
-			if (panel_widget_add (panel, applet, locked, 0, TRUE) != -1)
+			if (panel_widget_add (panel, applet, locked, 0, PANEL_OBJECT_PACK_START, FALSE) != -1)
 				break;
 		}
 

--- a/mate-panel/applet.h
+++ b/mate-panel/applet.h
@@ -47,15 +47,16 @@ typedef struct {
 	GtkWidget           *submenu;
 } AppletUserMenu;
 
-AppletInfo *mate_panel_applet_register    (GtkWidget       *applet,
-				      gpointer         data,
-				      GDestroyNotify   data_destroy,
-				      PanelWidget     *panel,
-				      gboolean         locked,
-				      gint             pos,
-				      gboolean         exactpos,
-				      PanelObjectType  type,
-				      const char      *id);
+AppletInfo *mate_panel_applet_register (GtkWidget           *applet,
+					gpointer             data,
+					GDestroyNotify       data_destroy,
+					PanelWidget         *panel,
+					gboolean             locked,
+					gint                 pos,
+					PanelObjectPackType  pack_type,
+					gboolean             exactpos,
+					PanelObjectType      type,
+					const char          *id);
 void mate_panel_applet_stop_loading (const char *id);
 
 const char *mate_panel_applet_get_id           (AppletInfo      *info);
@@ -67,12 +68,12 @@ GSList     *mate_panel_applet_list_applets (void);
 
 void        mate_panel_applet_clean        (AppletInfo    *info);
 
-void mate_panel_applet_queue_applet_to_load (const char      *id,
-					PanelObjectType  type,
-					const char      *toplevel_id,
-					int              position,
-					gboolean         right_stick,
-					gboolean         locked);
+void mate_panel_applet_queue_applet_to_load (const char          *id,
+					     PanelObjectType      type,
+					     const char          *toplevel_id,
+					     int                  position,
+					     PanelObjectPackType  pack_type,
+					     gboolean             locked);
 void mate_panel_applet_load_queued_applets  (gboolean initial_load);
 gboolean mate_panel_applet_on_load_queue    (const char *id);
 

--- a/mate-panel/applet.h
+++ b/mate-panel/applet.h
@@ -54,6 +54,7 @@ AppletInfo *mate_panel_applet_register (GtkWidget           *applet,
 					gboolean             locked,
 					gint                 pos,
 					PanelObjectPackType  pack_type,
+					int                  pack_index,
 					gboolean             exactpos,
 					PanelObjectType      type,
 					const char          *id);
@@ -73,6 +74,7 @@ void mate_panel_applet_queue_applet_to_load (const char          *id,
 					     const char          *toplevel_id,
 					     int                  position,
 					     PanelObjectPackType  pack_type,
+					     int                  pack_index,
 					     gboolean             locked);
 void mate_panel_applet_load_queued_applets  (gboolean initial_load);
 gboolean mate_panel_applet_on_load_queue    (const char *id);
@@ -95,7 +97,7 @@ void        mate_panel_applet_save_position           (AppletInfo *applet_info,
 int         mate_panel_applet_get_position    (AppletInfo *applet);
 
 /* True if all the keys relevant to moving are writable
-   (position, toplevel_id, panel_right_stick) */
+   (pack_type, pack_index, toplevel_id) */
 gboolean    mate_panel_applet_can_freely_move (AppletInfo *applet);
 
 /* True if the locked flag is writable */

--- a/mate-panel/drawer-private.h
+++ b/mate-panel/drawer-private.h
@@ -129,6 +129,7 @@ static void  load_drawer_applet                 (char             *toplevel_id,
                                                  gboolean          locked,
                                                  int               pos,
                                                  PanelObjectPackType pack_type,
+                                                 int               pack_index,
                                                  gboolean          exactpos,
                                                  const char       *id);
 

--- a/mate-panel/drawer-private.h
+++ b/mate-panel/drawer-private.h
@@ -128,6 +128,7 @@ static void  load_drawer_applet                 (char             *toplevel_id,
                                                  PanelToplevel    *parent_toplevel,
                                                  gboolean          locked,
                                                  int               pos,
+                                                 PanelObjectPackType pack_type,
                                                  gboolean          exactpos,
                                                  const char       *id);
 

--- a/mate-panel/drawer.c
+++ b/mate-panel/drawer.c
@@ -493,6 +493,7 @@ load_drawer_applet (char          *toplevel_id,
                     gboolean       locked,
                     int            pos,
                     PanelObjectPackType pack_type,
+                    int            pack_index,
                     gboolean       exactpos,
                     const char    *id)
 {
@@ -527,7 +528,7 @@ load_drawer_applet (char          *toplevel_id,
     drawer->info = mate_panel_applet_register (drawer->button, drawer,
                                           (GDestroyNotify) g_free,
                                           panel_widget,
-                                          locked, pos, pack_type, exactpos,
+                                          locked, pos, pack_type, pack_index, exactpos,
                                           PANEL_OBJECT_DRAWER, id);
 
     if (!drawer->info) {
@@ -624,7 +625,7 @@ panel_drawer_create (PanelToplevel *toplevel,
     char *id;
 
     id = panel_profile_prepare_object (PANEL_OBJECT_DRAWER, toplevel, position,
-                                       PANEL_OBJECT_PACK_START);
+                                       PANEL_OBJECT_PACK_START, 0);
 
     panel_drawer_prepare (id, custom_icon, use_custom_icon, tooltip, NULL);
 
@@ -644,7 +645,7 @@ panel_drawer_create_with_id (const char    *toplevel_id,
     char *attached_toplevel_id = NULL;
 
     id = panel_profile_prepare_object_with_id (PANEL_OBJECT_DRAWER, toplevel_id, position,
-                                               PANEL_OBJECT_PACK_START);
+                                               PANEL_OBJECT_PACK_START, 0);
 
     panel_drawer_prepare (id, custom_icon, use_custom_icon, tooltip, &attached_toplevel_id);
 
@@ -660,6 +661,7 @@ drawer_load_from_gsettings (PanelWidget *panel_widget,
                             gboolean     locked,
                             gint         position,
                             PanelObjectPackType pack_type,
+                            int          pack_index,
                             const char  *id)
 {
     gboolean     use_custom_icon;
@@ -694,6 +696,7 @@ drawer_load_from_gsettings (PanelWidget *panel_widget,
                         locked,
                         position,
                         pack_type,
+                        pack_index,
                         TRUE,
                         id);
 

--- a/mate-panel/drawer.c
+++ b/mate-panel/drawer.c
@@ -623,9 +623,14 @@ panel_drawer_create (PanelToplevel *toplevel,
                      const char    *tooltip)
 {
     char *id;
+    PanelObjectPackType pack_type = PANEL_OBJECT_PACK_START;
+    int pack_index = 0;
+
+    panel_widget_get_insert_at_pos (panel_toplevel_get_panel_widget (toplevel),
+                                    &pack_type, &pack_index, position);
 
     id = panel_profile_prepare_object (PANEL_OBJECT_DRAWER, toplevel, position,
-                                       PANEL_OBJECT_PACK_START, 0);
+                                       pack_type, pack_index);
 
     panel_drawer_prepare (id, custom_icon, use_custom_icon, tooltip, NULL);
 
@@ -643,9 +648,17 @@ panel_drawer_create_with_id (const char    *toplevel_id,
 {
     char *id;
     char *attached_toplevel_id = NULL;
+    PanelObjectPackType pack_type = PANEL_OBJECT_PACK_START;
+    int pack_index = 0;
+    PanelToplevel *toplevel;
+
+    toplevel = panel_profile_get_toplevel_by_id (toplevel_id);
+    if (toplevel)
+        panel_widget_get_insert_at_pos (panel_toplevel_get_panel_widget (toplevel),
+                                      &pack_type, &pack_index, position);
 
     id = panel_profile_prepare_object_with_id (PANEL_OBJECT_DRAWER, toplevel_id, position,
-                                               PANEL_OBJECT_PACK_START, 0);
+                                               pack_type, pack_index);
 
     panel_drawer_prepare (id, custom_icon, use_custom_icon, tooltip, &attached_toplevel_id);
 

--- a/mate-panel/drawer.c
+++ b/mate-panel/drawer.c
@@ -622,7 +622,8 @@ panel_drawer_create (PanelToplevel *toplevel,
 {
     char *id;
 
-    id = panel_profile_prepare_object (PANEL_OBJECT_DRAWER, toplevel, position, FALSE);
+    id = panel_profile_prepare_object (PANEL_OBJECT_DRAWER, toplevel, position,
+                                       PANEL_OBJECT_PACK_START);
 
     panel_drawer_prepare (id, custom_icon, use_custom_icon, tooltip, NULL);
 
@@ -641,7 +642,8 @@ panel_drawer_create_with_id (const char    *toplevel_id,
     char *id;
     char *attached_toplevel_id = NULL;
 
-    id = panel_profile_prepare_object_with_id (PANEL_OBJECT_DRAWER, toplevel_id, position, FALSE);
+    id = panel_profile_prepare_object_with_id (PANEL_OBJECT_DRAWER, toplevel_id, position,
+                                               PANEL_OBJECT_PACK_START);
 
     panel_drawer_prepare (id, custom_icon, use_custom_icon, tooltip, &attached_toplevel_id);
 

--- a/mate-panel/drawer.c
+++ b/mate-panel/drawer.c
@@ -492,6 +492,7 @@ load_drawer_applet (char          *toplevel_id,
                     PanelToplevel *parent_toplevel,
                     gboolean       locked,
                     int            pos,
+                    PanelObjectPackType pack_type,
                     gboolean       exactpos,
                     const char    *id)
 {
@@ -526,7 +527,7 @@ load_drawer_applet (char          *toplevel_id,
     drawer->info = mate_panel_applet_register (drawer->button, drawer,
                                           (GDestroyNotify) g_free,
                                           panel_widget,
-                                          locked, pos, exactpos,
+                                          locked, pos, pack_type, exactpos,
                                           PANEL_OBJECT_DRAWER, id);
 
     if (!drawer->info) {
@@ -658,6 +659,7 @@ void
 drawer_load_from_gsettings (PanelWidget *panel_widget,
                             gboolean     locked,
                             gint         position,
+                            PanelObjectPackType pack_type,
                             const char  *id)
 {
     gboolean     use_custom_icon;
@@ -691,6 +693,7 @@ drawer_load_from_gsettings (PanelWidget *panel_widget,
                         panel_widget->toplevel,
                         locked,
                         position,
+                        pack_type,
                         TRUE,
                         id);
 

--- a/mate-panel/drawer.h
+++ b/mate-panel/drawer.h
@@ -37,6 +37,7 @@ void  drawer_load_from_gsettings                (PanelWidget      *panel_widget,
                                                  gboolean          locked,
                                                  gint              position,
                                                  PanelObjectPackType pack_type,
+                                                 int               pack_index,
                                                  const char       *id);
 
 void  panel_drawer_set_dnd_enabled              (Drawer           *drawer,

--- a/mate-panel/drawer.h
+++ b/mate-panel/drawer.h
@@ -36,6 +36,7 @@ char *panel_drawer_create_with_id               (const char       *toplevel_id,
 void  drawer_load_from_gsettings                (PanelWidget      *panel_widget,
                                                  gboolean          locked,
                                                  gint              position,
+                                                 PanelObjectPackType pack_type,
                                                  const char       *id);
 
 void  panel_drawer_set_dnd_enabled              (Drawer           *drawer,

--- a/mate-panel/launcher.c
+++ b/mate-panel/launcher.c
@@ -1094,7 +1094,7 @@ panel_launcher_create_with_id (const char    *toplevel_id,
 	id = panel_profile_prepare_object_with_id (PANEL_OBJECT_LAUNCHER,
 						   toplevel_id,
 						   position,
-						   FALSE);
+						   PANEL_OBJECT_PACK_START);
 
 	path = g_strdup_printf ("%s%s/", PANEL_OBJECT_PATH, id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/launcher.c
+++ b/mate-panel/launcher.c
@@ -881,6 +881,7 @@ load_launcher_applet (const char       *location,
 		      gboolean          locked,
 		      int               pos,
 		      PanelObjectPackType pack_type,
+		      int               pack_index,
 		      gboolean          exactpos,
 		      const char       *id)
 {
@@ -893,7 +894,7 @@ load_launcher_applet (const char       *location,
 
 	launcher->info = mate_panel_applet_register (launcher->button, launcher,
 						free_launcher,
-						panel, locked, pos, pack_type, exactpos,
+						panel, locked, pos, pack_type, pack_index, exactpos,
 						PANEL_OBJECT_LAUNCHER, id);
 	if (!launcher->info) {
 		free_launcher (launcher);
@@ -919,6 +920,7 @@ launcher_load_from_gsettings (PanelWidget *panel_widget,
 			      gboolean     locked,
 			      int          position,
 			      PanelObjectPackType pack_type,
+			      int          pack_index,
 			      const char  *id)
 {
 	GSettings   *settings;
@@ -947,6 +949,7 @@ launcher_load_from_gsettings (PanelWidget *panel_widget,
 					 locked,
 					 position,
 					 pack_type,
+					 pack_index,
 					 TRUE,
 					 id);
 
@@ -1097,7 +1100,7 @@ panel_launcher_create_with_id (const char    *toplevel_id,
 	id = panel_profile_prepare_object_with_id (PANEL_OBJECT_LAUNCHER,
 						   toplevel_id,
 						   position,
-						   PANEL_OBJECT_PACK_START);
+						   PANEL_OBJECT_PACK_START, 0);
 
 	path = g_strdup_printf ("%s%s/", PANEL_OBJECT_PATH, id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/launcher.c
+++ b/mate-panel/launcher.c
@@ -1094,13 +1094,21 @@ panel_launcher_create_with_id (const char    *toplevel_id,
 	char        *id;
 	char        *no_uri;
 	char        *new_location;
+	PanelObjectPackType pack_type = PANEL_OBJECT_PACK_START;
+	int pack_index = 0;
+	PanelToplevel *toplevel;
 
 	g_return_if_fail (location != NULL);
+
+	toplevel = panel_profile_get_toplevel_by_id (toplevel_id);
+	if (toplevel)
+		panel_widget_get_insert_at_pos (panel_toplevel_get_panel_widget (toplevel),
+					      &pack_type, &pack_index, position);
 
 	id = panel_profile_prepare_object_with_id (PANEL_OBJECT_LAUNCHER,
 						   toplevel_id,
 						   position,
-						   PANEL_OBJECT_PACK_START, 0);
+						   pack_type, pack_index);
 
 	path = g_strdup_printf ("%s%s/", PANEL_OBJECT_PATH, id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/launcher.c
+++ b/mate-panel/launcher.c
@@ -880,6 +880,7 @@ load_launcher_applet (const char       *location,
 		      PanelWidget      *panel,
 		      gboolean          locked,
 		      int               pos,
+		      PanelObjectPackType pack_type,
 		      gboolean          exactpos,
 		      const char       *id)
 {
@@ -892,7 +893,7 @@ load_launcher_applet (const char       *location,
 
 	launcher->info = mate_panel_applet_register (launcher->button, launcher,
 						free_launcher,
-						panel, locked, pos, exactpos,
+						panel, locked, pos, pack_type, exactpos,
 						PANEL_OBJECT_LAUNCHER, id);
 	if (!launcher->info) {
 		free_launcher (launcher);
@@ -917,6 +918,7 @@ void
 launcher_load_from_gsettings (PanelWidget *panel_widget,
 			      gboolean     locked,
 			      int          position,
+			      PanelObjectPackType pack_type,
 			      const char  *id)
 {
 	GSettings   *settings;
@@ -944,6 +946,7 @@ launcher_load_from_gsettings (PanelWidget *panel_widget,
 					 panel_widget,
 					 locked,
 					 position,
+					 pack_type,
 					 TRUE,
 					 id);
 

--- a/mate-panel/launcher.h
+++ b/mate-panel/launcher.h
@@ -58,6 +58,7 @@ void		launcher_properties		(Launcher  *launcher);
 void            launcher_load_from_gsettings        (PanelWidget *panel_widget,
 													 gboolean     locked,
 													 gint         position,
+													 PanelObjectPackType pack_type,
 													 const char  *id);
 
 void            panel_launcher_delete           (Launcher *launcher);

--- a/mate-panel/launcher.h
+++ b/mate-panel/launcher.h
@@ -59,6 +59,7 @@ void            launcher_load_from_gsettings        (PanelWidget *panel_widget,
 													 gboolean     locked,
 													 gint         position,
 													 PanelObjectPackType pack_type,
+													 int          pack_index,
 													 const char  *id);
 
 void            panel_launcher_delete           (Launcher *launcher);

--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -943,7 +943,8 @@ panel_action_button_create (PanelToplevel         *toplevel,
 	char        *id;
 	char        *path;
 
-	id = panel_profile_prepare_object (PANEL_OBJECT_ACTION, toplevel, position, FALSE);
+	id = panel_profile_prepare_object (PANEL_OBJECT_ACTION, toplevel, position,
+					   PANEL_OBJECT_PACK_START);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -898,6 +898,7 @@ panel_action_button_load (PanelActionButtonType  type,
 			  PanelWidget           *panel,
 			  gboolean               locked,
 			  int                    position,
+			  PanelObjectPackType    pack_type,
 			  gboolean               exactpos,
 			  const char            *id)
 {
@@ -910,7 +911,7 @@ panel_action_button_load (PanelActionButtonType  type,
 	button->priv->info = mate_panel_applet_register (GTK_WIDGET (button),
 						    NULL, NULL,
 						    panel, locked, position,
-						    exactpos, PANEL_OBJECT_ACTION, id);
+						    pack_type, exactpos, PANEL_OBJECT_ACTION, id);
 	if (!button->priv->info) {
 		gtk_widget_destroy (GTK_WIDGET (button));
 		return;
@@ -964,6 +965,7 @@ void
 panel_action_button_load_from_gsettings (PanelWidget *panel,
 				     gboolean     locked,
 				     int          position,
+				     PanelObjectPackType pack_type,
 				     gboolean     exactpos,
 				     const char  *id)
 {
@@ -980,7 +982,7 @@ panel_action_button_load_from_gsettings (PanelWidget *panel,
 	g_object_unref (settings);
 
 	panel_action_button_load (type, panel, locked,
-					  position, exactpos, id);
+				  position, pack_type, exactpos, id);
 }
 
 void

--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -944,9 +944,14 @@ panel_action_button_create (PanelToplevel         *toplevel,
 	GSettings   *settings;
 	char        *id;
 	char        *path;
+	PanelObjectPackType pack_type = PANEL_OBJECT_PACK_START;
+	int pack_index = 0;
+
+	panel_widget_get_insert_at_pos (panel_toplevel_get_panel_widget (toplevel),
+				      &pack_type, &pack_index, position);
 
 	id = panel_profile_prepare_object (PANEL_OBJECT_ACTION, toplevel, position,
-					   PANEL_OBJECT_PACK_START, 0);
+					   pack_type, pack_index);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -899,6 +899,7 @@ panel_action_button_load (PanelActionButtonType  type,
 			  gboolean               locked,
 			  int                    position,
 			  PanelObjectPackType    pack_type,
+			  int                    pack_index,
 			  gboolean               exactpos,
 			  const char            *id)
 {
@@ -911,7 +912,7 @@ panel_action_button_load (PanelActionButtonType  type,
 	button->priv->info = mate_panel_applet_register (GTK_WIDGET (button),
 						    NULL, NULL,
 						    panel, locked, position,
-						    pack_type, exactpos, PANEL_OBJECT_ACTION, id);
+						    pack_type, pack_index, exactpos, PANEL_OBJECT_ACTION, id);
 	if (!button->priv->info) {
 		gtk_widget_destroy (GTK_WIDGET (button));
 		return;
@@ -945,7 +946,7 @@ panel_action_button_create (PanelToplevel         *toplevel,
 	char        *path;
 
 	id = panel_profile_prepare_object (PANEL_OBJECT_ACTION, toplevel, position,
-					   PANEL_OBJECT_PACK_START);
+					   PANEL_OBJECT_PACK_START, 0);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);
@@ -966,6 +967,7 @@ panel_action_button_load_from_gsettings (PanelWidget *panel,
 				     gboolean     locked,
 				     int          position,
 				     PanelObjectPackType pack_type,
+				     int          pack_index,
 				     gboolean     exactpos,
 				     const char  *id)
 {
@@ -982,7 +984,7 @@ panel_action_button_load_from_gsettings (PanelWidget *panel,
 	g_object_unref (settings);
 
 	panel_action_button_load (type, panel, locked,
-				  position, pack_type, exactpos, id);
+				  position, pack_type, pack_index, exactpos, id);
 }
 
 void

--- a/mate-panel/panel-action-button.h
+++ b/mate-panel/panel-action-button.h
@@ -70,6 +70,7 @@ void       panel_action_button_load_from_gsettings  (PanelWidget            *pan
 						 gboolean                locked,
 						 int                     position,
 						 PanelObjectPackType     pack_type,
+						 int                     pack_index,
 						 gboolean                exactpos,
 						 const char             *id);
 

--- a/mate-panel/panel-action-button.h
+++ b/mate-panel/panel-action-button.h
@@ -69,6 +69,7 @@ void       panel_action_button_set_type         (PanelActionButton     *button,
 void       panel_action_button_load_from_gsettings  (PanelWidget            *panel,
 						 gboolean                locked,
 						 int                     position,
+						 PanelObjectPackType     pack_type,
 						 gboolean                exactpos,
 						 const char             *id);
 

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -1073,7 +1073,8 @@ mate_panel_applet_frame_create (PanelToplevel *toplevel,
 
 	g_return_if_fail (iid != NULL);
 
-	id = panel_profile_prepare_object (PANEL_OBJECT_APPLET, toplevel, position, FALSE);
+	id = panel_profile_prepare_object (PANEL_OBJECT_APPLET, toplevel, position,
+					   PANEL_OBJECT_PACK_START);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -65,6 +65,7 @@ static void mate_panel_applet_frame_load            (const gchar *iid,
 						gboolean     locked,
 						int          position,
 						PanelObjectPackType pack_type,
+						int          pack_index,
 						gboolean     exactpos,
 						const char  *id);
 
@@ -73,6 +74,7 @@ struct _MatePanelAppletFrameActivating {
 	PanelWidget *panel;
 	int          position;
 	PanelObjectPackType pack_type;
+	int          pack_index;
 	gboolean     exactpos;
 	char        *id;
 };
@@ -586,7 +588,8 @@ _mate_panel_applet_frame_activated (MatePanelAppletFrame           *frame,
 	info = mate_panel_applet_register (GTK_WIDGET (frame), GTK_WIDGET (frame),
 				      NULL, frame->priv->panel,
 				      frame_act->locked, frame_act->position,
-				      frame_act->pack_type, frame_act->exactpos,
+				      frame_act->pack_type, frame_act->pack_index,
+				      frame_act->exactpos,
 				      PANEL_OBJECT_APPLET, frame_act->id);
 	frame->priv->applet_info = info;
 
@@ -719,8 +722,20 @@ mate_panel_applet_frame_reload_response (GtkWidget        *dialog,
 			mate_panel_applet_clean (info);
 		}
 
+		AppletData *applet_data;
+		PanelObjectPackType pack_type = PANEL_OBJECT_PACK_START;
+		int pack_idx = 0;
+
+		if (info) {
+			applet_data = g_object_get_data (G_OBJECT (info->widget), MATE_PANEL_APPLET_DATA);
+			if (applet_data) {
+				pack_type = applet_data->pack_type;
+				pack_idx  = applet_data->pack_index;
+			}
+		}
+
 		mate_panel_applet_frame_load (iid, panel, locked,
-					 position, PANEL_OBJECT_PACK_START, TRUE, id);
+					 position, pack_type, pack_idx, TRUE, id);
 
 		g_free (iid);
 		g_free (id);
@@ -1002,6 +1017,7 @@ mate_panel_applet_frame_load (const gchar *iid,
 			 gboolean     locked,
 			 int          position,
 			 PanelObjectPackType pack_type,
+			 int          pack_index,
 			 gboolean     exactpos,
 			 const char  *id)
 {
@@ -1023,12 +1039,13 @@ mate_panel_applet_frame_load (const gchar *iid,
 	}
 
 	frame_act = g_slice_new0 (MatePanelAppletFrameActivating);
-	frame_act->locked    = locked;
-	frame_act->panel     = panel;
-	frame_act->position  = position;
-	frame_act->pack_type = pack_type;
-	frame_act->exactpos  = exactpos;
-	frame_act->id       = g_strdup (id);
+	frame_act->locked     = locked;
+	frame_act->panel      = panel;
+	frame_act->position   = position;
+	frame_act->pack_type  = pack_type;
+	frame_act->pack_index = pack_index;
+	frame_act->exactpos   = exactpos;
+	frame_act->id        = g_strdup (id);
 
 	if (!mate_panel_applets_manager_load_applet (iid, frame_act)) {
 		mate_panel_applet_frame_loading_failed (iid, panel, id);
@@ -1041,6 +1058,7 @@ mate_panel_applet_frame_load_from_gsettings (PanelWidget *panel_widget,
 				    gboolean     locked,
 				    int          position,
 				    PanelObjectPackType pack_type,
+				    int          pack_index,
 				    const char  *id)
 {
 	GSettings *settings;
@@ -1062,7 +1080,7 @@ mate_panel_applet_frame_load_from_gsettings (PanelWidget *panel_widget,
 	}
 
 	mate_panel_applet_frame_load (applet_iid, panel_widget,
-				 locked, position, pack_type, TRUE, id);
+				 locked, position, pack_type, pack_index, TRUE, id);
 
 	g_free (applet_iid);
 }
@@ -1079,7 +1097,7 @@ mate_panel_applet_frame_create (PanelToplevel *toplevel,
 	g_return_if_fail (iid != NULL);
 
 	id = panel_profile_prepare_object (PANEL_OBJECT_APPLET, toplevel, position,
-					   PANEL_OBJECT_PACK_START);
+					   PANEL_OBJECT_PACK_START, 0);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -64,6 +64,7 @@ static void mate_panel_applet_frame_load            (const gchar *iid,
 						PanelWidget *panel,
 						gboolean     locked,
 						int          position,
+						PanelObjectPackType pack_type,
 						gboolean     exactpos,
 						const char  *id);
 
@@ -71,6 +72,7 @@ struct _MatePanelAppletFrameActivating {
 	gboolean     locked;
 	PanelWidget *panel;
 	int          position;
+	PanelObjectPackType pack_type;
 	gboolean     exactpos;
 	char        *id;
 };
@@ -584,8 +586,8 @@ _mate_panel_applet_frame_activated (MatePanelAppletFrame           *frame,
 	info = mate_panel_applet_register (GTK_WIDGET (frame), GTK_WIDGET (frame),
 				      NULL, frame->priv->panel,
 				      frame_act->locked, frame_act->position,
-				      frame_act->exactpos, PANEL_OBJECT_APPLET,
-				      frame_act->id);
+				      frame_act->pack_type, frame_act->exactpos,
+				      PANEL_OBJECT_APPLET, frame_act->id);
 	frame->priv->applet_info = info;
 
 	panel_widget_set_applet_size_constrained (frame->priv->panel,
@@ -718,7 +720,7 @@ mate_panel_applet_frame_reload_response (GtkWidget        *dialog,
 		}
 
 		mate_panel_applet_frame_load (iid, panel, locked,
-					 position, TRUE, id);
+					 position, PANEL_OBJECT_PACK_START, TRUE, id);
 
 		g_free (iid);
 		g_free (id);
@@ -999,6 +1001,7 @@ mate_panel_applet_frame_load (const gchar *iid,
 			 PanelWidget *panel,
 			 gboolean     locked,
 			 int          position,
+			 PanelObjectPackType pack_type,
 			 gboolean     exactpos,
 			 const char  *id)
 {
@@ -1020,10 +1023,11 @@ mate_panel_applet_frame_load (const gchar *iid,
 	}
 
 	frame_act = g_slice_new0 (MatePanelAppletFrameActivating);
-	frame_act->locked   = locked;
-	frame_act->panel    = panel;
-	frame_act->position = position;
-	frame_act->exactpos = exactpos;
+	frame_act->locked    = locked;
+	frame_act->panel     = panel;
+	frame_act->position  = position;
+	frame_act->pack_type = pack_type;
+	frame_act->exactpos  = exactpos;
 	frame_act->id       = g_strdup (id);
 
 	if (!mate_panel_applets_manager_load_applet (iid, frame_act)) {
@@ -1036,6 +1040,7 @@ void
 mate_panel_applet_frame_load_from_gsettings (PanelWidget *panel_widget,
 				    gboolean     locked,
 				    int          position,
+				    PanelObjectPackType pack_type,
 				    const char  *id)
 {
 	GSettings *settings;
@@ -1057,7 +1062,7 @@ mate_panel_applet_frame_load_from_gsettings (PanelWidget *panel_widget,
 	}
 
 	mate_panel_applet_frame_load (applet_iid, panel_widget,
-				 locked, position, TRUE, id);
+				 locked, position, pack_type, TRUE, id);
 
 	g_free (applet_iid);
 }

--- a/mate-panel/panel-applet-frame.c
+++ b/mate-panel/panel-applet-frame.c
@@ -1093,11 +1093,16 @@ mate_panel_applet_frame_create (PanelToplevel *toplevel,
 	GSettings   *settings;
 	gchar       *path;
 	char        *id;
+	PanelObjectPackType pack_type = PANEL_OBJECT_PACK_START;
+	int pack_index = 0;
 
 	g_return_if_fail (iid != NULL);
 
+	panel_widget_get_insert_at_pos (panel_toplevel_get_panel_widget (toplevel),
+				      &pack_type, &pack_index, position);
+
 	id = panel_profile_prepare_object (PANEL_OBJECT_APPLET, toplevel, position,
-					   PANEL_OBJECT_PACK_START, 0);
+					   pack_type, pack_index);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-applet-frame.h
+++ b/mate-panel/panel-applet-frame.h
@@ -86,6 +86,7 @@ void  mate_panel_applet_frame_create             (PanelToplevel       *toplevel,
 void  mate_panel_applet_frame_load_from_gsettings    (PanelWidget         *panel_widget,
 					     gboolean             locked,
 					     int                  position,
+					     PanelObjectPackType  pack_type,
 					     const char          *id);
 
 void  mate_panel_applet_frame_sync_menu_state    (MatePanelAppletFrame    *frame);

--- a/mate-panel/panel-applet-frame.h
+++ b/mate-panel/panel-applet-frame.h
@@ -87,6 +87,7 @@ void  mate_panel_applet_frame_load_from_gsettings    (PanelWidget         *panel
 					     gboolean             locked,
 					     int                  position,
 					     PanelObjectPackType  pack_type,
+					     int                  pack_index,
 					     const char          *id);
 
 void  mate_panel_applet_frame_sync_menu_state    (MatePanelAppletFrame    *frame);

--- a/mate-panel/panel-enums-gsettings.h
+++ b/mate-panel/panel-enums-gsettings.h
@@ -31,6 +31,11 @@
 
 G_BEGIN_DECLS
 
+typedef enum {
+	PANEL_OBJECT_PACK_START = 0,
+	PANEL_OBJECT_PACK_END   = 1
+} PanelObjectPackType;
+
 typedef enum { /*< flags=0 >*/
 	PANEL_ORIENTATION_TOP    = 1 << 0,
 	PANEL_ORIENTATION_RIGHT  = 1 << 1,

--- a/mate-panel/panel-enums-gsettings.h
+++ b/mate-panel/panel-enums-gsettings.h
@@ -32,8 +32,9 @@
 G_BEGIN_DECLS
 
 typedef enum {
-	PANEL_OBJECT_PACK_START = 0,
-	PANEL_OBJECT_PACK_END   = 1
+	PANEL_OBJECT_PACK_START  = 0,
+	PANEL_OBJECT_PACK_CENTER = 1,
+	PANEL_OBJECT_PACK_END    = 2
 } PanelObjectPackType;
 
 typedef enum { /*< flags=0 >*/

--- a/mate-panel/panel-layout.c
+++ b/mate-panel/panel-layout.c
@@ -81,6 +81,7 @@ static PanelLayoutKeyDefinition panel_layout_object_keys[] = {
         { PANEL_OBJECT_TYPE_KEY,                 G_TYPE_STRING   },
         { PANEL_OBJECT_TOPLEVEL_ID_KEY,          G_TYPE_STRING   },
         { PANEL_OBJECT_PACK_TYPE_KEY,            G_TYPE_STRING   },
+        { PANEL_OBJECT_PACK_INDEX_KEY,           G_TYPE_INT      },
         { PANEL_OBJECT_POSITION_KEY,             G_TYPE_INT      },
         { PANEL_OBJECT_PANEL_RIGHT_STICK_KEY,    G_TYPE_BOOLEAN  },
         { PANEL_OBJECT_LOCKED_KEY,               G_TYPE_BOOLEAN  },

--- a/mate-panel/panel-layout.c
+++ b/mate-panel/panel-layout.c
@@ -80,6 +80,7 @@ static PanelLayoutKeyDefinition panel_layout_toplevel_keys[] = {
 static PanelLayoutKeyDefinition panel_layout_object_keys[] = {
         { PANEL_OBJECT_TYPE_KEY,                 G_TYPE_STRING   },
         { PANEL_OBJECT_TOPLEVEL_ID_KEY,          G_TYPE_STRING   },
+        { PANEL_OBJECT_PACK_TYPE_KEY,            G_TYPE_STRING   },
         { PANEL_OBJECT_POSITION_KEY,             G_TYPE_INT      },
         { PANEL_OBJECT_PANEL_RIGHT_STICK_KEY,    G_TYPE_BOOLEAN  },
         { PANEL_OBJECT_LOCKED_KEY,               G_TYPE_BOOLEAN  },

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -385,9 +385,14 @@ void panel_menu_bar_load_from_gsettings (PanelWidget* panel, gboolean locked, in
 void panel_menu_bar_create(PanelToplevel* toplevel, int position)
 {
 	char* id;
+	PanelObjectPackType pack_type = PANEL_OBJECT_PACK_START;
+	int pack_index = 0;
+
+	panel_widget_get_insert_at_pos(panel_toplevel_get_panel_widget(toplevel),
+				     &pack_type, &pack_index, position);
 
 	id = panel_profile_prepare_object(PANEL_OBJECT_MENU_BAR, toplevel, position,
-					  PANEL_OBJECT_PACK_START, 0);
+					  pack_type, pack_index);
 	panel_profile_add_to_list(PANEL_GSETTINGS_OBJECTS, id);
 	g_free(id);
 }

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -339,7 +339,7 @@ static gboolean panel_menu_bar_on_draw (GtkWidget* widget, cairo_t* cr, gpointer
 	return FALSE;
 }
 
-static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int position, gboolean exactpos, const char* id)
+static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int position, PanelObjectPackType pack_type, gboolean exactpos, const char* id)
 {
 	PanelMenuBar* menubar;
 	GtkSettings* settings;
@@ -348,7 +348,7 @@ static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int positio
 
 	menubar = g_object_new(PANEL_TYPE_MENU_BAR, NULL);
 
-	menubar->priv->info = mate_panel_applet_register(GTK_WIDGET(menubar), NULL, NULL, panel, locked, position, exactpos, PANEL_OBJECT_MENU_BAR, id);
+	menubar->priv->info = mate_panel_applet_register(GTK_WIDGET(menubar), NULL, NULL, panel, locked, position, pack_type, exactpos, PANEL_OBJECT_MENU_BAR, id);
 
 	if (!menubar->priv->info)
 	{
@@ -377,9 +377,9 @@ static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int positio
 	panel_menu_bar_update_visibility(menubar->priv->settings, NULL, menubar);
 }
 
-void panel_menu_bar_load_from_gsettings (PanelWidget* panel, gboolean locked, int position, gboolean exactpos, const char* id)
+void panel_menu_bar_load_from_gsettings (PanelWidget* panel, gboolean locked, int position, PanelObjectPackType pack_type, gboolean exactpos, const char* id)
 {
-	panel_menu_bar_load(panel, locked, position, exactpos, id);
+	panel_menu_bar_load(panel, locked, position, pack_type, exactpos, id);
 }
 
 void panel_menu_bar_create(PanelToplevel* toplevel, int position)

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -386,7 +386,8 @@ void panel_menu_bar_create(PanelToplevel* toplevel, int position)
 {
 	char* id;
 
-	id = panel_profile_prepare_object(PANEL_OBJECT_MENU_BAR, toplevel, position, FALSE);
+	id = panel_profile_prepare_object(PANEL_OBJECT_MENU_BAR, toplevel, position,
+					  PANEL_OBJECT_PACK_START);
 	panel_profile_add_to_list(PANEL_GSETTINGS_OBJECTS, id);
 	g_free(id);
 }

--- a/mate-panel/panel-menu-bar.c
+++ b/mate-panel/panel-menu-bar.c
@@ -339,7 +339,7 @@ static gboolean panel_menu_bar_on_draw (GtkWidget* widget, cairo_t* cr, gpointer
 	return FALSE;
 }
 
-static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int position, PanelObjectPackType pack_type, gboolean exactpos, const char* id)
+static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int position, PanelObjectPackType pack_type, int pack_index, gboolean exactpos, const char* id)
 {
 	PanelMenuBar* menubar;
 	GtkSettings* settings;
@@ -348,7 +348,7 @@ static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int positio
 
 	menubar = g_object_new(PANEL_TYPE_MENU_BAR, NULL);
 
-	menubar->priv->info = mate_panel_applet_register(GTK_WIDGET(menubar), NULL, NULL, panel, locked, position, pack_type, exactpos, PANEL_OBJECT_MENU_BAR, id);
+	menubar->priv->info = mate_panel_applet_register(GTK_WIDGET(menubar), NULL, NULL, panel, locked, position, pack_type, pack_index, exactpos, PANEL_OBJECT_MENU_BAR, id);
 
 	if (!menubar->priv->info)
 	{
@@ -377,9 +377,9 @@ static void panel_menu_bar_load(PanelWidget* panel, gboolean locked, int positio
 	panel_menu_bar_update_visibility(menubar->priv->settings, NULL, menubar);
 }
 
-void panel_menu_bar_load_from_gsettings (PanelWidget* panel, gboolean locked, int position, PanelObjectPackType pack_type, gboolean exactpos, const char* id)
+void panel_menu_bar_load_from_gsettings (PanelWidget* panel, gboolean locked, int position, PanelObjectPackType pack_type, int pack_index, gboolean exactpos, const char* id)
 {
-	panel_menu_bar_load(panel, locked, position, pack_type, exactpos, id);
+	panel_menu_bar_load(panel, locked, position, pack_type, pack_index, exactpos, id);
 }
 
 void panel_menu_bar_create(PanelToplevel* toplevel, int position)
@@ -387,7 +387,7 @@ void panel_menu_bar_create(PanelToplevel* toplevel, int position)
 	char* id;
 
 	id = panel_profile_prepare_object(PANEL_OBJECT_MENU_BAR, toplevel, position,
-					  PANEL_OBJECT_PACK_START);
+					  PANEL_OBJECT_PACK_START, 0);
 	panel_profile_add_to_list(PANEL_GSETTINGS_OBJECTS, id);
 	g_free(id);
 }

--- a/mate-panel/panel-menu-bar.h
+++ b/mate-panel/panel-menu-bar.h
@@ -63,6 +63,7 @@ void       panel_menu_bar_load_from_gsettings  (PanelWidget  *panel,
 					    gboolean      locked,
 					    int           position,
 					    PanelObjectPackType pack_type,
+					    int           pack_index,
 					    gboolean      exactpos,
 					    const char   *id);
 

--- a/mate-panel/panel-menu-bar.h
+++ b/mate-panel/panel-menu-bar.h
@@ -62,6 +62,7 @@ void       panel_menu_bar_create           (PanelToplevel *toplevel,
 void       panel_menu_bar_load_from_gsettings  (PanelWidget  *panel,
 					    gboolean      locked,
 					    int           position,
+					    PanelObjectPackType pack_type,
 					    gboolean      exactpos,
 					    const char   *id);
 

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -668,6 +668,7 @@ panel_menu_button_load (const char  *menu_path,
 			PanelWidget *panel,
 			gboolean     locked,
 			int          position,
+			PanelObjectPackType pack_type,
 			gboolean     exactpos,
 			gboolean     has_arrow,
 			const char  *id)
@@ -687,7 +688,7 @@ panel_menu_button_load (const char  *menu_path,
 			       NULL);
 
 	info = mate_panel_applet_register (GTK_WIDGET (button), NULL, NULL,
-				      panel, locked, position, exactpos,
+				      panel, locked, position, pack_type, exactpos,
 				      PANEL_OBJECT_MENU, id);
 	if (!info) {
 		gtk_widget_destroy (GTK_WIDGET (button));
@@ -915,6 +916,7 @@ void
 panel_menu_button_load_from_gsettings (PanelWidget *panel,
 				   gboolean     locked,
 				   int          position,
+				   PanelObjectPackType pack_type,
 				   gboolean     exactpos,
 				   const char  *id)
 {
@@ -945,6 +947,7 @@ panel_menu_button_load_from_gsettings (PanelWidget *panel,
 				panel,
 				locked,
 				position,
+				pack_type,
 				exactpos,
 				has_arrow,
 				id);

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -969,7 +969,8 @@ panel_menu_button_create (PanelToplevel *toplevel,
 	const char  *scheme;
 	char        *id;
 
-	id = panel_profile_prepare_object (PANEL_OBJECT_MENU, toplevel, position, FALSE);
+	id = panel_profile_prepare_object (PANEL_OBJECT_MENU, toplevel, position,
+					   PANEL_OBJECT_PACK_START);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -669,6 +669,7 @@ panel_menu_button_load (const char  *menu_path,
 			gboolean     locked,
 			int          position,
 			PanelObjectPackType pack_type,
+			int          pack_index,
 			gboolean     exactpos,
 			gboolean     has_arrow,
 			const char  *id)
@@ -688,7 +689,7 @@ panel_menu_button_load (const char  *menu_path,
 			       NULL);
 
 	info = mate_panel_applet_register (GTK_WIDGET (button), NULL, NULL,
-				      panel, locked, position, pack_type, exactpos,
+				      panel, locked, position, pack_type, pack_index, exactpos,
 				      PANEL_OBJECT_MENU, id);
 	if (!info) {
 		gtk_widget_destroy (GTK_WIDGET (button));
@@ -917,6 +918,7 @@ panel_menu_button_load_from_gsettings (PanelWidget *panel,
 				   gboolean     locked,
 				   int          position,
 				   PanelObjectPackType pack_type,
+				   int          pack_index,
 				   gboolean     exactpos,
 				   const char  *id)
 {
@@ -948,6 +950,7 @@ panel_menu_button_load_from_gsettings (PanelWidget *panel,
 				locked,
 				position,
 				pack_type,
+				pack_index,
 				exactpos,
 				has_arrow,
 				id);
@@ -973,7 +976,7 @@ panel_menu_button_create (PanelToplevel *toplevel,
 	char        *id;
 
 	id = panel_profile_prepare_object (PANEL_OBJECT_MENU, toplevel, position,
-					   PANEL_OBJECT_PACK_START);
+					   PANEL_OBJECT_PACK_START, 0);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-menu-button.c
+++ b/mate-panel/panel-menu-button.c
@@ -974,9 +974,14 @@ panel_menu_button_create (PanelToplevel *toplevel,
 	gchar       *path;
 	const char  *scheme;
 	char        *id;
+	PanelObjectPackType pack_type = PANEL_OBJECT_PACK_START;
+	int pack_index = 0;
+
+	panel_widget_get_insert_at_pos (panel_toplevel_get_panel_widget (toplevel),
+				      &pack_type, &pack_index, position);
 
 	id = panel_profile_prepare_object (PANEL_OBJECT_MENU, toplevel, position,
-					   PANEL_OBJECT_PACK_START, 0);
+					   pack_type, pack_index);
 
 	path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, path);

--- a/mate-panel/panel-menu-button.h
+++ b/mate-panel/panel-menu-button.h
@@ -81,6 +81,7 @@ void       panel_menu_button_load_from_gsettings     (PanelWidget      *panel,
 						  gboolean          locked,
 						  int               position,
 						  PanelObjectPackType pack_type,
+						  int               pack_index,
 						  gboolean          exactpos,
 						  const char       *id);
 

--- a/mate-panel/panel-menu-button.h
+++ b/mate-panel/panel-menu-button.h
@@ -80,6 +80,7 @@ void       panel_menu_button_set_has_arrow       (PanelMenuButton *button,
 void       panel_menu_button_load_from_gsettings     (PanelWidget      *panel,
 						  gboolean          locked,
 						  int               position,
+						  PanelObjectPackType pack_type,
 						  gboolean          exactpos,
 						  const char       *id);
 

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -1308,13 +1308,14 @@ panel_profile_delete_object (AppletInfo *applet_info)
 static void
 panel_profile_load_object (char *id)
 {
-	PanelObjectType  object_type;
-	char            *object_path;
-	char            *toplevel_id;
-	int              position;
-	gboolean         right_stick;
-	gboolean         locked;
-	GSettings       *settings;
+	PanelObjectType      object_type;
+	char                *object_path;
+	char                *toplevel_id;
+	int                  position;
+	PanelObjectPackType  pack_type;
+	gboolean             right_stick;
+	gboolean             locked;
+	GSettings           *settings;
 
 	object_path = g_strdup_printf (PANEL_OBJECT_PATH "%s/", id);
 	settings = g_settings_new_with_path (PANEL_OBJECT_SCHEMA, object_path);
@@ -1322,14 +1323,21 @@ panel_profile_load_object (char *id)
 	object_type = g_settings_get_enum (settings, PANEL_OBJECT_TYPE_KEY);
 	position = g_settings_get_int (settings, PANEL_OBJECT_POSITION_KEY);
 	toplevel_id = g_settings_get_string (settings, PANEL_OBJECT_TOPLEVEL_ID_KEY);
+	pack_type = g_settings_get_enum (settings, PANEL_OBJECT_PACK_TYPE_KEY);
 	right_stick = g_settings_get_boolean (settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY);
 	locked = g_settings_get_boolean (settings, PANEL_OBJECT_LOCKED_KEY);
+
+	/* If pack-type is still at the default value ('start') but right-stick
+	 * is set, then map right-stick to PACK_END so the comparator sorts
+	 * correctly. */
+	if (pack_type == PANEL_OBJECT_PACK_START && right_stick)
+		pack_type = PANEL_OBJECT_PACK_END;
 
 	mate_panel_applet_queue_applet_to_load (id,
 					   object_type,
 					   toplevel_id,
 					   position,
-					   right_stick,
+					   pack_type,
 					   locked);
 
 	g_free (toplevel_id);

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -1251,7 +1251,8 @@ char *
 panel_profile_prepare_object_with_id (PanelObjectType     object_type,
 				      const char         *toplevel_id,
 				      int                 position,
-				      PanelObjectPackType pack_type)
+				      PanelObjectPackType pack_type,
+				      int                 pack_index)
 {
 	PanelGSettingsKeyType  key_type;
 	char              *id;
@@ -1269,6 +1270,7 @@ panel_profile_prepare_object_with_id (PanelObjectType     object_type,
 	g_settings_set_string (settings, PANEL_OBJECT_TOPLEVEL_ID_KEY, toplevel_id);
 	g_settings_set_int (settings, PANEL_OBJECT_POSITION_KEY, position);
 	g_settings_set_enum (settings, PANEL_OBJECT_PACK_TYPE_KEY, pack_type);
+	g_settings_set_int (settings, PANEL_OBJECT_PACK_INDEX_KEY, pack_index);
 
 	/* Force writing the settings in order to reserve the object ID *now*,
 	 * so that a later call to panel_profile_find_new_id() won't find the same
@@ -1285,12 +1287,14 @@ char *
 panel_profile_prepare_object (PanelObjectType      object_type,
 			      PanelToplevel       *toplevel,
 			      int                  position,
-			      PanelObjectPackType  pack_type)
+			      PanelObjectPackType  pack_type,
+			      int                  pack_index)
 {
 	return panel_profile_prepare_object_with_id (object_type,
 						     panel_profile_get_toplevel_id (toplevel),
 						     position,
-						     pack_type);
+						     pack_type,
+						     pack_index);
 }
 
 void
@@ -1313,6 +1317,7 @@ panel_profile_load_object (char *id)
 	char                *toplevel_id;
 	int                  position;
 	PanelObjectPackType  pack_type;
+	int                  pack_index;
 	gboolean             right_stick;
 	gboolean             locked;
 	GSettings           *settings;
@@ -1324,6 +1329,7 @@ panel_profile_load_object (char *id)
 	position = g_settings_get_int (settings, PANEL_OBJECT_POSITION_KEY);
 	toplevel_id = g_settings_get_string (settings, PANEL_OBJECT_TOPLEVEL_ID_KEY);
 	pack_type = g_settings_get_enum (settings, PANEL_OBJECT_PACK_TYPE_KEY);
+	pack_index = g_settings_get_int (settings, PANEL_OBJECT_PACK_INDEX_KEY);
 	right_stick = g_settings_get_boolean (settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY);
 	locked = g_settings_get_boolean (settings, PANEL_OBJECT_LOCKED_KEY);
 
@@ -1338,6 +1344,7 @@ panel_profile_load_object (char *id)
 					   toplevel_id,
 					   position,
 					   pack_type,
+					   pack_index,
 					   locked);
 
 	g_free (toplevel_id);

--- a/mate-panel/panel-profile.c
+++ b/mate-panel/panel-profile.c
@@ -1248,10 +1248,10 @@ panel_profile_destroy_toplevel (const char *id)
 }
 
 char *
-panel_profile_prepare_object_with_id (PanelObjectType  object_type,
-				      const char      *toplevel_id,
-				      int              position,
-				      gboolean         right_stick)
+panel_profile_prepare_object_with_id (PanelObjectType     object_type,
+				      const char         *toplevel_id,
+				      int                 position,
+				      PanelObjectPackType pack_type)
 {
 	PanelGSettingsKeyType  key_type;
 	char              *id;
@@ -1268,7 +1268,7 @@ panel_profile_prepare_object_with_id (PanelObjectType  object_type,
 	g_settings_set_enum (settings, PANEL_OBJECT_TYPE_KEY, object_type);
 	g_settings_set_string (settings, PANEL_OBJECT_TOPLEVEL_ID_KEY, toplevel_id);
 	g_settings_set_int (settings, PANEL_OBJECT_POSITION_KEY, position);
-	g_settings_set_boolean (settings, PANEL_OBJECT_PANEL_RIGHT_STICK_KEY, right_stick);
+	g_settings_set_enum (settings, PANEL_OBJECT_PACK_TYPE_KEY, pack_type);
 
 	/* Force writing the settings in order to reserve the object ID *now*,
 	 * so that a later call to panel_profile_find_new_id() won't find the same
@@ -1282,15 +1282,15 @@ panel_profile_prepare_object_with_id (PanelObjectType  object_type,
 }
 
 char *
-panel_profile_prepare_object (PanelObjectType  object_type,
-			      PanelToplevel   *toplevel,
-			      int              position,
-			      gboolean         right_stick)
+panel_profile_prepare_object (PanelObjectType      object_type,
+			      PanelToplevel       *toplevel,
+			      int                  position,
+			      PanelObjectPackType  pack_type)
 {
 	return panel_profile_prepare_object_with_id (object_type,
 						     panel_profile_get_toplevel_id (toplevel),
 						     position,
-						     right_stick);
+						     pack_type);
 }
 
 void

--- a/mate-panel/panel-profile.h
+++ b/mate-panel/panel-profile.h
@@ -62,11 +62,13 @@ void           panel_profile_delete_toplevel        (PanelToplevel     *toplevel
 char          *panel_profile_prepare_object         (PanelObjectType     object_type,
 						     PanelToplevel      *toplevel,
 						     int                 position,
-						     PanelObjectPackType pack_type);
+						     PanelObjectPackType pack_type,
+						     int                 pack_index);
 char          *panel_profile_prepare_object_with_id (PanelObjectType     object_type,
 						     const char         *toplevel_id,
 						     int                 position,
-						     PanelObjectPackType pack_type);
+						     PanelObjectPackType pack_type,
+						     int                 pack_index);
 void           panel_profile_delete_object          (AppletInfo        *applet_info);
 
 gboolean    panel_profile_key_is_writable            (PanelToplevel *toplevel,

--- a/mate-panel/panel-profile.h
+++ b/mate-panel/panel-profile.h
@@ -32,6 +32,7 @@
 
 #include "panel-toplevel.h"
 #include "panel-enums.h"
+#include "panel-enums-gsettings.h"
 #include "panel-types.h"
 #include "applet.h"
 
@@ -58,14 +59,14 @@ gboolean       panel_profile_id_lists_are_writable  (void);
 void           panel_profile_create_toplevel        (GdkScreen         *screen);
 PanelToplevel *panel_profile_load_toplevel          (const char        *toplevel_id);
 void           panel_profile_delete_toplevel        (PanelToplevel     *toplevel);
-char          *panel_profile_prepare_object         (PanelObjectType    object_type,
-						     PanelToplevel     *toplevel,
-						     int                position,
-						     gboolean           right_stick);
-char          *panel_profile_prepare_object_with_id (PanelObjectType    object_type,
-						     const char        *toplevel_id,
-						     int                position,
-						     gboolean           right_stick);
+char          *panel_profile_prepare_object         (PanelObjectType     object_type,
+						     PanelToplevel      *toplevel,
+						     int                 position,
+						     PanelObjectPackType pack_type);
+char          *panel_profile_prepare_object_with_id (PanelObjectType     object_type,
+						     const char         *toplevel_id,
+						     int                 position,
+						     PanelObjectPackType pack_type);
 void           panel_profile_delete_object          (AppletInfo        *applet_info);
 
 gboolean    panel_profile_key_is_writable            (PanelToplevel *toplevel,

--- a/mate-panel/panel-schemas.h
+++ b/mate-panel/panel-schemas.h
@@ -45,6 +45,7 @@
 #define PANEL_OBJECT_SCHEMA                  "org.mate.panel.object"
 #define PANEL_OBJECT_TYPE_KEY                "object-type"
 #define PANEL_OBJECT_TOPLEVEL_ID_KEY         "toplevel-id"
+#define PANEL_OBJECT_PACK_TYPE_KEY           "pack-type"
 #define PANEL_OBJECT_POSITION_KEY            "position"
 #define PANEL_OBJECT_PANEL_RIGHT_STICK_KEY   "panel-right-stick"
 #define PANEL_OBJECT_LOCKED_KEY              "locked"

--- a/mate-panel/panel-schemas.h
+++ b/mate-panel/panel-schemas.h
@@ -46,6 +46,7 @@
 #define PANEL_OBJECT_TYPE_KEY                "object-type"
 #define PANEL_OBJECT_TOPLEVEL_ID_KEY         "toplevel-id"
 #define PANEL_OBJECT_PACK_TYPE_KEY           "pack-type"
+#define PANEL_OBJECT_PACK_INDEX_KEY          "pack-index"
 #define PANEL_OBJECT_POSITION_KEY            "position"
 #define PANEL_OBJECT_PANEL_RIGHT_STICK_KEY   "panel-right-stick"
 #define PANEL_OBJECT_LOCKED_KEY              "locked"

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -263,7 +263,8 @@ panel_separator_create (PanelToplevel *toplevel,
 	char *id;
 
 	id = panel_profile_prepare_object (PANEL_OBJECT_SEPARATOR,
-					   toplevel, position, FALSE);
+					   toplevel,
+					   position, PANEL_OBJECT_PACK_START);
 	panel_profile_add_to_list (PANEL_GSETTINGS_OBJECTS, id);
 	g_free (id);
 }

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -232,6 +232,7 @@ void
 panel_separator_load_from_gsettings (PanelWidget *panel,
 				 gboolean     locked,
 				 int          position,
+				 PanelObjectPackType pack_type,
 				 const char  *id)
 {
 	PanelSeparator *separator;
@@ -241,7 +242,7 @@ panel_separator_load_from_gsettings (PanelWidget *panel,
 	separator->priv->info = mate_panel_applet_register (GTK_WIDGET (separator),
 						       NULL, NULL,
 						       panel, locked, position,
-						       TRUE,
+						       pack_type, TRUE,
 						       PANEL_OBJECT_SEPARATOR,
 						       id);
 

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -263,10 +263,15 @@ panel_separator_create (PanelToplevel *toplevel,
 			int            position)
 {
 	char *id;
+	PanelObjectPackType pack_type = PANEL_OBJECT_PACK_START;
+	int pack_index = 0;
+
+	panel_widget_get_insert_at_pos (panel_toplevel_get_panel_widget (toplevel),
+				      &pack_type, &pack_index, position);
 
 	id = panel_profile_prepare_object (PANEL_OBJECT_SEPARATOR,
 					   toplevel,
-					   position, PANEL_OBJECT_PACK_START, 0);
+					   position, pack_type, pack_index);
 	panel_profile_add_to_list (PANEL_GSETTINGS_OBJECTS, id);
 	g_free (id);
 }

--- a/mate-panel/panel-separator.c
+++ b/mate-panel/panel-separator.c
@@ -233,6 +233,7 @@ panel_separator_load_from_gsettings (PanelWidget *panel,
 				 gboolean     locked,
 				 int          position,
 				 PanelObjectPackType pack_type,
+				 int          pack_index,
 				 const char  *id)
 {
 	PanelSeparator *separator;
@@ -242,7 +243,7 @@ panel_separator_load_from_gsettings (PanelWidget *panel,
 	separator->priv->info = mate_panel_applet_register (GTK_WIDGET (separator),
 						       NULL, NULL,
 						       panel, locked, position,
-						       pack_type, TRUE,
+						       pack_type, pack_index, TRUE,
 						       PANEL_OBJECT_SEPARATOR,
 						       id);
 
@@ -265,7 +266,7 @@ panel_separator_create (PanelToplevel *toplevel,
 
 	id = panel_profile_prepare_object (PANEL_OBJECT_SEPARATOR,
 					   toplevel,
-					   position, PANEL_OBJECT_PACK_START);
+					   position, PANEL_OBJECT_PACK_START, 0);
 	panel_profile_add_to_list (PANEL_GSETTINGS_OBJECTS, id);
 	g_free (id);
 }

--- a/mate-panel/panel-separator.h
+++ b/mate-panel/panel-separator.h
@@ -60,6 +60,7 @@ void   panel_separator_create            (PanelToplevel    *toplevel,
 void   panel_separator_load_from_gsettings   (PanelWidget      *panel_widget,
 					  gboolean          locked,
 					  gint              position,
+					  PanelObjectPackType pack_type,
 					  const char       *id);
 void   panel_separator_set_orientation   (PanelSeparator   *separator,
 					  PanelOrientation  orientation);

--- a/mate-panel/panel-separator.h
+++ b/mate-panel/panel-separator.h
@@ -61,6 +61,7 @@ void   panel_separator_load_from_gsettings   (PanelWidget      *panel_widget,
 					  gboolean          locked,
 					  gint              position,
 					  PanelObjectPackType pack_type,
+					  int               pack_index,
 					  const char       *id);
 void   panel_separator_set_orientation   (PanelSeparator   *separator,
 					  PanelOrientation  orientation);

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -582,6 +582,8 @@ panel_widget_cremove (GtkContainer *container, GtkWidget *widget)
 	if (ad)
 		panel->applet_list = g_list_remove (panel->applet_list, ad);
 
+	panel_widget_update_positions (panel);
+
 	g_signal_emit (G_OBJECT (container),
 		       panel_widget_signals[APPLET_REMOVED_SIGNAL],
 		       0, widget);

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -35,7 +35,6 @@
 
 typedef enum {
 	PANEL_SWITCH_MOVE = 0,
-	PANEL_FREE_MOVE,
 	PANEL_PUSH_MOVE
 } PanelMovementType;
 
@@ -49,7 +48,6 @@ enum {
 	APPLET_REMOVED_SIGNAL,
 	PUSH_MOVE_SIGNAL,
 	SWITCH_MOVE_SIGNAL,
-	FREE_MOVE_SIGNAL,
 	TAB_MOVE_SIGNAL,
 	END_MOVE_SIGNAL,
 	POPUP_PANEL_MENU_SIGNAL,
@@ -85,8 +83,6 @@ static void panel_widget_finalize       (GObject          *obj);
 static void panel_widget_push_move_applet   (PanelWidget      *panel,
                                              GtkDirectionType  dir);
 static void panel_widget_switch_move_applet (PanelWidget      *panel,
-                                             GtkDirectionType  dir);
-static void panel_widget_free_move_applet   (PanelWidget      *panel,
                                              GtkDirectionType  dir);
 static void panel_widget_update_positions   (PanelWidget      *panel);
 static void panel_widget_tab_move           (PanelWidget      *panel,
@@ -184,8 +180,6 @@ add_all_move_bindings (PanelWidget *panel)
 
 	add_move_bindings (binding_set, GDK_SHIFT_MASK, "push_move");
 	add_move_bindings (binding_set, GDK_CONTROL_MASK, "switch_move");
-	add_move_bindings (binding_set, GDK_MOD1_MASK, "free_move");
-	add_move_bindings (binding_set, 0, "free_move");
 
 	add_tab_bindings (binding_set, 0, TRUE);
 	add_tab_bindings (binding_set, GDK_SHIFT_MASK, FALSE);
@@ -384,18 +378,6 @@ panel_widget_class_init (PanelWidgetClass *class)
                               1,
                               GTK_TYPE_DIRECTION_TYPE);
 
-	panel_widget_signals[FREE_MOVE_SIGNAL] =
-                g_signal_new ("free_move",
-                              G_TYPE_FROM_CLASS (class),
-                              G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
-                              G_STRUCT_OFFSET (PanelWidgetClass, free_move),
-                              NULL,
-                              NULL,
-                              g_cclosure_marshal_VOID__ENUM,
-                              G_TYPE_NONE,
-                              1,
-                              GTK_TYPE_DIRECTION_TYPE);
-
 	panel_widget_signals[TAB_MOVE_SIGNAL] =
                 g_signal_new ("tab_move",
                               G_TYPE_FROM_CLASS (class),
@@ -426,7 +408,6 @@ panel_widget_class_init (PanelWidgetClass *class)
 	class->applet_removed = NULL;
 	class->push_move = panel_widget_push_move_applet;
 	class->switch_move = panel_widget_switch_move_applet;
-	class->free_move = panel_widget_free_move_applet;
 	class->tab_move = panel_widget_tab_move;
 	class->end_move = panel_widget_end_move;
 
@@ -2262,29 +2243,6 @@ panel_widget_get_free_spot (PanelWidget *panel,
 	}
 }
 
-static void
-panel_widget_nice_move (PanelWidget *panel,
-			AppletData  *ad,
-			int          pos)
-{
-	g_return_if_fail (PANEL_IS_WIDGET (panel));
-	g_return_if_fail (ad != NULL);
-
-	pos = panel_widget_get_free_spot (panel, ad, pos);
-	if (pos < 0 || pos == ad->pos)
-		return;
-
-	ad->pos = ad->constrained = pos;
-
-	panel->applet_list =
-		panel_g_list_resort_item (panel->applet_list, ad,
-					  (GCompareFunc)applet_data_compare);
-
-	gtk_widget_queue_resize (GTK_WIDGET (panel));
-
-	emit_applet_moved (panel, ad);
-}
-
 /* schedule to run the below function */
 static void schedule_try_move (PanelWidget *panel, gboolean repeater);
 
@@ -2364,17 +2322,12 @@ panel_widget_applet_move_to_cursor (PanelWidget *panel)
 			movement = PANEL_SWITCH_MOVE;
 		else if (mods & GDK_SHIFT_MASK)
 			movement = PANEL_PUSH_MOVE;
-		else if (mods & GDK_MOD1_MASK)
-			movement = PANEL_FREE_MOVE;
 	}
 
 	switch (movement) {
 	case PANEL_SWITCH_MOVE:
 		moveby = panel_widget_get_moveby (panel, pos, ad->drag_off);
 		panel_widget_switch_move (panel, ad, moveby);
-		break;
-	case PANEL_FREE_MOVE:
-		panel_widget_nice_move (panel, ad, panel_widget_get_cursorloc (panel));
 		break;
 	case PANEL_PUSH_MOVE:
 		moveby = panel_widget_get_moveby (panel, pos, ad->drag_off);
@@ -2974,32 +2927,6 @@ panel_widget_switch_move_applet (PanelWidget      *panel,
 	default:
 		return;
 	}
-}
-
-static void
-panel_widget_free_move_applet (PanelWidget      *panel,
-                               GtkDirectionType  dir)
-{
-	AppletData *ad;
-	gint        increment = MOVE_INCREMENT;
-
-	ad = panel->currently_dragged_applet;
-
-	g_return_if_fail (ad);
-
-	switch (dir) {
-	case GTK_DIR_LEFT:
-	case GTK_DIR_UP:
-		increment = -increment;
-		break;
-	case GTK_DIR_RIGHT:
-	case GTK_DIR_DOWN:
-		break;
-	default:
-		return;
-	}
-
-	panel_widget_nice_move (panel, ad, increment + ad->constrained + ad->drag_off);
 }
 
 static void

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -550,7 +550,8 @@ panel_widget_cadd (GtkContainer *container,
 	g_return_if_fail (PANEL_IS_WIDGET (container));
 	g_return_if_fail (GTK_IS_WIDGET (widget));
 
-	panel_widget_add (PANEL_WIDGET (container), widget, FALSE, 0, FALSE);
+	panel_widget_add (PANEL_WIDGET (container), widget, FALSE,
+			  0, PANEL_OBJECT_PACK_START, FALSE);
 
 	p = g_object_get_data (G_OBJECT(widget),
 			       MATE_PANEL_APPLET_ASSOC_PANEL_KEY);
@@ -2443,16 +2444,24 @@ panel_widget_add_forbidden (PanelWidget *panel)
 }
 
 int
-panel_widget_add (PanelWidget *panel,
-		  GtkWidget   *applet,
-		  gboolean     locked,
-		  int          pos,
-		  gboolean     insert_at_pos)
+panel_widget_add (PanelWidget         *panel,
+		  GtkWidget           *applet,
+		  gboolean             locked,
+		  int                  pos,
+		  PanelObjectPackType  pack_type,
+		  gboolean             insert_at_pos)
 {
 	AppletData *ad = NULL;
 
 	g_return_val_if_fail (PANEL_IS_WIDGET (panel), -1);
 	g_return_val_if_fail (GTK_IS_WIDGET (applet), -1);
+
+	if (pack_type == PANEL_OBJECT_PACK_END) {
+		if (!panel->packed)
+			pos = panel->size - pos;
+		else
+			pos = -1;
+	}
 
 	ad = g_object_get_data (G_OBJECT (applet), MATE_PANEL_APPLET_DATA);
 

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1246,6 +1246,59 @@ get_applet_list_pack (PanelWidget         *panel,
 	return ret;
 }
 
+/* get pack type & index for insertion at a given position in panel */
+void
+panel_widget_get_insert_at_pos (PanelWidget         *panel,
+				PanelObjectPackType *pack_type,
+				int                 *pack_index,
+				int                  pos)
+{
+	GList      *l;
+	AppletData *ad;
+
+	g_return_if_fail (PANEL_IS_WIDGET (panel));
+
+	/* check if pos is in an object; in this case, return the pack type
+	 * of the object */
+	for (l = panel->applet_list; l; l = l->next) {
+		ad = l->data;
+
+		if (ad->constrained <= pos) {
+			if (ad->constrained + ad->cells > pos) {
+				*pack_type = ad->pack_type;
+				*pack_index = ad->pack_index;
+				return;
+			}
+		} else
+			break;
+	}
+
+	if (pos <= panel->size / 2)
+		*pack_type = PANEL_OBJECT_PACK_START;
+	else
+		*pack_type = PANEL_OBJECT_PACK_END;
+
+	*pack_index = panel_widget_get_new_pack_index (panel, *pack_type);
+}
+
+/* get index for insertion with pack type */
+int
+panel_widget_get_new_pack_index (PanelWidget         *panel,
+				 PanelObjectPackType  pack_type)
+{
+	GList      *l;
+	AppletData *ad;
+	int         max_pack_index = -1;
+
+	for (l = panel->applet_list; l; l = l->next) {
+		ad = l->data;
+		if (ad->pack_type == pack_type)
+			max_pack_index = MAX (max_pack_index, ad->pack_index);
+	}
+
+	return max_pack_index + 1;
+}
+
 /* Note: this can only be called at the beginning of size_allocate, which means
  * that ad->constrained doesn't matter yet (it will be set to the correct
  * value in size_allocate). */

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1284,6 +1284,46 @@ panel_widget_update_positions_packed_start (PanelWidget *panel)
 }
 
 /* Note: only use this function when you can; see comment above
+ * panel_widget_update_positions_packed_start()
+ * For center specifically, we require ad->cells to be set. Note that we don't
+ * care much about min_cells: if we need it, this means objects will have to be
+ * pushed to accomodate other objects, which will kill centering anyway.
+ * (FIXME: hrm, not that sure about it ;-)) */
+static void
+panel_widget_update_positions_packed_center (PanelWidget *panel)
+{
+	GList *list,*l;
+	AppletData *ad;
+	int size_all = 0;
+	int pos_next;
+
+	if (panel->packed)
+		return;
+
+	list = get_applet_list_pack (panel, PANEL_OBJECT_PACK_CENTER);
+
+	/* get size used by the objects */
+	for (l = list; l; l = l->next) {
+		ad = l->data;
+		size_all += ad->cells;
+	}
+
+	/* update absolute position of all applets based on this information,
+	 * starting with the first centered object */
+	pos_next = (panel->size - size_all) / 2;
+	l = list;
+
+	while (l) {
+		ad = l->data;
+		ad->constrained = pos_next;
+		pos_next += ad->cells;
+		l = l->next;
+	}
+
+	g_list_free (list);
+}
+
+/* Note: only use this function when you can; see comment above
  * panel_widget_update_positions_packed_start() */
 static void
 panel_widget_update_positions_packed_end (PanelWidget *panel)
@@ -1340,11 +1380,13 @@ panel_widget_update_positions (PanelWidget *panel)
 	} else {
 		/* Re-compute the ideal position of objects, based on their size */
 		panel_widget_update_positions_packed_start (panel);
+		panel_widget_update_positions_packed_center (panel);
 		panel_widget_update_positions_packed_end (panel);
 
 		/* Second pass: try to position from the start, to make sure
 		 * there's enough room. Also respect ad->pos for backward
-		 * compat with configs not yet migrated to pack-type/pack-index. */
+		 * compat with configs not yet migrated to pack-type/pack-index
+		 * (except for CENTER applets, which should stay centered). */
 		for (list = panel->applet_list;
 		     list != NULL;
 		     list = g_list_next (list)) {
@@ -1352,7 +1394,7 @@ panel_widget_update_positions (PanelWidget *panel)
 
 			/* Use the larger of zone position and old pixel
 			 * position, so pre-migration gaps are preserved. */
-			if (ad->pos > ad->constrained)
+			if (ad->pack_type != PANEL_OBJECT_PACK_CENTER && ad->pos > ad->constrained)
 				ad->constrained = ad->pos;
 			if (ad->constrained < i)
 				ad->constrained = i;
@@ -1665,15 +1707,19 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 		/* Compute zone-based positions and resolve collisions */
 		panel_widget_update_positions (panel);
 
-		/* Now expand from the right, using size hints */
+		/* Now expand from the right, using size hints.
+		 * But don't push CENTER applets since they should stay centered
+		 * as computed by update_positions. */
 		i = panel->size;
 		for(list = g_list_last(panel->applet_list);
 		    list!=NULL;
 		    list = g_list_previous(list)) {
 			AppletData *ad = list->data;
 
-			if (ad->constrained + ad->min_cells > i)
-				ad->constrained = MAX (i - ad->min_cells, 0);
+			if (ad->pack_type != PANEL_OBJECT_PACK_CENTER) {
+				if (ad->constrained + ad->min_cells > i)
+					ad->constrained = MAX (i - ad->min_cells, 0);
+			}
 
 			if (ad->expand_major) {
 				int cells = (i - ad->constrained) - 1;

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -612,38 +612,6 @@ get_applet_list_pos (PanelWidget *panel,
 	return NULL;
 }
 
-/*tells us if an applet is "stuck" on the right side*/
-int
-panel_widget_is_applet_stuck (PanelWidget *panel_widget,
-			      GtkWidget   *widget)
-{
-	AppletData *applet;
-
-	g_return_val_if_fail (PANEL_IS_WIDGET (panel_widget), FALSE);
-	g_return_val_if_fail (GTK_IS_WIDGET (widget), FALSE);
-
-	applet = g_object_get_data (G_OBJECT (widget), MATE_PANEL_APPLET_DATA);
-	if (applet) {
-		GList *applet_list, *l;
-		int    end_pos = -1;
-
-		applet_list = g_list_find (panel_widget->applet_list, applet);
-
-		for (l = applet_list; l; l = l->next) {
-			applet = l->data;
-
-			if (end_pos != -1 && applet->pos != end_pos)
-				break;
-
-			end_pos = applet->pos + applet->cells;
-			if (end_pos >= panel_widget->size)
-				return TRUE;
-		}
-	}
-
-	return FALSE;
-}
-
 static int
 get_size_from_hints (AppletData *ad, int cells)
 {
@@ -1073,46 +1041,6 @@ panel_widget_push_move (PanelWidget *panel,
 				break;
 		}
 	}
-}
-
-/*this is a special function and may fail if called improperly, it works
-only under special circumstance when we know there is nothing from
-old_size to panel->size*/
-static void
-panel_widget_right_stick(PanelWidget *panel,int old_size)
-{
-	int i,pos;
-	GList *list,*prev;
-	AppletData *ad;
-
-	g_return_if_fail(PANEL_IS_WIDGET(panel));
-	g_return_if_fail(old_size>=0);
-
-	if(old_size>=panel->size ||
-	   panel->packed)
-	   	return;
-
-	list = get_applet_list_pos(panel,old_size-1);
-
-	if(!list)
-		return;
-
-	pos = panel->size-1;
-
-	ad = list->data;
-	do {
-		i = ad->pos;
-		ad->pos = ad->constrained = pos--;
-		ad->cells = 1;
-		prev = list;
-		list = g_list_previous(list);
-		if(!list)
-			break;
-		ad = list->data;
-	} while(ad->pos + ad->cells == i);
-
-	for (list = prev; list; list = list->next)
-		emit_applet_moved (panel, list->data);
 }
 
 /* data should be freed with g_list_free() */

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -88,6 +88,7 @@ static void panel_widget_switch_move_applet (PanelWidget      *panel,
                                              GtkDirectionType  dir);
 static void panel_widget_free_move_applet   (PanelWidget      *panel,
                                              GtkDirectionType  dir);
+static void panel_widget_update_positions   (PanelWidget      *panel);
 static void panel_widget_tab_move           (PanelWidget      *panel,
                                              gboolean          next);
 static void panel_widget_end_move           (PanelWidget      *panel);
@@ -107,6 +108,19 @@ static gboolean panel_widget_push_applet_left  (PanelWidget *panel,
 static int
 applet_data_compare (AppletData *ad1, AppletData *ad2)
 {
+	if (ad1->pack_type != ad2->pack_type)
+		return ad1->pack_type - ad2->pack_type; /* start < center < end */
+
+	/* Within the same pack zone, sort by pack_index. For END zone,
+	 * higher index = leftmost (closer to center), so reverse. */
+	if (ad1->pack_index != ad2->pack_index) {
+		if (ad1->pack_type != PANEL_OBJECT_PACK_END)
+			return ad1->pack_index - ad2->pack_index;
+		else
+			return ad2->pack_index - ad1->pack_index;
+	}
+
+	/* Fallback to pixel position in case all pack_index are 0. */
 	return ad1->pos - ad2->pos;
 }
 
@@ -550,8 +564,8 @@ panel_widget_cadd (GtkContainer *container,
 	g_return_if_fail (PANEL_IS_WIDGET (container));
 	g_return_if_fail (GTK_IS_WIDGET (widget));
 
-	panel_widget_add (PANEL_WIDGET (container), widget, FALSE,
-			  0, PANEL_OBJECT_PACK_START, FALSE);
+	panel_widget_add (PANEL_WIDGET (container), widget, FALSE, 0,
+			  PANEL_OBJECT_PACK_START, 0, FALSE);
 
 	p = g_object_get_data (G_OBJECT(widget),
 			       MATE_PANEL_APPLET_ASSOC_PANEL_KEY);
@@ -1193,6 +1207,194 @@ panel_widget_right_stick(PanelWidget *panel,int old_size)
 		emit_applet_moved (panel, list->data);
 }
 
+/* data should be freed with g_list_free() */
+static GList *
+get_applet_list_pack (PanelWidget         *panel,
+		      PanelObjectPackType  pack_type)
+{
+	GList *ret;
+	GList *l;
+	GList *prev;
+
+	g_return_val_if_fail (PANEL_IS_WIDGET (panel), NULL);
+
+	for (l = panel->applet_list; l; l = l->next) {
+		AppletData *ad = l->data;
+
+		if (ad->pack_type == pack_type)
+			break;
+	}
+
+	if (!l)
+		return NULL;
+
+	ret = g_list_copy (l);
+	for (l = ret; l; l = l->next) {
+		AppletData *ad = l->data;
+		if (ad->pack_type != pack_type)
+			break;
+	}
+
+	if (!l)
+		return ret;
+
+	prev = l->prev;
+	if (prev)
+		prev->next = NULL;
+	g_list_free (l);
+
+	return ret;
+}
+
+/* Note: this can only be called at the beginning of size_allocate, which means
+ * that ad->constrained doesn't matter yet (it will be set to the correct
+ * value in size_allocate). */
+static void
+panel_widget_update_positions_packed_start (PanelWidget *panel)
+{
+	GList *list,*l;
+	AppletData *ad;
+	int size_all = 0;
+	int pos_next;
+
+	if (panel->packed)
+		return;
+
+	list = get_applet_list_pack (panel, PANEL_OBJECT_PACK_START);
+
+	/* get size used by the objects */
+	for (l = list; l; l = l->next) {
+		ad = l->data;
+		size_all += ad->cells;
+	}
+
+	/* update absolute position of all applets based on this information,
+	 * starting with the first object */
+	pos_next = 0;
+	l = list;
+
+	while (l) {
+		ad = l->data;
+		ad->constrained = pos_next;
+		pos_next += ad->cells;
+		l = l->next;
+	}
+
+	g_list_free (list);
+}
+
+/* Note: only use this function when you can; see comment above
+ * panel_widget_update_positions_packed_start() */
+static void
+panel_widget_update_positions_packed_end (PanelWidget *panel)
+{
+	GList *list,*l;
+	AppletData *ad;
+	int size_all = 0;
+	int pos_next;
+
+	if (panel->packed)
+		return;
+
+	list = get_applet_list_pack (panel, PANEL_OBJECT_PACK_END);
+
+	/* get size used by the objects */
+	for (l = list; l; l = l->next) {
+		ad = l->data;
+		size_all += ad->cells;
+	}
+
+	/* update absolute position of all applets based on this information,
+	 * starting with the first object */
+	pos_next = panel->size - size_all;
+	l = list;
+
+	while (l) {
+		ad = l->data;
+		ad->constrained = pos_next;
+		pos_next += ad->cells;
+		l = l->next;
+	}
+
+	g_list_free (list);
+}
+
+static void
+panel_widget_update_positions (PanelWidget *panel)
+{
+	int i = 0;
+	GList *list;
+	AppletData *ad;
+
+	i = 0;
+
+	if (panel->packed) {
+		/* keep in sync with code in size_allocate */
+		for (list = panel->applet_list;
+		     list != NULL;
+		     list = g_list_next (list)) {
+			ad = list->data;
+			ad->constrained = i;
+			i += ad->cells;
+		}
+	} else {
+		/* Re-compute the ideal position of objects, based on their size */
+		panel_widget_update_positions_packed_start (panel);
+		panel_widget_update_positions_packed_end (panel);
+
+		/* Second pass: try to position from the start, to make sure
+		 * there's enough room. Also respect ad->pos for backward
+		 * compat with configs not yet migrated to pack-type/pack-index. */
+		for (list = panel->applet_list;
+		     list != NULL;
+		     list = g_list_next (list)) {
+			ad = list->data;
+
+			/* Use the larger of zone position and old pixel
+			 * position, so pre-migration gaps are preserved. */
+			if (ad->pos > ad->constrained)
+				ad->constrained = ad->pos;
+			if (ad->constrained < i)
+				ad->constrained = i;
+
+			i = ad->constrained + ad->cells;
+		}
+
+		/* Third pass: try to push applets to the left to see if
+		 * there is enough room. */
+		if (i > panel->size) {
+			i = panel->size;
+			for (list = g_list_last (panel->applet_list);
+			     list != NULL;
+			     list = g_list_previous (list)) {
+				ad = list->data;
+
+				if (ad->constrained + ad->cells > i)
+					ad->constrained = MAX (i - ad->cells, 0);
+
+				i = ad->constrained;
+			}
+		}
+
+		/* EEEEK, there's not enough room, so shift applets even
+		 * at the expense of perhaps running out of room on the
+		 * right if there is no free space in the middle */
+		if (i < 0) {
+			i = 0;
+			for (list = panel->applet_list;
+			     list != NULL;
+			     list = g_list_next (list)) {
+				ad = list->data;
+
+				if (ad->constrained < i)
+					ad->constrained = i;
+
+				i = ad->constrained + ad->cells;
+			}
+		}
+	}
+}
+
 static void
 panel_widget_get_preferred_size(GtkWidget	     *widget,
 				GtkRequisition *minimum_size,
@@ -1362,7 +1564,6 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 	PanelWidget *panel;
 	GList *list;
 	int i;
-	int old_size;
 	gboolean ltr;
 
 	g_return_if_fail(PANEL_IS_WIDGET(widget));
@@ -1370,7 +1571,6 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 
 	panel = PANEL_WIDGET(widget);
 
-	old_size = panel->size;
 	ltr = gtk_widget_get_direction (widget) == GTK_TEXT_DIR_LTR;
 
 	gtk_widget_set_allocation (widget, allocation);
@@ -1385,8 +1585,6 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 		panel->size = allocation->width;
 	else
 		panel->size = allocation->height;
-	if(old_size<panel->size)
-		panel_widget_right_stick(panel,old_size);
 
 	if (panel->packed) {
 		/* we're assuming the order is the same as the one that was
@@ -1443,8 +1641,7 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 
 	} else { /*not packed*/
 
-		/* First make sure there's enough room on the left */
-		i = 0;
+		/* First pass: set ad->cells from applet sizes */
 		for (list = panel->applet_list;
 		     list != NULL;
 		     list = g_list_next (list)) {
@@ -1463,15 +1660,12 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 				ad->cells = ad->size_hints [ad->size_hints_len - 1];
 				ad->min_cells = ad->size_hints [ad->size_hints_len - 1];
 			}
-
-			ad->constrained = ad->pos;
-			if (ad->constrained < i)
-				ad->constrained = i;
-
-			i = ad->constrained + ad->cells;
 		}
 
-		/* Now expand from the right */
+		/* Compute zone-based positions and resolve collisions */
+		panel_widget_update_positions (panel);
+
+		/* Now expand from the right, using size hints */
 		i = panel->size;
 		for(list = g_list_last(panel->applet_list);
 		    list!=NULL;
@@ -1493,23 +1687,6 @@ panel_widget_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 			}
 
 			i = ad->constrained;
-		}
-
-		/* EEEEK, there's not enough room, so shift applets even
-		 * at the expense of perhaps running out of room on the
-		 * right if there is no free space in the middle */
-		if(i < 0) {
-			i = 0;
-			for(list = panel->applet_list;
-			    list!=NULL;
-			    list = g_list_next(list)) {
-				AppletData *ad = list->data;
-
-				if (ad->constrained < i)
-					ad->constrained = i;
-
-				i = ad->constrained + ad->cells;
-			}
 		}
 
 		for(list = panel->applet_list;
@@ -2449,6 +2626,7 @@ panel_widget_add (PanelWidget         *panel,
 		  gboolean             locked,
 		  int                  pos,
 		  PanelObjectPackType  pack_type,
+		  int                  pack_index,
 		  gboolean             insert_at_pos)
 {
 	AppletData *ad = NULL;
@@ -2492,6 +2670,8 @@ panel_widget_add (PanelWidget         *panel,
 	if (ad == NULL) {
 		ad = g_new (AppletData, 1);
 		ad->applet = applet;
+		ad->pack_type = pack_type;
+		ad->pack_index = pack_index;
 		ad->cells = 1;
 		ad->min_cells = 1;
 		ad->pos = pos;

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -672,365 +672,253 @@ get_size_from_hints (AppletData *ad, int cells)
 	return MAX (cells, ad->min_cells);
 }
 
-static void
-panel_widget_jump_applet_right (PanelWidget *panel,
-				GList       *list,
-				GList       *next,
-				int          pos)
+static inline int
+panel_widget_get_moveby (PanelWidget *panel,
+			 AppletData  *ad)
 {
-	AppletData *ad;
-	const AppletData *nad = NULL;
+	/* move relative to the center of the object */
+	return panel_widget_get_cursorloc (panel) - ad->constrained - ad->cells / 2;
+}
 
-	ad = list->data;
-	if (next)
-		nad = next->data;
-
-	if (pos >= panel->size)
-		return;
-
-	if (!nad || nad->constrained >= pos + ad->min_cells)
-		goto jump_right;
-
-	if (!panel_widget_push_applet_right (panel, next, pos + ad->min_cells - nad->constrained)) {
-		panel_widget_jump_applet_right (panel,
-						list,
-						next->next,
-						nad->constrained + nad->min_cells);
-		return;
+static int
+panel_widget_move_get_pos_pack (PanelWidget         *panel,
+				PanelObjectPackType  pack_type)
+{
+	switch (pack_type) {
+	case PANEL_OBJECT_PACK_START:
+		return 0;
+		break;
+	case PANEL_OBJECT_PACK_CENTER:
+		return panel->size / 2;
+		break;
+	case PANEL_OBJECT_PACK_END:
+		return panel->size;
+		break;
+	default:
+		g_assert_not_reached ();
+		break;
 	}
 
- jump_right:
-	ad->pos = ad->constrained = pos;
-	panel->applet_list = g_list_remove_link (panel->applet_list, list);
-	panel->applet_list = panel_g_list_insert_before (panel->applet_list, next, list);
-	gtk_widget_queue_resize (GTK_WIDGET (panel));
-	emit_applet_moved (panel, ad);
+	return 0;
+}
+
+static int
+panel_widget_move_get_pos_next_pack (PanelWidget *panel,
+				     AppletData  *ad,
+				     AppletData  *nad)
+{
+	if (!nad || nad->pack_type > ad->pack_type + 1)
+		return panel_widget_move_get_pos_pack (panel, ad->pack_type + 1);
+
+	return nad->constrained;
+}
+
+static int
+panel_widget_move_get_pos_prev_pack (PanelWidget *panel,
+				     AppletData  *ad,
+				     AppletData  *pad)
+{
+	if (!pad || pad->pack_type < ad->pack_type - 1)
+		return panel_widget_move_get_pos_pack (panel, ad->pack_type - 1);
+
+	return pad->constrained + pad->cells;
 }
 
 static void
+panel_widget_move_to_pack (PanelWidget         *panel,
+			   AppletData          *ad,
+			   PanelObjectPackType  new_pack_type,
+			   int                  pack_index)
+{
+	GList *l;
+
+	if (pack_index >= 0) {
+		for (l = panel->applet_list; l; l = l->next) {
+			AppletData *ad_to_move = l->data;
+			if (ad_to_move->pack_type == new_pack_type &&
+			    ad_to_move->pack_index >= pack_index) {
+				ad_to_move->pack_index++;
+				emit_applet_moved (panel, ad_to_move);
+			}
+		}
+	} else
+		pack_index = panel_widget_get_new_pack_index (panel, new_pack_type);
+
+	ad->pack_type = new_pack_type;
+	ad->pack_index = pack_index;
+
+	/* Reset pixel position so the backward-compat fallback in
+	 * update_positions doesn't override the zone-computed position */
+	ad->pos = 0;
+
+	/* Re-sort the applet list since pack_type changed */
+	panel->applet_list =
+		panel_g_list_resort_item (panel->applet_list, ad,
+					  (GCompareFunc)applet_data_compare);
+}
+
+/*
+ * Switch move
+ */
+
+/* if force_switch is set, moveby will be ignored */
+static gboolean
 panel_widget_switch_applet_right (PanelWidget *panel,
-				  GList       *list)
+				  GList       *list,
+				  int          moveby,
+				  gboolean     force_switch)
 {
 	AppletData *ad;
-	AppletData *nad = NULL;
-
-	g_assert (list != NULL);
+	AppletData *nad;
+	int         swap_index;
+	int         next_pos;
 
 	ad = list->data;
-	if (ad->constrained + ad->min_cells >= panel->size)
-		return;
 
-	if (list->next)
-		nad = list->next->data;
+	if (panel->packed && !list->next)
+		return FALSE;
 
-	if (!nad || nad->constrained >= ad->constrained + ad->min_cells + MOVE_INCREMENT) {
-		ad->pos = ad->constrained += MOVE_INCREMENT;
-		gtk_widget_queue_resize (GTK_WIDGET (panel));
+	if (ad->pack_type == PANEL_OBJECT_PACK_END && !list->next)
+		return FALSE;
+
+	/* count moveby from end of object => remove distance to go there */
+	moveby -= ad->cells / 2;
+
+	nad = list->next ? list->next->data : NULL;
+
+	/* Move inside same pack */
+	if (nad && nad->pack_type == ad->pack_type) {
+		if (force_switch ||
+		    (moveby >= nad->cells / 2)) {
+			swap_index = ad->pack_index;
+			ad->pack_index = nad->pack_index;
+			nad->pack_index = swap_index;
+
+			panel->applet_list = panel_g_list_swap_next (panel->applet_list, list);
+
+			emit_applet_moved (panel, nad);
+			emit_applet_moved (panel, ad);
+
+			panel_widget_update_positions (panel);
+			gtk_widget_queue_resize (GTK_WIDGET (panel));
+
+			return TRUE;
+		} else
+			return FALSE;
+	}
+
+	/* Move to next pack */
+	next_pos = panel_widget_move_get_pos_next_pack (panel, ad, nad);
+	if (force_switch ||
+	    (moveby >= (next_pos - (ad->constrained + ad->cells)) / 2)) {
+		if (ad->pack_type + 1 == PANEL_OBJECT_PACK_END)
+			panel_widget_move_to_pack (panel, ad, ad->pack_type + 1, -1);
+		else
+			panel_widget_move_to_pack (panel, ad, ad->pack_type + 1, 0);
+
 		emit_applet_moved (panel, ad);
-		return;
+
+		panel_widget_update_positions (panel);
+		gtk_widget_queue_resize (GTK_WIDGET (panel));
+
+		return TRUE;
 	}
 
-	if (nad->locked) {
-		panel_widget_jump_applet_right (panel,
-						list,
-						list->next->next,
-						nad->constrained + nad->min_cells);
-		return;
-	}
-
-	nad->constrained = nad->pos = ad->constrained;
-	ad->constrained = ad->pos = ad->constrained + nad->min_cells;
-	panel->applet_list = panel_g_list_swap_next (panel->applet_list, list);
-
-	gtk_widget_queue_resize (GTK_WIDGET (panel));
-
-	emit_applet_moved (panel, ad);
-	emit_applet_moved (panel, nad);
+	return FALSE;
 }
 
-static void
-panel_widget_jump_applet_left (PanelWidget *panel,
-			       GList       *list,
-			       GList       *prev,
-			       int          pos)
-{
-	AppletData *ad;
-	const AppletData *pad = NULL;
-
-	ad = list->data;
-	if (prev)
-		pad = prev->data;
-
-	if (pos < 0)
-		return;
-
-	if (!pad || pad->constrained + pad->min_cells <= pos)
-		goto jump_left;
-
-	if (!panel_widget_push_applet_left (panel, prev, pad->constrained + pad->min_cells - pos)) {
-		panel_widget_jump_applet_left (panel,
-					       list,
-					       prev->prev,
-					       pad->constrained - ad->min_cells);
-		return;
-	}
-
- jump_left:
-	ad->pos = ad->constrained = pos;
-	panel->applet_list = g_list_remove_link (panel->applet_list, list);
-	panel->applet_list = panel_g_list_insert_after (panel->applet_list, prev, list);
-	gtk_widget_queue_resize (GTK_WIDGET (panel));
-	emit_applet_moved (panel, ad);
-}
-
-static void
+/* if force_switch is set, moveby will be ignored */
+static gboolean
 panel_widget_switch_applet_left (PanelWidget *panel,
-				 GList       *list)
+				 GList       *list,
+				 int          moveby,
+				 gboolean     force_switch)
 {
 	AppletData *ad;
-	AppletData *pad = NULL;
+	AppletData *pad;
+	int         swap_index;
+	int         prev_pos;
 
 	ad = list->data;
-	if (ad->constrained <= 0)
-		return;
 
-	if (list->prev)
-		pad = list->prev->data;
+	if (panel->packed && !list->prev)
+		return FALSE;
 
-	if (!pad || pad->constrained + pad->min_cells <= ad->constrained - MOVE_INCREMENT) {
-		ad->pos = ad->constrained -= MOVE_INCREMENT;
-		gtk_widget_queue_resize (GTK_WIDGET (panel));
+	if (ad->pack_type == PANEL_OBJECT_PACK_START && !list->prev)
+		return FALSE;
+
+	/* count moveby from start of object => add distance to go there */
+	moveby += ad->cells / 2;
+
+	pad = list->prev ? list->prev->data : NULL;
+
+	/* Move inside same pack */
+	if (pad && pad->pack_type == ad->pack_type) {
+		if (force_switch ||
+		    (moveby <= - pad->cells / 2)) {
+			swap_index = ad->pack_index;
+			ad->pack_index = pad->pack_index;
+			pad->pack_index = swap_index;
+
+			panel->applet_list = panel_g_list_swap_prev (panel->applet_list, list);
+
+			emit_applet_moved (panel, ad);
+			emit_applet_moved (panel, pad);
+
+			panel_widget_update_positions (panel);
+			gtk_widget_queue_resize (GTK_WIDGET (panel));
+
+			return TRUE;
+		} else
+			return FALSE;
+	}
+
+	/* Move to prev pack */
+	prev_pos = panel_widget_move_get_pos_prev_pack (panel, ad, pad);
+	if (force_switch ||
+	    (moveby <= - ((ad->constrained - prev_pos) / 2))) {
+		panel_widget_move_to_pack (panel, ad, ad->pack_type - 1, -1);
 		emit_applet_moved (panel, ad);
-		return;
+
+		panel_widget_update_positions (panel);
+		gtk_widget_queue_resize (GTK_WIDGET (panel));
+
+		return TRUE;
 	}
 
-	if (pad->locked) {
-		panel_widget_jump_applet_left (panel,
-					       list,
-					       list->prev->prev,
-					       pad->constrained - ad->min_cells);
-		return;
-	}
-
-	ad->constrained = ad->pos = pad->constrained;
-	pad->constrained = pad->pos = ad->constrained + ad->min_cells;
-	panel->applet_list = panel_g_list_swap_prev (panel->applet_list, list);
-
-	gtk_widget_queue_resize (GTK_WIDGET (panel));
-
-	emit_applet_moved (panel, ad);
-	emit_applet_moved (panel, pad);
-}
-
-static gboolean
-panel_widget_try_push_right (PanelWidget *panel,
-			     GList       *list,
-			     int          push)
-{
-	AppletData *ad;
-	const AppletData *nad = NULL;
-
-	g_assert (list != NULL);
-
-	ad = list->data;
-	if (list->next)
-		nad = list->next->data;
-
-	if (ad->locked)
-		return FALSE;
-
-	if (ad->constrained + ad->min_cells + push >= panel->size)
-		return FALSE;
-
-	if (!nad || nad->constrained >= ad->constrained + ad->min_cells + push)
-		return TRUE;
-
-	return panel_widget_try_push_right (panel, list->next, push);
-}
-
-static int
-panel_widget_get_right_jump_pos (PanelWidget *panel,
-				 AppletData  *ad,
-				 GList       *next,
-				 int          pos)
-{
-	const AppletData *nad = NULL;
-
-	if (next)
-		nad = next->data;
-
-	if (!nad || nad->constrained >= pos + ad->min_cells)
-		return pos;
-
-	if (panel_widget_try_push_right (panel, next, pos + ad->min_cells - nad->constrained))
-		return pos;
-
-	return panel_widget_get_right_jump_pos (panel,
-						ad,
-						next->next,
-						nad->constrained + nad->min_cells);
-}
-
-static int
-panel_widget_get_right_switch_pos (PanelWidget *panel,
-				   GList       *list)
-{
-	AppletData *ad;
-	const AppletData *nad = NULL;
-
-	g_assert (list != NULL);
-
-	ad = list->data;
-	if (list->next)
-		nad = list->next->data;
-
-	if (!nad || nad->constrained >= ad->constrained + ad->min_cells + MOVE_INCREMENT)
-		return ad->constrained + MOVE_INCREMENT;
-
-	if (nad->locked)
-		return panel_widget_get_right_jump_pos (panel,
-							ad,
-							list->next->next,
-							nad->constrained + nad->min_cells);
-
-	return nad->constrained + nad->min_cells - ad->cells;
-}
-
-static gboolean
-panel_widget_try_push_left (PanelWidget *panel,
-			    GList       *list,
-			    int          push)
-{
-	AppletData *ad;
-	const AppletData *pad = NULL;
-
-	g_assert (list != NULL);
-
-	ad = list->data;
-	if (list->prev)
-		pad = list->prev->data;
-
-	if (ad->locked)
-		return FALSE;
-
-	if (ad->constrained - push < 0)
-		return FALSE;
-
-	if (!pad || pad->constrained + pad->min_cells <= ad->constrained - push)
-		return TRUE;
-
-	return panel_widget_try_push_left (panel, list->prev, push);
-}
-
-static int
-panel_widget_get_left_jump_pos (PanelWidget *panel,
-				AppletData  *ad,
-				GList       *prev,
-				int          pos)
-{
-	const AppletData *pad = NULL;
-
-	if (prev)
-		pad = prev->data;
-
-	if (!pad || pad->constrained + pad->min_cells <= pos)
-		return pos;
-
-	if (panel_widget_try_push_left (panel, prev, pad->constrained + pad->min_cells - pos))
-		return pos;
-
-	return panel_widget_get_left_jump_pos (panel,
-					       ad,
-					       prev->prev,
-					       pad->constrained - ad->min_cells);
-}
-
-static int
-panel_widget_get_left_switch_pos (PanelWidget *panel,
-				  GList       *list)
-{
-	AppletData *ad;
-	const AppletData *pad = NULL;
-
-	g_assert (list != NULL);
-
-	ad = list->data;
-	if (list->prev)
-		pad = list->prev->data;
-
-	if (!pad || pad->constrained + pad->min_cells <= ad->constrained - MOVE_INCREMENT)
-		return ad->constrained - MOVE_INCREMENT;
-
-	if (pad->locked)
-		return panel_widget_get_left_jump_pos (panel,
-						       ad,
-						       list->prev->prev,
-						       pad->constrained - ad->min_cells);
-
-	return pad->constrained;
+	return FALSE;
 }
 
 static void
 panel_widget_switch_move (PanelWidget *panel,
-			  AppletData  *ad,
-			  int          moveby)
+			  AppletData  *ad)
 {
 	GList *list;
-	int    finalpos;
-	int    pos;
+	gboolean moved;
+	int      moveby;
 
 	g_return_if_fail (ad != NULL);
 	g_return_if_fail (PANEL_IS_WIDGET (panel));
 
-	if (moveby == 0)
-		return;
-
 	list = g_list_find (panel->applet_list, ad);
 	g_return_if_fail (list != NULL);
 
-	finalpos = ad->constrained + moveby;
+	moveby = panel_widget_get_moveby (panel, ad);
 
-	if (ad->constrained < finalpos) {
-		const AppletData *pad;
-
-		if (list->prev) {
-			pad = list->prev->data;
-			if (pad->expand_major)
-				gtk_widget_queue_resize (GTK_WIDGET (panel));
-		}
-
-		while (ad->constrained < finalpos) {
-			pos = panel_widget_get_right_switch_pos (panel, list);
-
-			if (abs (pos - finalpos) >= abs (ad->constrained - finalpos) ||
-			    pos + ad->min_cells > panel->size)
-				break;
-
-			panel_widget_switch_applet_right (panel, list);
-		}
-
-		if (list->prev) {
-			pad = list->prev->data;
-			if (pad->expand_major)
-				gtk_widget_queue_resize (GTK_WIDGET (panel));
+	if (moveby > ad->cells / 2) {
+		moved = TRUE;
+		while (moved && moveby > ad->cells / 2) {
+			moved = panel_widget_switch_applet_right (panel, list,
+								  moveby, FALSE);
+			moveby = panel_widget_get_moveby (panel, ad);
 		}
 	} else {
-
-		if (list->next) {
-			const AppletData *nad = list->next->data;
-			if (nad->expand_major)
-				gtk_widget_queue_resize (GTK_WIDGET (panel));
+		moved = TRUE;
+		while (moved && moveby < - ad->cells / 2) {
+			moved = panel_widget_switch_applet_left (panel, list,
+								 moveby, FALSE);
+			moveby = panel_widget_get_moveby (panel, ad);
 		}
-
-		while (ad->constrained > finalpos) {
-			pos = panel_widget_get_left_switch_pos (panel, list);
-
-			if (abs (pos - finalpos) >= abs (ad->constrained - finalpos) || pos < 0)
-				break;
-
-			panel_widget_switch_applet_left (panel, list);
-		}
-
 	}
 }
 
@@ -2119,15 +2007,6 @@ panel_widget_get_cursorloc (PanelWidget *panel)
 		return y;
 }
 
-/*calculates the value to move the applet by*/
-static int
-panel_widget_get_moveby (PanelWidget *panel, int pos, int offset)
-{
-	g_return_val_if_fail (PANEL_IS_WIDGET (panel), -1);
-
-	return panel_widget_get_cursorloc (panel) - offset - pos;
-}
-
 static GList *
 walk_up_to (int pos, GList *list)
 {
@@ -2250,8 +2129,6 @@ static void schedule_try_move (PanelWidget *panel, gboolean repeater);
 static void
 panel_widget_applet_move_to_cursor (PanelWidget *panel)
 {
-	int moveby;
-	int pos;
 	int movement;
 	GtkWidget *applet;
 	GdkDevice      *device;
@@ -2265,8 +2142,6 @@ panel_widget_applet_move_to_cursor (PanelWidget *panel)
 		return;
 
 	ad = panel->currently_dragged_applet;
-
-	pos = ad->constrained;
 
 	applet = ad->applet;
 	g_assert(GTK_IS_WIDGET(applet));
@@ -2288,8 +2163,9 @@ panel_widget_applet_move_to_cursor (PanelWidget *panel)
 			    panel_screen_from_panel_widget (new_panel) &&
 			    !g_slist_find (forb, new_panel) &&
 			    !panel_lockdown_get_locked_down ()) {
-				pos = panel_widget_get_moveby (new_panel, 0, ad->drag_off);
+				int pos;
 
+				pos = panel_widget_get_cursorloc (new_panel);
 				if (pos < 0) pos = 0;
 
 				panel_widget_applet_drag_end (panel);
@@ -2297,12 +2173,12 @@ panel_widget_applet_move_to_cursor (PanelWidget *panel)
 				/*disable reentrancy into this function*/
 				if (!panel_widget_reparent (panel, new_panel, applet, pos)) {
 					panel_widget_applet_drag_start (
-						panel, applet, ad->drag_off, GDK_CURRENT_TIME);
+						panel, applet, PW_DRAG_OFF_CENTER, GDK_CURRENT_TIME);
 					continue;
 				}
 
 				panel_widget_applet_drag_start (
-					new_panel, applet, ad->drag_off, GDK_CURRENT_TIME);
+					new_panel, applet, PW_DRAG_OFF_CENTER, GDK_CURRENT_TIME);
 				schedule_try_move (new_panel, TRUE);
 
 				return;
@@ -2326,12 +2202,10 @@ panel_widget_applet_move_to_cursor (PanelWidget *panel)
 
 	switch (movement) {
 	case PANEL_SWITCH_MOVE:
-		moveby = panel_widget_get_moveby (panel, pos, ad->drag_off);
-		panel_widget_switch_move (panel, ad, moveby);
+		panel_widget_switch_move (panel, ad);
 		break;
 	case PANEL_PUSH_MOVE:
-		moveby = panel_widget_get_moveby (panel, pos, ad->drag_off);
-		panel_widget_push_move (panel, ad, moveby);
+		panel_widget_push_move (panel, ad, panel_widget_get_moveby (panel, ad));
 		break;
 	}
 }
@@ -2918,11 +2792,11 @@ panel_widget_switch_move_applet (PanelWidget      *panel,
 	switch (dir) {
 	case GTK_DIR_LEFT:
 	case GTK_DIR_UP:
-		panel_widget_switch_applet_left (panel, list);
+		panel_widget_switch_applet_left (panel, list, -1, TRUE);
 		break;
 	case GTK_DIR_RIGHT:
 	case GTK_DIR_DOWN:
-		panel_widget_switch_applet_right (panel, list);
+		panel_widget_switch_applet_right (panel, list, -1, TRUE);
 		break;
 	default:
 		return;

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -1896,6 +1896,43 @@ panel_widget_applet_drag_start_no_grab (PanelWidget *panel,
 }
 
 static void
+panel_widget_compress_pack_indexes_list (PanelWidget *panel,
+					 GList       *list)
+{
+	GList *l;
+	AppletData *ad;
+	int index;
+
+	for (l = list, index = 0; l; l = l->next, index++) {
+		ad = l->data;
+		if (ad->pack_index != index) {
+			ad->pack_index = index;
+			emit_applet_moved (panel, ad);
+		}
+	}
+}
+
+/* make sure our lists always start at 0 */
+static void
+panel_widget_compress_pack_indexes (PanelWidget *panel)
+{
+	GList *list;
+
+	list = get_applet_list_pack (panel, PANEL_OBJECT_PACK_START);
+	panel_widget_compress_pack_indexes_list (panel, list);
+	g_list_free (list);
+
+	list = get_applet_list_pack (panel, PANEL_OBJECT_PACK_CENTER);
+	panel_widget_compress_pack_indexes_list (panel, list);
+	g_list_free (list);
+
+	list = get_applet_list_pack (panel, PANEL_OBJECT_PACK_END);
+	list = g_list_reverse (list);
+	panel_widget_compress_pack_indexes_list (panel, list);
+	g_list_free (list);
+}
+
+static void
 panel_widget_applet_drag_end_no_grab (PanelWidget *panel)
 {
 	g_return_if_fail (panel != NULL);
@@ -1913,6 +1950,15 @@ panel_widget_applet_drag_end_no_grab (PanelWidget *panel)
 		moving_timeout = 0;
 		been_moved = FALSE;
 	}
+
+	/* Make sure we keep our indexes in a 0:n range, instead of a x:x+n
+	 * range, with a growing x. Note that this is useful not only because
+	 * of moves, but also because of removal of objects (object 0 could be
+	 * removed, but if there is still object 1, we start growing the
+	 * range). But doing this compress only once in a while, after moving
+	 * objects is good enough, since this is nothing urgent and the user
+	 * will move objects before this becomes a real annoying issue. */
+	panel_widget_compress_pack_indexes (panel);
 }
 
 void

--- a/mate-panel/panel-widget.c
+++ b/mate-panel/panel-widget.c
@@ -31,8 +31,6 @@
 #include "panel-profile.h"
 #include "panel-lockdown.h"
 
-#define MOVE_INCREMENT 1
-
 typedef enum {
 	PANEL_SWITCH_MOVE = 0,
 	PANEL_PUSH_MOVE
@@ -90,13 +88,6 @@ static void panel_widget_tab_move           (PanelWidget      *panel,
 static void panel_widget_end_move           (PanelWidget      *panel);
 static gboolean panel_widget_real_focus     (GtkWidget        *widget,
                                              GtkDirectionType  direction);
-
-static gboolean panel_widget_push_applet_right (PanelWidget *panel,
-						GList       *list,
-						int          push);
-static gboolean panel_widget_push_applet_left  (PanelWidget *panel,
-						GList       *list,
-						int          push);
 
 /************************
  convenience functions
@@ -925,38 +916,57 @@ panel_widget_switch_move (PanelWidget *panel,
 static int
 panel_widget_push_applet_right (PanelWidget *panel,
 				GList       *list,
-				int          push)
+				int          moveby,
+				gboolean     force_switch)
 {
 	AppletData *ad;
-	const AppletData *nad = NULL;
-
-	g_assert (list != NULL);
+	AppletData *nad;
+	PanelObjectPackType new_pack_type;
+	GList *l;
+	GList *last_in_pack;
+	int next_pos;
 
 	ad = list->data;
-	if (ad->constrained + ad->min_cells + push >= panel->size)
+
+	if (ad->pack_type == PANEL_OBJECT_PACK_END)
 		return FALSE;
 
-	if (ad->locked)
-		return FALSE;
+	/* count moveby from end of object => remove distance to go there */
+	moveby -= ad->cells / 2;
 
-	if (list->next)
-		nad = list->next->data;
+	new_pack_type = ad->pack_type + 1;
 
-	if (!nad || nad->constrained >= ad->constrained + ad->min_cells + push) {
-		ad->pos = ad->constrained += push;
-		gtk_widget_queue_resize (GTK_WIDGET (panel));
-		emit_applet_moved (panel, ad);
-		return TRUE;
+	for (l = list; l && l->next; l = l->next) {
+		nad = l->next->data;
+		if (nad->pack_type != ad->pack_type)
+			break;
 	}
 
-	g_assert (list->next != NULL);
+	last_in_pack = l;
 
-	if (!panel_widget_push_applet_right (panel, list->next, push))
+	nad = last_in_pack->next ? last_in_pack->next->data : NULL;
+	next_pos = panel_widget_move_get_pos_next_pack (panel, ad, nad);
+
+	if (!force_switch &&
+	    (moveby < (next_pos - (ad->constrained + ad->cells)) / 2))
 		return FALSE;
 
-	ad->pos = ad->constrained += push;;
+	for (l = last_in_pack; l; l = l->prev) {
+		ad = l->data;
+
+		if (new_pack_type == PANEL_OBJECT_PACK_END)
+			panel_widget_move_to_pack (panel, ad, new_pack_type, -1);
+		else
+			panel_widget_move_to_pack (panel, ad, new_pack_type, 0);
+
+		emit_applet_moved (panel, ad);
+
+		if (l == list)
+			break;
+	}
+
+	panel_widget_update_positions (panel);
 	gtk_widget_queue_resize (GTK_WIDGET (panel));
-	emit_applet_moved (panel, ad);
 
 	return TRUE;
 }
@@ -964,38 +974,53 @@ panel_widget_push_applet_right (PanelWidget *panel,
 static int
 panel_widget_push_applet_left (PanelWidget *panel,
 			       GList       *list,
-			       int          push)
+			       int          moveby,
+			       gboolean     force_switch)
 {
 	AppletData *ad;
-	const AppletData *pad = NULL;
-
-	g_assert (list != NULL);
+	AppletData *pad;
+	PanelObjectPackType new_pack_type;
+	GList *l;
+	GList *first_in_pack;
+	int prev_pos;
 
 	ad = list->data;
-	if (ad->constrained - push < 0)
+
+	if (ad->pack_type == PANEL_OBJECT_PACK_START)
 		return FALSE;
 
-	if (ad->locked)
-		return FALSE;
+	/* count moveby from start of object => add distance to go there */
+	moveby += ad->cells / 2;
 
-	if (list->prev)
-		pad = list->prev->data;
+	new_pack_type = ad->pack_type - 1;
 
-	if (!pad || pad->constrained + pad->min_cells <= ad->constrained - push) {
-		ad->pos = ad->constrained -= push;
-		gtk_widget_queue_resize (GTK_WIDGET (panel));
-		emit_applet_moved (panel, ad);
-		return TRUE;
+	for (l = list; l && l->prev; l = l->prev) {
+		pad = l->prev->data;
+		if (pad->pack_type != ad->pack_type)
+			break;
 	}
 
-	g_assert (list->prev != NULL);
+	first_in_pack = l;
 
-	if (!panel_widget_push_applet_left (panel, list->prev, push))
+	pad = first_in_pack->prev ? first_in_pack->prev->data : NULL;
+	prev_pos = panel_widget_move_get_pos_prev_pack (panel, ad, pad);
+
+	if (!force_switch &&
+	    (moveby >  - ((ad->constrained - prev_pos) / 2)))
 		return FALSE;
 
-	ad->pos = ad->constrained -= push;
+	for (l = first_in_pack; l; l = l->next) {
+		ad = l->data;
+
+		panel_widget_move_to_pack (panel, ad, new_pack_type, -1);
+		emit_applet_moved (panel, ad);
+
+		if (l == list)
+			break;
+	}
+
+	panel_widget_update_positions (panel);
 	gtk_widget_queue_resize (GTK_WIDGET (panel));
-	emit_applet_moved (panel, ad);
 
 	return TRUE;
 }
@@ -1003,36 +1028,48 @@ panel_widget_push_applet_left (PanelWidget *panel,
 static void
 panel_widget_push_move (PanelWidget *panel,
 			AppletData  *ad,
-			int          moveby)
+			int          direction)
 {
-	int finalpos;
 	GList *list;
+	gboolean moved;
+	int      moveby;
+
+	/* direction is only used when we move with keybindings */
 
 	g_return_if_fail (ad != NULL);
 	g_return_if_fail (PANEL_IS_WIDGET (panel));
 
-	if (moveby == 0)
-		return;
-
 	list = g_list_find (panel->applet_list, ad);
 	g_return_if_fail (list != NULL);
 
-	finalpos = ad->constrained + moveby;
+	moveby = panel_widget_get_moveby (panel, ad);
 
-	if (ad->constrained < finalpos) {
-		while (ad->constrained < finalpos)
-			if (!panel_widget_push_applet_right (panel, list, 1))
+	if (direction > 0 || moveby > ad->cells / 2) {
+		moved = TRUE;
+		while (direction > 0 ||
+		       (moved && moveby > ad->cells / 2)) {
+			moved = panel_widget_push_applet_right (panel, list,
+								moveby,
+								direction != 0);
+			moveby = panel_widget_get_moveby (panel, ad);
+
+			/* a keybinding pushes only once */
+			if (direction != 0)
 				break;
-
-                if (list->prev) {
-			const AppletData *pad = list->prev->data;
-			if (pad->expand_major)
-				gtk_widget_queue_resize (GTK_WIDGET (panel));
 		}
 	} else {
-                while (ad->constrained > finalpos)
-			if (!panel_widget_push_applet_left (panel, list, 1))
+		moved = TRUE;
+		while (direction < 0 ||
+		       (moved && moveby < ad->cells / 2)) {
+			moved = panel_widget_push_applet_left (panel, list,
+							       moveby,
+							       direction != 0);
+			moveby = panel_widget_get_moveby (panel, ad);
+
+			/* a keybinding pushes only once */
+			if (direction != 0)
 				break;
+		}
 	}
 }
 
@@ -2251,7 +2288,7 @@ panel_widget_applet_move_to_cursor (PanelWidget *panel)
 		panel_widget_switch_move (panel, ad);
 		break;
 	case PANEL_PUSH_MOVE:
-		panel_widget_push_move (panel, ad, panel_widget_get_moveby (panel, ad));
+		panel_widget_push_move (panel, ad, 0);
 		break;
 	}
 }
@@ -2801,7 +2838,7 @@ panel_widget_push_move_applet (PanelWidget     *panel,
                                GtkDirectionType dir)
 {
 	AppletData *applet;
-	int         increment = 0;
+	int         direction = 0;
 
 	applet = panel->currently_dragged_applet;
 	g_return_if_fail (applet);
@@ -2809,17 +2846,17 @@ panel_widget_push_move_applet (PanelWidget     *panel,
 	switch (dir) {
 	case GTK_DIR_LEFT:
 	case GTK_DIR_UP:
-		increment = -MOVE_INCREMENT;
+		direction = -1;
 		break;
 	case GTK_DIR_RIGHT:
 	case GTK_DIR_DOWN:
-		increment = MOVE_INCREMENT;
+		direction = 1;
 		break;
 	default:
 		return;
 	}
 
-	panel_widget_push_move (panel, applet, increment);
+	panel_widget_push_move (panel, applet, direction);
 }
 
 static void

--- a/mate-panel/panel-widget.h
+++ b/mate-panel/panel-widget.h
@@ -14,6 +14,7 @@
 #include <gtk/gtk.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include "button-widget.h"
+#include "panel-enums-gsettings.h"
 #include "panel-types.h"
 #include "panel-background.h"
 #include "panel-toplevel.h"
@@ -154,6 +155,7 @@ int		panel_widget_add		(PanelWidget *panel,
 						 GtkWidget   *applet,
 						 gboolean     locked,
 						 int          pos,
+						 PanelObjectPackType pack_type,
 						 gboolean     insert_at_pos);
 
 /*needs to be called for drawers after add*/

--- a/mate-panel/panel-widget.h
+++ b/mate-panel/panel-widget.h
@@ -210,6 +210,13 @@ void            panel_widget_focus              (PanelWidget *panel);
 
 PanelOrientation panel_widget_get_applet_orientation (PanelWidget *panel);
 
+void     panel_widget_get_insert_at_pos (PanelWidget         *panel,
+					 PanelObjectPackType *pack_type,
+					 int                 *pack_index,
+					 int                  pos);
+int      panel_widget_get_new_pack_index (PanelWidget        *panel,
+					  PanelObjectPackType pack_type);
+
 void     panel_widget_emit_background_changed (PanelWidget *panel);
 
 void     panel_widget_set_applet_size_constrained (PanelWidget *panel,

--- a/mate-panel/panel-widget.h
+++ b/mate-panel/panel-widget.h
@@ -65,6 +65,8 @@ struct _AppletSizeHintsAlloc {
 struct _AppletData
 {
 	GtkWidget *	applet;
+	PanelObjectPackType pack_type;
+	int		pack_index;
 	int		pos;
 	int             constrained;
 	int		cells;
@@ -151,12 +153,13 @@ GtkWidget *	panel_widget_new		(PanelToplevel  *toplevel,
 						 int             sz);
 /*add an applet to the panel, preferably at position pos, if insert_at_pos
   is on, we REALLY want to insert at the pos given by pos*/
-int		panel_widget_add		(PanelWidget *panel,
-						 GtkWidget   *applet,
-						 gboolean     locked,
-						 int          pos,
+int		panel_widget_add		(PanelWidget        *panel,
+						 GtkWidget          *applet,
+						 gboolean            locked,
+						 int                 pos,
 						 PanelObjectPackType pack_type,
-						 gboolean     insert_at_pos);
+						 int                 pack_index,
+						 gboolean            insert_at_pos);
 
 /*needs to be called for drawers after add*/
 void		panel_widget_add_forbidden	(PanelWidget *panel);

--- a/mate-panel/panel-widget.h
+++ b/mate-panel/panel-widget.h
@@ -138,8 +138,6 @@ struct _PanelWidgetClass
                             GtkDirectionType	 dir);
 	void (* switch_move) (PanelWidget	*panel,
                               GtkDirectionType	 dir);
-	void (* free_move) (PanelWidget		*panel,
-                            GtkDirectionType	 dir);
 	void (* tab_move) (PanelWidget	*panel,
                            gboolean	 next);
 	void (* end_move) (PanelWidget	*panel);

--- a/mate-panel/panel-widget.h
+++ b/mate-panel/panel-widget.h
@@ -194,9 +194,6 @@ void		panel_widget_draw_all		(PanelWidget *panel,
 void		panel_widget_draw_icon		(PanelWidget *panel,
 						 ButtonWidget *applet);
 
-/*tells us if an applet is "stuck" on the right side*/
-int		panel_widget_is_applet_stuck	(PanelWidget *panel,
-						 GtkWidget *applet);
 /*get pos of the cursor location in panel coordinates*/
 int		panel_widget_get_cursorloc	(PanelWidget *panel);
 

--- a/mate-panel/panel.c
+++ b/mate-panel/panel.c
@@ -1401,26 +1401,6 @@ panel_screen_from_panel_widget (PanelWidget *panel)
 	return gtk_window_get_screen (GTK_WINDOW (panel->toplevel));
 }
 
-gboolean
-panel_is_applet_right_stick (GtkWidget *applet)
-{
-	GtkWidget   *parent;
-	PanelWidget *panel_widget;
-
-	g_return_val_if_fail (GTK_IS_WIDGET (applet), FALSE);
-
-	parent = gtk_widget_get_parent (applet);
-
-	g_return_val_if_fail (PANEL_IS_WIDGET (parent), FALSE);
-
-	panel_widget = PANEL_WIDGET (parent);
-
-	if (!panel_toplevel_get_expand (panel_widget->toplevel))
-		return FALSE;
-
-	return panel_widget_is_applet_stuck (panel_widget, applet);
-}
-
 static void
 panel_delete_without_query (PanelToplevel *toplevel)
 {

--- a/mate-panel/panel.h
+++ b/mate-panel/panel.h
@@ -26,7 +26,7 @@ PanelData *panel_setup (PanelToplevel *toplevel);
 
 GdkScreen *panel_screen_from_panel_widget  (PanelWidget *panel);
 
-gboolean panel_is_applet_right_stick (GtkWidget *applet);
+
 
 gboolean panel_check_dnd_target_data (GtkWidget      *widget,
 				      GdkDragContext *context,


### PR DESCRIPTION
This is a backport of gnome-panel's pack model, where applets are index-sorted in either START, CENTER, or END zones within the panel.

This is the list of commits backported:
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/446ff991d
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/f42b54636
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/8804c8b37
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/9480f4458
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/6db6be277
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/51757603d
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/cb29d47f5
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/1652218bb
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/ed1054799
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/2256381b6
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/533581210
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/f63d91d16
- https://gitlab.gnome.org/GNOME/gnome-panel/-/commit/6278658de

The main difference is that mate-panel still supports the right-stick and position as a fallback, but as soon as the applets load they'll get the new keys. That way we don't break existing layouts. We can make the old keys a no-op on the next major release.

Fixes #62
Fixes #183
Fixes #1108
Fixes #1456
Fixes https://github.com/mate-desktop/mate-desktop/issues/560