### PR TITLE
build: Fix Wayland auto-detection breaking X11-only builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,15 +214,21 @@ if test "x$enable_wayland" != "xno"; then
     ])
 fi
 
-AM_CONDITIONAL(ENABLE_WAYLAND, [test "x$have_wayland" = "xyes"])
-
 have_xfw=no
 if test "x$have_wayland" = "xyes"; then
-  AC_DEFINE(HAVE_WAYLAND, 1, [Have the Wayland development library])
-
-  PKG_CHECK_MODULES(XFW, libxfce4windowing-0 >= 4.19.0, have_xfw=yes, [
-    AC_MSG_ERROR([Wayland support requires libxfce4windowing-0 >= 4.19.0])
+  PKG_CHECK_MODULES(XFW, libxfce4windowing-0 >= 4.19.4, have_xfw=yes, [
+    if test "x$enable_wayland" = "xyes"; then
+      AC_MSG_ERROR([Wayland support requires libxfce4windowing-0 >= 4.19.4])
+    else
+      have_wayland=no
+    fi
   ])
+fi
+
+AM_CONDITIONAL(ENABLE_WAYLAND, [test "x$have_wayland" = "xyes"])
+
+if test "x$have_wayland" = "xyes"; then
+  AC_DEFINE(HAVE_WAYLAND, 1, [Have the Wayland development library])
 fi
 
 AC_SUBST(WAYLAND_CFLAGS)

--- a/meson.build
+++ b/meson.build
@@ -205,7 +205,14 @@ wayland_deps = [
 ]
 have_wayland = wayland_deps[0].found() and wayland_deps[1].found()
 if have_wayland
-  xfw_dep = dependency('libxfce4windowing-0', version: '>= 4.19.0')
+  xfw_dep = dependency('libxfce4windowing-0', version: '>= 4.19.4', required: false)
+  if not xfw_dep.found()
+    if wayland_opt.enabled()
+      error('Wayland support requires libxfce4windowing-0 >= 4.19.4')
+    else
+      have_wayland = false
+    endif
+  endif
 endif
 config_h.set('HAVE_WAYLAND', have_wayland)
 


### PR DESCRIPTION
libxfce4windowing check was a hard error even when Wayland support was only auto-detected. Any X11 without libxfce4windowing would fail to configure entirely.

This changes it to only error out if --enable-wayland=yes was explicit and otherwise it just falls back to X11.

Also bumped the version requirement to 4.19.4, since that's what XFW_CLIENT_TYPE_PAGER actually needs.

Fixes #1572